### PR TITLE
fix: add Authorization header to sign endpoints and canonicalize stamp payloads

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,8 @@
     "@turnkey/http": "^3.12.1",
     "@turnkey/iframe-stamper": "^2.5.0",
     "@turnkey/indexed-db-stamper": "^1.1.1",
-    "@turnkey/webauthn-stamper": "^0.6.0"
+    "@turnkey/webauthn-stamper": "^0.6.0",
+    "json-canonicalize": "^2.0.0"
   },
   "peerDependencies": {
     "viem": "^2.38.0"

--- a/packages/core/src/actions/auth/loginWithStamp.ts
+++ b/packages/core/src/actions/auth/loginWithStamp.ts
@@ -1,3 +1,4 @@
+import { canonicalizeEx } from 'json-canonicalize'
 import type { Client } from '../../client/types.js'
 import type { Stamp } from '../../stampers/types.js'
 
@@ -48,14 +49,14 @@ export async function loginWithStamp(
   const timestampMsString = timestampMs.toString()
   const timestampIso = new Date(timestampMs).toISOString()
 
-  const stampPayload = `${JSON.stringify({
+  const stampPayload = canonicalizeEx({
     organizationId,
     parameters: {
       publicKey: targetPublicKey,
     },
     timestampMs: timestampMsString,
     type: 'ACTIVITY_TYPE_STAMP_LOGIN',
-  })}\n`
+  })
   let stamp: Stamp
   if (stampWith === 'indexedDb') {
     stamp = await client.indexedDbStamper.stamp(stampPayload)

--- a/packages/core/src/actions/wallet/signRawPayload.ts
+++ b/packages/core/src/actions/wallet/signRawPayload.ts
@@ -6,6 +6,8 @@ export type SignRawPayloadParameters = {
   organizationId: string
   /** The project ID for the request */
   projectId: string
+  /** The session token for authorization */
+  token: string
   /** The address to sign with */
   address: Hex
   /** The payload hash to sign (without 0x prefix) */
@@ -43,6 +45,7 @@ export async function signRawPayload(
   const {
     organizationId,
     projectId,
+    token,
     address,
     payload,
     encoding = 'PAYLOAD_ENCODING_HEXADECIMAL',
@@ -52,20 +55,21 @@ export async function signRawPayload(
   const { signature } = await client.request({
     path: `${projectId}/sign/raw-payload`,
     body: {
-      body: {
-        type: 'ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2',
-        timestampMs: Date.now().toString(),
-        organizationId,
-        parameters: {
-          signWith: address,
-          payload,
-          encoding,
-          hashFunction,
-        },
+      type: 'ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2',
+      timestampMs: Date.now().toString(),
+      organizationId,
+      parameters: {
+        signWith: address,
+        payload,
+        encoding,
+        hashFunction,
       },
-      apiUrl: 'https://api.turnkey.com/public/v1/submit/sign_raw_payload',
+    },
+    headers: {
+      Authorization: `Bearer ${token}`,
     },
     stamp: true,
+    stampPostion: 'headers',
   })
   return signature as Hex
 }

--- a/packages/core/src/actions/wallet/signTransaction.ts
+++ b/packages/core/src/actions/wallet/signTransaction.ts
@@ -6,6 +6,8 @@ export type SignTransactionParameters = {
   organizationId: string
   /** The project ID for the request */
   projectId: string
+  /** The session token for authorization */
+  token: string
   /** The address to sign with */
   address: Hex
   /** The unsigned transaction to sign */
@@ -36,24 +38,26 @@ export async function signTransaction(
   client: Client,
   params: SignTransactionParameters,
 ): Promise<SignTransactionReturnType> {
-  const { organizationId, projectId, address, unsignedTransaction } = params
+  const { organizationId, projectId, token, address, unsignedTransaction } =
+    params
 
   const { signature } = await client.request({
     path: `${projectId}/sign/transaction`,
     body: {
-      body: {
-        type: 'ACTIVITY_TYPE_SIGN_TRANSACTION_V2',
-        timestampMs: Date.now().toString(),
-        organizationId,
-        parameters: {
-          signWith: address,
-          type: 'TRANSACTION_TYPE_ETHEREUM',
-          unsignedTransaction,
-        },
+      type: 'ACTIVITY_TYPE_SIGN_TRANSACTION_V2',
+      timestampMs: Date.now().toString(),
+      organizationId,
+      parameters: {
+        signWith: address,
+        type: 'TRANSACTION_TYPE_ETHEREUM',
+        unsignedTransaction,
       },
-      apiUrl: 'https://api.turnkey.com/public/v1/submit/sign_transaction',
+    },
+    headers: {
+      Authorization: `Bearer ${token}`,
     },
     stamp: true,
+    stampPostion: 'headers',
   })
 
   return `0x${signature}` as Hex

--- a/packages/core/src/adapters/viem.ts
+++ b/packages/core/src/adapters/viem.ts
@@ -53,6 +53,7 @@ export async function toViemAccount(
     return await client.signRawPayload({
       organizationId,
       projectId,
+      token,
       address,
       payload,
       encoding,
@@ -78,6 +79,7 @@ export async function toViemAccount(
     const signature = await client.signTransaction({
       organizationId,
       projectId,
+      token,
       address,
       unsignedTransaction: nonHexPrefixedSerializedTx,
     })

--- a/packages/core/src/client/transports/rest.ts
+++ b/packages/core/src/client/transports/rest.ts
@@ -1,3 +1,4 @@
+import { canonicalizeEx } from 'json-canonicalize'
 import { RestRequestError, RestTimeoutError } from '../../errors/request.js'
 import type { IndexedDbStamper, WebauthnStamper } from '../../stampers/types.js'
 
@@ -62,7 +63,7 @@ export function rest(url: string, cfg: RestTransportConfig): RestTransport {
           stamper = cfg.indexedDbStamper
         }
         const { body, apiUrl } = args.body
-        const bodyString = `${JSON.stringify(body ?? args.body)}\n`
+        const bodyString = canonicalizeEx(body ?? args.body)
         const stamp = await stamper.stamp(bodyString)
 
         // Restructure request body to match backend expectation

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@turnkey/webauthn-stamper':
         specifier: ^0.6.0
         version: 0.6.0
+      json-canonicalize:
+        specifier: ^2.0.0
+        version: 2.0.0
       viem:
         specifier: ^2.38.0
         version: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12)
@@ -1601,6 +1604,9 @@ packages:
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
+
+  json-canonicalize@2.0.0:
+    resolution: {integrity: sha512-yyrnK/mEm6Na3ChbJUWueXdapueW0p380RUyTW87XGb1ww8l8hU0pRrGC3vSWHe9CxrbPHX2fGUOZpNiHR0IIg==}
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
@@ -5257,6 +5263,8 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
+
+  json-canonicalize@2.0.0: {}
 
   json-stringify-safe@5.0.1:
     optional: true


### PR DESCRIPTION
- Add token parameter to signRawPayload and signTransaction actions
- Pass Authorization Bearer token header for sign requests
- Use json-canonicalize for consistent stamp payload serialization
- Update viem adapter to pass token through to sign functions