### PR TITLE
feat: simplify OAuth to use backend PKCE flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ const config = createConfig({
       projectId: 'your-project-id',
       aaUrl: 'your-aa-provider-url',
       chains: [sepolia],
-      oauthConfig: {
-        googleClientId: 'your-google-client-id',
-        redirectUri: 'http://localhost:3000/oauth/callback',
-      }
     })
   ],
   transports: {
@@ -198,21 +194,24 @@ await wallet.auth({
 
 ### OAuth (Google)
 
-Social login with Google.
+Social login with Google. The backend handles PKCE and token exchange - no client-side OAuth library needed.
 
 ```typescript
-// Using @react-oauth/google or similar
-import { GoogleLogin } from '@react-oauth/google';
+// React SDK (recommended)
+import { useAuthenticateOAuth, OAUTH_PROVIDERS } from '@zerodev/wallet-react'
 
-<GoogleLogin
-  onSuccess={async (response) => {
-    await wallet.auth({
-      type: 'oauth',
-      provider: 'google',
-      credential: response.credential
-    });
-  }}
-/>
+const authenticateOAuth = useAuthenticateOAuth()
+
+// Opens popup, SDK handles everything automatically
+await authenticateOAuth.mutateAsync({
+  provider: OAUTH_PROVIDERS.GOOGLE
+})
+
+// Core SDK
+await wallet.auth({
+  type: 'oauth',
+  provider: 'google'
+})
 ```
 
 ## Session Management

--- a/packages/core/src/actions/auth/authenticateWithOAuth.ts
+++ b/packages/core/src/actions/auth/authenticateWithOAuth.ts
@@ -1,14 +1,10 @@
 import type { Client } from '../../client/types.js'
 
 export type AuthenticateWithOAuthParameters = {
-  /** The OAuth credential/token */
-  oidcToken: string
   /** The OAuth provider (e.g., 'google') */
   provider: string
   /** The project ID for the request */
   projectId: string
-  /** Target public key for authentication */
-  targetPublicKey: string
 }
 
 export type AuthenticateWithOAuthReturnType = {
@@ -23,7 +19,11 @@ export type AuthenticateWithOAuthReturnType = {
 }
 
 /**
- * Authenticates a user with OAuth credentials
+ * Authenticates a user with OAuth using cookie-based backend flow
+ *
+ * The backend reads the OAuth session from a cookie set during the OAuth flow.
+ * This requires the OAuth popup flow to complete first via the backend's
+ * /oauth/google/login endpoint.
  *
  * @param client - The ZeroDev Wallet client
  * @param params - The parameters for OAuth authentication
@@ -32,10 +32,8 @@ export type AuthenticateWithOAuthReturnType = {
  * @example
  * ```ts
  * const result = await authenticateWithOAuth(client, {
- *   oidcToken: 'oauth_token_here',
  *   provider: 'google',
  *   projectId: 'proj_456',
- *   targetPublicKey: '0x...'
  * });
  * ```
  */
@@ -43,16 +41,12 @@ export async function authenticateWithOAuth(
   client: Client,
   params: AuthenticateWithOAuthParameters,
 ): Promise<AuthenticateWithOAuthReturnType> {
-  const { oidcToken, provider, projectId, targetPublicKey } = params
+  const { projectId } = params
 
   return await client.request({
     path: `${projectId}/auth/oauth`,
     method: 'POST',
-    body: {
-      oidcToken,
-      provider,
-      targetPublicKey,
-      projectId,
-    },
+    body: null,
+    credentials: 'include',
   })
 }

--- a/packages/core/src/client/transports/rest.ts
+++ b/packages/core/src/client/transports/rest.ts
@@ -9,6 +9,8 @@ export type RestRequestArgs = {
   stamp?: boolean
   stampWith?: 'indexedDb' | 'webAuthn'
   stampPostion?: 'body' | 'headers'
+  /** Include credentials (cookies) in the request */
+  credentials?: RequestCredentials
 }
 
 export type RestRequestFn = <T = any>(args: RestRequestArgs) => Promise<T>
@@ -97,6 +99,7 @@ export function rest(url: string, cfg: RestTransportConfig): RestTransport {
         headers: requestHeaders,
         body: requestBody != null ? JSON.stringify(requestBody) : null,
         signal: controller.signal,
+        ...(args.credentials && { credentials: args.credentials }),
       }
 
       const finalInit = (await cfg.onRequest?.(fullUrl, init)) ?? init

--- a/packages/core/src/core/createZeroDevWallet.ts
+++ b/packages/core/src/core/createZeroDevWallet.ts
@@ -45,8 +45,6 @@ export type AuthParams =
   | {
       type: 'oauth'
       provider: string
-      redirectUrl?: string
-      credential: string
     }
   | {
       type: 'passkey'
@@ -202,23 +200,17 @@ export async function createZeroDevWallet(
     async auth(params: AuthParams) {
       switch (params.type) {
         case 'oauth': {
-          const { credential } = params
-          const targetPublicKey = await client.indexedDbStamper.getPublicKey()
-
-          if (!targetPublicKey) {
-            throw new Error('Failed to get public key')
-          }
-
+          // Backend OAuth flow - the backend reads the OAuth session from a cookie
+          // set during the OAuth popup flow via /oauth/google/login
           const data = await client.authenticateWithOAuth({
-            oidcToken: credential,
-            provider: 'google',
-            targetPublicKey,
+            provider: params.provider,
             projectId,
           })
 
           if (data.turnkeySession) {
             // Parse the JWT to get session data
             const parsedSession = parseSession(data.turnkeySession)
+            const publicKey = await client.indexedDbStamper.getPublicKey()
             const session: ZeroDevWalletSession = {
               id: `session_oauth_${Date.now()}`,
               userId: parsedSession.userId,
@@ -228,7 +220,7 @@ export async function createZeroDevWallet(
               token: data.turnkeySession,
               expiry: parsedSession.expiry,
               createdAt: Date.now(),
-              publicKey: targetPublicKey,
+              publicKey: publicKey || '',
             }
             await sessionStorageManager.storeSession(session, session.id)
           }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,6 +48,8 @@ export {
   type ZeroDevWalletClient,
   zeroDevWalletTransport,
 } from './client/index.js'
+// Constants
+export { KMS_SERVER_URL } from './constants.js'
 export type {
   AuthParams,
   ZeroDevWalletConfig,

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -38,10 +38,6 @@ const config = createConfig({
       projectId: 'YOUR_PROJECT_ID',
       aaUrl: 'YOUR_AA_PROVIDER_URL',
       chains: [sepolia],
-      oauthConfig: {
-        googleClientId: 'YOUR_GOOGLE_CLIENT_ID',
-        redirectUri: 'http://localhost:3000',
-      },
     })
   ],
   transports: {
@@ -150,7 +146,8 @@ await loginPasskey.mutateAsync({ email: 'user@example.com' })
 ```typescript
 const authenticateOAuth = useAuthenticateOAuth()
 
-// Opens popup automatically, handles token exchange
+// Opens popup, backend handles PKCE and token exchange
+// No callback page or OAuth library needed - SDK handles everything
 await authenticateOAuth.mutateAsync({
   provider: OAUTH_PROVIDERS.GOOGLE
 })
@@ -182,18 +179,12 @@ type ZeroDevWalletConnectorParams = {
   projectId: string                    // Required: Your ZeroDev project ID
   organizationId?: string               // Optional: Turnkey organization ID
   proxyBaseUrl?: string                 // Optional: KMS proxy URL
-  aaUrl: string                         // Required: Bundler/paymaster URL
+  aaUrl?: string                        // Optional: Bundler/paymaster URL
   chains: readonly Chain[]              // Required: Supported chains
   rpId?: string                         // Optional: WebAuthn RP ID
   sessionStorage?: StorageAdapter       // Optional: Custom session storage
   autoRefreshSession?: boolean          // Optional: Auto-refresh (default: true)
   sessionWarningThreshold?: number      // Optional: Refresh threshold in ms (default: 60000)
-  oauthConfig?: OAuthConfig             // Optional: OAuth configuration
-}
-
-type OAuthConfig = {
-  googleClientId?: string
-  redirectUri: string
 }
 ```
 
@@ -259,7 +250,6 @@ All hooks follow the TanStack Query mutation pattern:
 ### Types
 
 - `OAuthProvider` - OAuth provider type
-- `OAuthConfig` - OAuth configuration type
 - `ZeroDevWalletConnectorParams` - Connector parameters
 - `ZeroDevWalletState` - Store state type
 - `ZeroDevProvider` - EIP-1193 provider type

--- a/packages/react/src/actions.ts
+++ b/packages/react/src/actions.ts
@@ -2,10 +2,9 @@ import type { Config, Connector } from '@wagmi/core'
 import { connect as wagmiConnect } from '@wagmi/core/actions'
 import type { OAuthProvider } from './oauth.js'
 import {
-  buildOAuthUrl,
-  generateOAuthNonce,
+  buildBackendOAuthUrl,
+  listenForOAuthMessage,
   openOAuthPopup,
-  pollOAuthPopup,
 } from './oauth.js'
 
 /**
@@ -111,12 +110,12 @@ export declare namespace loginPasskey {
 
 /**
  * Authenticate with OAuth (opens popup)
+ * Uses backend OAuth flow where the backend handles PKCE and token exchange
  */
 export async function authenticateOAuth(
   config: Config,
   parameters: {
     provider: OAuthProvider
-    clientId?: string
     connector?: Connector
   },
 ): Promise<void> {
@@ -129,38 +128,23 @@ export async function authenticateOAuth(
 
   if (!wallet) throw new Error('Wallet not initialized')
   if (!oauthConfig) {
-    throw new Error(
-      'OAuth is not configured. Please provide oauthConfig to zeroDevWallet connector.',
-    )
+    throw new Error('Wallet not initialized. Please wait for connector setup.')
   }
 
-  // Get client ID for the provider
-  let clientId = parameters.clientId
-  if (!clientId) {
-    clientId = oauthConfig.googleClientId
-  }
-
-  if (!clientId) {
-    throw new Error(`Client ID not configured for ${parameters.provider}`)
-  }
-
-  if (!oauthConfig.redirectUri) {
-    throw new Error('OAuth redirect URI is not configured.')
-  }
-
-  // Generate nonce from wallet public key
+  // Get wallet public key for the OAuth flow
   const publicKey = await wallet.getPublicKey()
   if (!publicKey) {
     throw new Error('Failed to get wallet public key')
   }
-  const nonce = generateOAuthNonce(publicKey)
 
-  // Build OAuth URL
-  const oauthUrl = buildOAuthUrl({
+  // Build OAuth URL that redirects to backend
+  // Use current origin as redirect - SDK auto-detects callback on any page
+  const oauthUrl = buildBackendOAuthUrl({
     provider: parameters.provider,
-    clientId,
-    redirectUri: oauthConfig.redirectUri,
-    nonce,
+    backendUrl: oauthConfig.backendUrl,
+    projectId: oauthConfig.projectId,
+    publicKey,
+    returnTo: `${window.location.origin}?oauth_success=true&oauth_provider=${parameters.provider}`,
   })
 
   // Open popup
@@ -170,18 +154,18 @@ export async function authenticateOAuth(
     throw new Error(`Failed to open ${parameters.provider} login window.`)
   }
 
-  // Poll for OAuth completion
+  // Listen for OAuth completion via postMessage
   return new Promise<void>((resolve, reject) => {
-    pollOAuthPopup(
+    const cleanup = listenForOAuthMessage(
       authWindow,
       window.location.origin,
-      async (idToken) => {
+      async () => {
         try {
           // Complete OAuth authentication with wallet-core
+          // The backend has stored the OAuth session in a cookie
           await wallet.auth({
             type: 'oauth',
             provider: parameters.provider,
-            credential: idToken,
           })
 
           const [session, eoaAccount] = await Promise.all([
@@ -200,7 +184,10 @@ export async function authenticateOAuth(
           reject(err)
         }
       },
-      reject,
+      (error) => {
+        cleanup()
+        reject(error)
+      },
     )
   })
 }
@@ -208,7 +195,6 @@ export async function authenticateOAuth(
 export declare namespace authenticateOAuth {
   type Parameters = {
     provider: OAuthProvider
-    clientId?: string
     connector?: Connector
   }
   type ReturnType = void

--- a/packages/react/src/connector.ts
+++ b/packages/react/src/connector.ts
@@ -6,12 +6,70 @@ import {
 } from '@zerodev/sdk'
 import { getEntryPoint, KERNEL_V3_3 } from '@zerodev/sdk/constants'
 import type { StorageAdapter } from '@zerodev/wallet-core'
-import { createZeroDevWallet } from '@zerodev/wallet-core'
+import { createZeroDevWallet, KMS_SERVER_URL } from '@zerodev/wallet-core'
 import { type Chain, createPublicClient, http } from 'viem'
-import type { OAuthConfig } from './oauth.js'
+import { handleOAuthCallback, type OAuthProvider } from './oauth.js'
 import { createProvider } from './provider.js'
 import { createZeroDevWalletStore } from './store.js'
 import { getAAUrl } from './utils/aaUtils.js'
+
+// OAuth URL parameter used to detect callback
+const OAUTH_SUCCESS_PARAM = 'oauth_success'
+const OAUTH_PROVIDER_PARAM = 'oauth_provider'
+
+/**
+ * Detect OAuth callback from URL params and handle it.
+ * - If in popup: sends postMessage to opener and closes
+ * - If not in popup: completes auth directly
+ */
+async function detectAndHandleOAuthCallback(
+  wallet: Awaited<ReturnType<typeof createZeroDevWallet>>,
+  store: ReturnType<typeof createZeroDevWalletStore>,
+): Promise<boolean> {
+  if (typeof window === 'undefined') return false
+
+  const params = new URLSearchParams(window.location.search)
+  const isOAuthCallback = params.get(OAUTH_SUCCESS_PARAM) === 'true'
+
+  if (!isOAuthCallback) return false
+
+  // If in popup, use the existing handler to notify opener
+  if (window.opener) {
+    handleOAuthCallback(OAUTH_SUCCESS_PARAM)
+    return true
+  }
+
+  // Not in popup - complete auth directly (redirect flow)
+  console.log('OAuth callback detected, completing authentication...')
+  const provider = (params.get(OAUTH_PROVIDER_PARAM) ||
+    'google') as OAuthProvider
+
+  try {
+    await wallet.auth({ type: 'oauth', provider })
+
+    const [session, eoaAccount] = await Promise.all([
+      wallet.getSession(),
+      wallet.toAccount(),
+    ])
+
+    store.getState().setEoaAccount(eoaAccount)
+    store.getState().setSession(session || null)
+
+    // Clean up URL params
+    params.delete(OAUTH_SUCCESS_PARAM)
+    params.delete(OAUTH_PROVIDER_PARAM)
+    const newUrl = params.toString()
+      ? `${window.location.pathname}?${params.toString()}`
+      : window.location.pathname
+    window.history.replaceState({}, '', newUrl)
+
+    console.log('OAuth authentication completed')
+    return true
+  } catch (error) {
+    console.error('OAuth authentication failed:', error)
+    return false
+  }
+}
 
 export type ZeroDevWalletConnectorParams = {
   projectId: string
@@ -23,7 +81,6 @@ export type ZeroDevWalletConnectorParams = {
   sessionStorage?: StorageAdapter
   autoRefreshSession?: boolean
   sessionWarningThreshold?: number
-  oauthConfig?: OAuthConfig
 }
 
 export function zeroDevWallet(
@@ -79,10 +136,11 @@ export function zeroDevWallet(
       const chainIds = params.chains.map((c) => c.id)
       store.setState({ chainIds })
 
-      // Store OAuth config if provided
-      if (params.oauthConfig) {
-        store.getState().setOAuthConfig(params.oauthConfig)
-      }
+      // Store OAuth config - uses proxyBaseUrl and projectId from params
+      store.getState().setOAuthConfig({
+        backendUrl: params.proxyBaseUrl || `${KMS_SERVER_URL}/api/v1`,
+        projectId: params.projectId,
+      })
 
       // Create EIP-1193 provider
       provider = createProvider({
@@ -99,6 +157,9 @@ export function zeroDevWallet(
         store.getState().setEoaAccount(eoaAccount)
         store.getState().setSession(session)
       }
+
+      // Auto-detect OAuth callback (when popup redirects back with ?oauth_success=true)
+      await detectAndHandleOAuthCallback(wallet, store)
 
       console.log('ZeroDevWallet connector initialized')
     }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,8 +7,13 @@ export { useRefreshSession } from './hooks/useRefreshSession.js'
 export { useRegisterPasskey } from './hooks/useRegisterPasskey.js'
 export { useSendOTP } from './hooks/useSendOTP.js'
 export { useVerifyOTP } from './hooks/useVerifyOTP.js'
-export type { OAuthConfig, OAuthProvider } from './oauth.js'
-export { OAUTH_PROVIDERS } from './oauth.js'
+export type { OAuthMessageData, OAuthProvider } from './oauth.js'
+export {
+  buildBackendOAuthUrl,
+  handleOAuthCallback,
+  listenForOAuthMessage,
+  OAUTH_PROVIDERS,
+} from './oauth.js'
 export type { ZeroDevProvider } from './provider.js'
 export type { ZeroDevWalletState } from './store.js'
 export { createZeroDevWalletStore } from './store.js'

--- a/packages/react/src/oauth.ts
+++ b/packages/react/src/oauth.ts
@@ -7,55 +7,16 @@ export const OAUTH_PROVIDERS = {
 export type OAuthProvider =
   (typeof OAUTH_PROVIDERS)[keyof typeof OAUTH_PROVIDERS]
 
-export type OAuthConfig = {
-  googleClientId?: string
-  redirectUri: string
-}
-
-export type OAuthFlowParams = {
+export type BackendOAuthFlowParams = {
   provider: OAuthProvider
-  clientId: string
-  redirectUri: string
-  nonce: string
-  state?: Record<string, string>
+  backendUrl: string
+  projectId: string
+  publicKey: string
+  returnTo: string
 }
-
-const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth'
 
 const POPUP_WIDTH = 500
 const POPUP_HEIGHT = 600
-
-export function buildOAuthUrl(params: OAuthFlowParams): string {
-  const { provider, clientId, redirectUri, nonce, state } = params
-
-  if (provider !== OAUTH_PROVIDERS.GOOGLE) {
-    throw new Error(`Unsupported OAuth provider: ${provider}`)
-  }
-
-  const authUrl = new URL(GOOGLE_AUTH_URL)
-  authUrl.searchParams.set('client_id', clientId)
-  authUrl.searchParams.set('redirect_uri', redirectUri)
-  authUrl.searchParams.set('response_type', 'id_token')
-  authUrl.searchParams.set('scope', 'openid email profile')
-  authUrl.searchParams.set('nonce', nonce)
-  authUrl.searchParams.set('prompt', 'select_account')
-
-  let stateParam = `provider=${provider}`
-  if (state) {
-    const additionalState = Object.entries(state)
-      .map(
-        ([key, value]) =>
-          `${encodeURIComponent(key)}=${encodeURIComponent(value)}`,
-      )
-      .join('&')
-    if (additionalState) {
-      stateParam += `&${additionalState}`
-    }
-  }
-  authUrl.searchParams.set('state', stateParam)
-
-  return authUrl.toString()
-}
 
 export function openOAuthPopup(url: string): Window | null {
   const width = POPUP_WIDTH
@@ -76,49 +37,107 @@ export function openOAuthPopup(url: string): Window | null {
   return authWindow
 }
 
-export function extractOAuthToken(url: string): string | null {
-  const hashParams = new URLSearchParams(url.split('#')[1])
-  let idToken = hashParams.get('id_token')
-
-  if (!idToken) {
-    const queryParams = new URLSearchParams(url.split('?')[1])
-    idToken = queryParams.get('id_token')
-  }
-
-  return idToken
-}
-
-export function pollOAuthPopup(
-  authWindow: Window,
-  originUrl: string,
-  onSuccess: (token: string) => void,
-  onError: (error: Error) => void,
-): void {
-  const interval = setInterval(() => {
-    try {
-      if (authWindow.closed) {
-        clearInterval(interval)
-        onError(new Error('Authentication window was closed'))
-        return
-      }
-
-      const url = authWindow.location.href || ''
-
-      if (url.startsWith(originUrl)) {
-        const token = extractOAuthToken(url)
-
-        if (token) {
-          authWindow.close()
-          clearInterval(interval)
-          onSuccess(token)
-        }
-      }
-    } catch {
-      // Ignore cross-origin errors
-    }
-  }, 500)
-}
-
 export function generateOAuthNonce(publicKey: string): string {
   return sha256(publicKey as Hex).replace(/^0x/, '')
+}
+
+/**
+ * Build OAuth URL that redirects to backend's OAuth endpoint
+ * The backend handles PKCE, client credentials, and token exchange
+ */
+export function buildBackendOAuthUrl(params: BackendOAuthFlowParams): string {
+  const { provider, backendUrl, projectId, publicKey, returnTo } = params
+
+  if (provider !== OAUTH_PROVIDERS.GOOGLE) {
+    throw new Error(`Unsupported OAuth provider: ${provider}`)
+  }
+
+  const oauthUrl = new URL(`${backendUrl}/oauth/google/login`)
+  oauthUrl.searchParams.set('project_id', projectId)
+  oauthUrl.searchParams.set('pub_key', publicKey.replace(/^0x/, ''))
+  oauthUrl.searchParams.set('return_to', returnTo)
+
+  return oauthUrl.toString()
+}
+
+export type OAuthMessageData = {
+  type: 'oauth_success' | 'oauth_error'
+  error?: string
+}
+
+/**
+ * Listen for OAuth completion via postMessage from popup
+ * The popup sends a message when it detects a successful redirect
+ */
+export function listenForOAuthMessage(
+  authWindow: Window,
+  expectedOrigin: string,
+  onSuccess: () => void,
+  onError: (error: Error) => void,
+): () => void {
+  let cleaned = false
+
+  const handleMessage = (event: MessageEvent<OAuthMessageData>) => {
+    // Only trust messages from expected origin
+    if (event.origin !== expectedOrigin) return
+    if (!event.data || typeof event.data !== 'object') return
+
+    if (event.data.type === 'oauth_success') {
+      cleanup()
+      onSuccess()
+    } else if (event.data.type === 'oauth_error') {
+      cleanup()
+      onError(new Error(event.data.error || 'OAuth authentication failed'))
+    }
+  }
+
+  const checkWindowClosed = setInterval(() => {
+    if (authWindow.closed) {
+      cleanup()
+      onError(new Error('Authentication window was closed'))
+    }
+  }, 500)
+
+  const cleanup = () => {
+    if (cleaned) return
+    cleaned = true
+    window.removeEventListener('message', handleMessage)
+    clearInterval(checkWindowClosed)
+  }
+
+  window.addEventListener('message', handleMessage)
+
+  return cleanup
+}
+
+/**
+ * Handle OAuth callback on the return page
+ * Call this on the page that receives the OAuth redirect
+ * It sends a postMessage to the opener and closes the window
+ */
+export function handleOAuthCallback(successParam = 'oauth_success'): boolean {
+  const urlParams = new URLSearchParams(window.location.search)
+  const isSuccess = urlParams.get(successParam) === 'true'
+  const error = urlParams.get('error')
+
+  if (window.opener) {
+    if (isSuccess) {
+      window.opener.postMessage(
+        { type: 'oauth_success' } satisfies OAuthMessageData,
+        window.location.origin,
+      )
+      window.close()
+      return true
+    }
+    if (error) {
+      window.opener.postMessage(
+        { type: 'oauth_error', error } satisfies OAuthMessageData,
+        window.location.origin,
+      )
+      window.close()
+      return false
+    }
+  }
+
+  return false
 }

--- a/packages/react/src/store.ts
+++ b/packages/react/src/store.ts
@@ -10,7 +10,12 @@ import type { LocalAccount } from 'viem'
 import type { SmartAccount } from 'viem/account-abstraction'
 import { create } from 'zustand'
 import { persist, subscribeWithSelector } from 'zustand/middleware'
-import type { OAuthConfig } from './oauth.js'
+
+// Internal OAuth config stored in the state (derived from connector params)
+type InternalOAuthConfig = {
+  backendUrl: string
+  projectId: string
+}
 
 export type ZeroDevWalletState = {
   // Core
@@ -26,8 +31,8 @@ export type ZeroDevWalletState = {
   // Session expiry
   isExpiring: boolean
 
-  // OAuth config (optional)
-  oauthConfig: OAuthConfig | null
+  // OAuth config (derived from connector params)
+  oauthConfig: InternalOAuthConfig | null
 
   // Actions
   setWallet: (wallet: ZeroDevWalletSDK) => void
@@ -40,7 +45,7 @@ export type ZeroDevWalletState = {
   setSession: (session: ZeroDevWalletSession | null) => void
   setActiveChain: (chainId: number) => void
   setIsExpiring: (isExpiring: boolean) => void
-  setOAuthConfig: (config: OAuthConfig | null) => void
+  setOAuthConfig: (config: InternalOAuthConfig | null) => void
   clear: () => void
 }
 


### PR DESCRIPTION
Remove legacy frontend OAuth flow in favor of backend-handled PKCE. The SDK now auto-detects OAuth callbacks and handles popup communication via postMessage, eliminating the need for callback pages or client-side OAuth libraries.

- Remove oauthConfig from connector params (derived internally)
- Add auto-detection of ?oauth_success=true URL params
- Use cookie-based auth with backend's /oauth/google/login endpoint
- Update README docs to reflect simplified developer experience