### PR TITLE
test: add unit test suite for core and react packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "ci": "biome ci .",
-    "test": "pnpm --recursive run test",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "prepare": "husky",
     "changeset": "changeset",
     "changeset:version": "changeset version && pnpm install --lockfile-only",
@@ -37,10 +39,15 @@
   "devDependencies": {
     "@biomejs/biome": "^2.2.4",
     "@changesets/cli": "^2.29.7",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^4.0.18",
+    "happy-dom": "^20.6.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.3",
-    "typescript": "~5.9.0"
+    "typescript": "~5.9.0",
+    "vitest": "^4.0.18"
   },
   "packageManager": "pnpm@10.17.1+sha512.17c560fca4867ae9473a3899ad84a88334914f379be46d455cbf92e5cf4b39d34985d452d2583baf19967fa76cb5c17bc9e245529d0b98745721aa7200ecaf7a",
   "lint-staged": {

--- a/packages/core/src/actions/auth/auth.test.ts
+++ b/packages/core/src/actions/auth/auth.test.ts
@@ -1,0 +1,503 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Client } from '../../client/types.js'
+import { authenticateWithEmail } from './authenticateWithEmail.js'
+import { authenticateWithOAuth } from './authenticateWithOAuth.js'
+import { getUserEmail } from './getUserEmail.js'
+import { getWhoami } from './getWhoami.js'
+import { loginWithStamp } from './loginWithStamp.js'
+import { registerWithPasskey } from './registerWithPasskey.js'
+
+// Create a mock client with configurable request implementation
+function createMockClient(
+  requestImpl?: (params: {
+    path: string
+    method?: string
+    body?: unknown
+    credentials?: string
+    headers?: Record<string, string>
+    stamp?: boolean
+    stampPostion?: string
+  }) => Promise<unknown>,
+): Client {
+  const mockStamp = {
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'mock-stamp-value',
+  }
+
+  return {
+    transport: {
+      name: 'test',
+      key: 'test',
+      url: 'https://test.example.com',
+      timeoutMs: 5000,
+      type: 'rest',
+    },
+    request: vi.fn(
+      requestImpl || (async () => ({})),
+    ) as unknown as Client['request'],
+    indexedDbStamper: {
+      stamp: vi.fn().mockResolvedValue(mockStamp),
+      init: vi.fn().mockResolvedValue(undefined),
+      publicKey: vi.fn().mockReturnValue('mock-public-key'),
+      injectCredentialBundle: vi.fn().mockResolvedValue(undefined),
+      getStamperType: vi.fn().mockReturnValue('indexedDb'),
+      clear: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Client['indexedDbStamper'],
+    webauthnStamper: {
+      stamp: vi.fn().mockResolvedValue(mockStamp),
+    } as unknown as Client['webauthnStamper'],
+    key: 'test-client',
+    name: 'Test Client',
+    type: 'zeroDevWalletClient',
+    uid: 'test-uid',
+    extend: vi.fn() as unknown as Client['extend'],
+  }
+}
+
+describe('authenticateWithOAuth', () => {
+  it('sends OAuth auth request with correct path and credentials', async () => {
+    const mockClient = createMockClient(async () => ({
+      userId: 'user-123',
+      session: 'session-jwt',
+    }))
+
+    const result = await authenticateWithOAuth(mockClient, {
+      provider: 'google',
+      projectId: 'proj-456',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith({
+      path: 'proj-456/auth/oauth',
+      method: 'POST',
+      body: null,
+      credentials: 'include',
+    })
+    expect(result).toEqual({
+      userId: 'user-123',
+      session: 'session-jwt',
+    })
+  })
+
+  it('returns full OAuth response with all optional fields', async () => {
+    const fullResponse = {
+      userId: 'user-123',
+      walletAddress: '0x1234567890abcdef',
+      subOrganizationId: 'suborg-456',
+      session: 'session-jwt-token',
+    }
+    const mockClient = createMockClient(async () => fullResponse)
+
+    const result = await authenticateWithOAuth(mockClient, {
+      provider: 'google',
+      projectId: 'proj-456',
+    })
+
+    expect(result).toEqual(fullResponse)
+  })
+
+  it('handles OAuth failure gracefully', async () => {
+    const mockClient = createMockClient(async () => {
+      throw new Error('OAuth session expired')
+    })
+
+    await expect(
+      authenticateWithOAuth(mockClient, {
+        provider: 'google',
+        projectId: 'proj-456',
+      }),
+    ).rejects.toThrow('OAuth session expired')
+  })
+})
+
+describe('authenticateWithEmail', () => {
+  it('sends email auth request with correct parameters', async () => {
+    const mockClient = createMockClient(async () => ({
+      userId: 'user-123',
+      requiresMagicLink: true,
+    }))
+
+    const result = await authenticateWithEmail(mockClient, {
+      email: 'user@example.com',
+      projectId: 'proj-456',
+      targetPublicKey: '03abcdef1234567890',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith({
+      path: 'proj-456/auth/email-magic',
+      method: 'POST',
+      body: {
+        email: 'user@example.com',
+        emailCustomization: undefined,
+        targetPublicKey: '03abcdef1234567890',
+        projectId: 'proj-456',
+      },
+    })
+    expect(result).toEqual({
+      userId: 'user-123',
+      requiresMagicLink: true,
+    })
+  })
+
+  it('includes email customization when provided', async () => {
+    const mockClient = createMockClient(async () => ({}))
+
+    await authenticateWithEmail(mockClient, {
+      email: 'user@example.com',
+      projectId: 'proj-456',
+      targetPublicKey: '03abcdef',
+      emailCustomization: {
+        magicLinkTemplate: 'https://myapp.com/verify/%s',
+      },
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          emailCustomization: {
+            magicLinkTemplate: 'https://myapp.com/verify/%s',
+          },
+        }),
+      }),
+    )
+  })
+
+  it('returns turnkey session when available', async () => {
+    const mockClient = createMockClient(async () => ({
+      userId: 'user-123',
+      turnkeySession: 'turnkey-jwt-token',
+      requiresMagicLink: false,
+    }))
+
+    const result = await authenticateWithEmail(mockClient, {
+      email: 'user@example.com',
+      projectId: 'proj-456',
+      targetPublicKey: '03abcdef',
+    })
+
+    expect(result.turnkeySession).toBe('turnkey-jwt-token')
+    expect(result.requiresMagicLink).toBe(false)
+  })
+})
+
+describe('loginWithStamp', () => {
+  it('sends stamp login request with indexedDb stamper by default', async () => {
+    const mockClient = createMockClient(async () => ({
+      session: 'session-jwt',
+    }))
+
+    const result = await loginWithStamp(mockClient, {
+      projectId: 'proj-456',
+      organizationId: 'org-123',
+      targetPublicKey: '03abcdef1234567890',
+    })
+
+    // Verify indexedDb stamper was used
+    expect(mockClient.indexedDbStamper.stamp).toHaveBeenCalled()
+    expect(mockClient.webauthnStamper.stamp).not.toHaveBeenCalled()
+
+    // Verify the stamp payload structure
+    const stampCall = vi.mocked(mockClient.indexedDbStamper.stamp).mock.calls[0]
+    const stampPayload = JSON.parse(stampCall[0] as string)
+    expect(stampPayload).toMatchObject({
+      organizationId: 'org-123',
+      parameters: {
+        publicKey: '03abcdef1234567890',
+      },
+      type: 'ACTIVITY_TYPE_STAMP_LOGIN',
+    })
+    expect(stampPayload.timestampMs).toBeDefined()
+
+    // Verify request was made correctly
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: 'proj-456/auth/login/stamp',
+        method: 'POST',
+        body: expect.objectContaining({
+          subOrganizationId: 'org-123',
+          targetPublicKey: '03abcdef1234567890',
+          stamp: expect.objectContaining({
+            stampHeaderName: 'X-Stamp',
+            stampHeaderValue: 'mock-stamp-value',
+          }),
+        }),
+      }),
+    )
+
+    expect(result).toEqual({ session: 'session-jwt' })
+  })
+
+  it('uses webauthn stamper when specified', async () => {
+    const mockClient = createMockClient(async () => ({
+      session: 'session-jwt',
+    }))
+
+    await loginWithStamp(mockClient, {
+      projectId: 'proj-456',
+      organizationId: 'org-123',
+      targetPublicKey: '03abcdef',
+      stampWith: 'webauthn',
+    })
+
+    expect(mockClient.webauthnStamper.stamp).toHaveBeenCalled()
+    expect(mockClient.indexedDbStamper.stamp).not.toHaveBeenCalled()
+  })
+
+  it('uses indexedDb stamper when explicitly specified', async () => {
+    const mockClient = createMockClient(async () => ({
+      session: 'session-jwt',
+    }))
+
+    await loginWithStamp(mockClient, {
+      projectId: 'proj-456',
+      organizationId: 'org-123',
+      targetPublicKey: '03abcdef',
+      stampWith: 'indexedDb',
+    })
+
+    expect(mockClient.indexedDbStamper.stamp).toHaveBeenCalled()
+    expect(mockClient.webauthnStamper.stamp).not.toHaveBeenCalled()
+  })
+
+  it('includes timestamp in request body', async () => {
+    const mockClient = createMockClient(async () => ({
+      session: 'session-jwt',
+    }))
+
+    await loginWithStamp(mockClient, {
+      projectId: 'proj-456',
+      organizationId: 'org-123',
+      targetPublicKey: '03abcdef',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/), // ISO format
+        }),
+      }),
+    )
+  })
+
+  it('propagates stamper errors', async () => {
+    const mockClient = createMockClient()
+    vi.mocked(mockClient.indexedDbStamper.stamp).mockRejectedValue(
+      new Error('Stamper unavailable'),
+    )
+
+    await expect(
+      loginWithStamp(mockClient, {
+        projectId: 'proj-456',
+        organizationId: 'org-123',
+        targetPublicKey: '03abcdef',
+      }),
+    ).rejects.toThrow('Stamper unavailable')
+  })
+})
+
+describe('registerWithPasskey', () => {
+  it('sends passkey registration request with correct parameters', async () => {
+    const attestation = {
+      attestationObject: 'attestation-object-base64',
+      clientDataJson: 'client-data-json-base64',
+      credentialId: 'credential-id-123',
+    }
+    const mockClient = createMockClient(async () => ({
+      userId: 'user-123',
+      walletAddress: '0x1234567890abcdef',
+      subOrganizationId: 'suborg-456',
+    }))
+
+    const result = await registerWithPasskey(mockClient, {
+      email: 'user@example.com',
+      projectId: 'proj-456',
+      challenge: 'challenge-base64',
+      attestation,
+      encodedPublicKey: '03abcdef1234567890',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith({
+      path: 'proj-456/auth/register/passkey',
+      method: 'POST',
+      body: {
+        email: 'user@example.com',
+        attestation,
+        challenge: 'challenge-base64',
+        encodedPublicKey: '03abcdef1234567890',
+      },
+    })
+    expect(result).toEqual({
+      userId: 'user-123',
+      walletAddress: '0x1234567890abcdef',
+      subOrganizationId: 'suborg-456',
+    })
+  })
+
+  it('handles registration failure', async () => {
+    const mockClient = createMockClient(async () => {
+      throw new Error('Invalid attestation')
+    })
+
+    await expect(
+      registerWithPasskey(mockClient, {
+        email: 'user@example.com',
+        projectId: 'proj-456',
+        challenge: 'challenge',
+        attestation: {
+          attestationObject: 'invalid',
+          clientDataJson: 'invalid',
+          credentialId: 'invalid',
+        },
+        encodedPublicKey: '03abcdef',
+      }),
+    ).rejects.toThrow('Invalid attestation')
+  })
+})
+
+describe('getUserEmail', () => {
+  it('sends user email request with correct parameters', async () => {
+    const mockClient = createMockClient(async () => ({
+      email: 'user@example.com',
+    }))
+
+    const result = await getUserEmail(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'test-token',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith({
+      path: 'proj-456/user-email',
+      method: 'POST',
+      body: {
+        organizationId: 'org-123',
+      },
+      headers: {
+        Authorization: 'Bearer test-token',
+      },
+      stamp: true,
+      stampPostion: 'headers',
+    })
+    expect(result).toEqual({ email: 'user@example.com' })
+  })
+
+  it('returns user email on success', async () => {
+    const mockClient = createMockClient(async () => ({
+      email: 'test@domain.com',
+    }))
+
+    const result = await getUserEmail(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'test-token',
+    })
+
+    expect(result.email).toBe('test@domain.com')
+  })
+
+  it('requests stamping', async () => {
+    const mockClient = createMockClient(async () => ({ email: 'a@b.com' }))
+
+    await getUserEmail(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stamp: true,
+      }),
+    )
+  })
+
+  it('propagates errors', async () => {
+    const mockClient = createMockClient(async () => {
+      throw new Error('User not found')
+    })
+
+    await expect(
+      getUserEmail(mockClient, {
+        organizationId: 'org-123',
+        projectId: 'proj-456',
+      }),
+    ).rejects.toThrow('User not found')
+  })
+})
+
+describe('getWhoami', () => {
+  it('sends whoami request with correct parameters', async () => {
+    const mockClient = createMockClient(async () => ({
+      userId: 'user-789',
+      organizationId: 'org-123',
+    }))
+
+    const result = await getWhoami(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith({
+      path: 'proj-456/whoami',
+      method: 'POST',
+      body: {
+        organizationId: 'org-123',
+      },
+      stamp: true,
+    })
+    expect(result).toEqual({
+      userId: 'user-789',
+      organizationId: 'org-123',
+    })
+  })
+
+  it('returns all user info fields when available', async () => {
+    const mockClient = createMockClient(async () => ({
+      userId: 'user-789',
+      organizationId: 'org-123',
+      organizationName: 'My Organization',
+      username: 'john_doe',
+    }))
+
+    const result = await getWhoami(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+    })
+
+    expect(result).toEqual({
+      userId: 'user-789',
+      organizationId: 'org-123',
+      organizationName: 'My Organization',
+      username: 'john_doe',
+    })
+  })
+
+  it('requests stamping', async () => {
+    const mockClient = createMockClient(async () => ({
+      userId: 'user-789',
+      organizationId: 'org-123',
+    }))
+
+    await getWhoami(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stamp: true,
+      }),
+    )
+  })
+
+  it('propagates errors', async () => {
+    const mockClient = createMockClient(async () => {
+      throw new Error('Unauthorized')
+    })
+
+    await expect(
+      getWhoami(mockClient, {
+        organizationId: 'org-123',
+        projectId: 'proj-456',
+      }),
+    ).rejects.toThrow('Unauthorized')
+  })
+})

--- a/packages/core/src/actions/auth/otp.test.ts
+++ b/packages/core/src/actions/auth/otp.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Client } from '../../client/types.js'
+import { loginWithOTP } from './loginWithOTP.js'
+import { registerWithOTP } from './registerWithOTP.js'
+
+// Create a mock client
+function createMockClient(
+  requestImpl?: (params: {
+    path: string
+    method: string
+    body?: unknown
+  }) => Promise<unknown>,
+): Client {
+  return {
+    transport: {
+      name: 'test',
+      key: 'test',
+      url: 'https://test.example.com',
+      timeoutMs: 5000,
+      type: 'rest',
+    },
+    request: vi.fn(
+      requestImpl || (async () => ({})),
+    ) as unknown as Client['request'],
+    indexedDbStamper: {} as Client['indexedDbStamper'],
+    webauthnStamper: {} as Client['webauthnStamper'],
+    key: 'test-client',
+    name: 'Test Client',
+    type: 'zeroDevWalletClient',
+    uid: 'test-uid',
+    extend: vi.fn() as unknown as Client['extend'],
+  }
+}
+
+describe('registerWithOTP', () => {
+  it('sends OTP init request with correct parameters', async () => {
+    const mockClient = createMockClient(async () => ({ otpId: 'otp-123' }))
+
+    const result = await registerWithOTP(mockClient, {
+      email: 'user@example.com',
+      contact: {
+        type: 'email',
+        contact: 'user@example.com',
+      },
+      projectId: 'proj-456',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith({
+      path: 'proj-456/auth/init/otp',
+      method: 'POST',
+      body: {
+        email: 'user@example.com',
+        contact: {
+          type: 'email',
+          contact: 'user@example.com',
+        },
+        emailCustomization: undefined,
+      },
+    })
+    expect(result).toEqual({ otpId: 'otp-123' })
+  })
+
+  it('includes email customization when provided', async () => {
+    const mockClient = createMockClient(async () => ({ otpId: 'otp-123' }))
+
+    await registerWithOTP(mockClient, {
+      email: 'user@example.com',
+      contact: {
+        type: 'email',
+        contact: 'user@example.com',
+      },
+      projectId: 'proj-456',
+      emailCustomization: {
+        magicLinkTemplate: 'https://example.com/verify/%s',
+      },
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          emailCustomization: {
+            magicLinkTemplate: 'https://example.com/verify/%s',
+          },
+        }),
+      }),
+    )
+  })
+
+  it('supports SMS contact type', async () => {
+    const mockClient = createMockClient(async () => ({ otpId: 'otp-sms' }))
+
+    await registerWithOTP(mockClient, {
+      email: 'user@example.com',
+      contact: {
+        type: 'sms',
+        contact: '+1234567890',
+      },
+      projectId: 'proj-456',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          contact: {
+            type: 'sms',
+            contact: '+1234567890',
+          },
+        }),
+      }),
+    )
+  })
+
+  it('propagates request errors', async () => {
+    const mockClient = createMockClient(async () => {
+      throw new Error('Network error')
+    })
+
+    await expect(
+      registerWithOTP(mockClient, {
+        email: 'user@example.com',
+        contact: { type: 'email', contact: 'user@example.com' },
+        projectId: 'proj-456',
+      }),
+    ).rejects.toThrow('Network error')
+  })
+})
+
+describe('loginWithOTP', () => {
+  it('sends OTP login request with correct parameters', async () => {
+    const mockClient = createMockClient(async () => ({
+      session: 'session-jwt-token',
+    }))
+
+    const result = await loginWithOTP(mockClient, {
+      verificationToken: 'verification-jwt',
+      clientSignature: 'a1'.repeat(64),
+      projectId: 'proj-456',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith({
+      path: 'proj-456/auth/login/otp',
+      method: 'POST',
+      body: {
+        verificationToken: 'verification-jwt',
+        clientSignature: 'a1'.repeat(64),
+      },
+    })
+    expect(result).toEqual({ session: 'session-jwt-token' })
+  })
+
+  it('returns session token on successful login', async () => {
+    const expectedSession = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9...'
+    const mockClient = createMockClient(async () => ({
+      session: expectedSession,
+    }))
+
+    const result = await loginWithOTP(mockClient, {
+      verificationToken: 'verification-jwt',
+      clientSignature: 'a1'.repeat(64),
+      projectId: 'proj-456',
+    })
+
+    expect(result.session).toBe(expectedSession)
+  })
+
+  it('propagates request errors', async () => {
+    const mockClient = createMockClient(async () => {
+      throw new Error('Invalid verification token')
+    })
+
+    await expect(
+      loginWithOTP(mockClient, {
+        verificationToken: 'invalid-token',
+        clientSignature: 'a1'.repeat(64),
+        projectId: 'proj-456',
+      }),
+    ).rejects.toThrow('Invalid verification token')
+  })
+
+  it('uses project ID in the request path', async () => {
+    const mockClient = createMockClient(async () => ({ session: 'jwt' }))
+
+    await loginWithOTP(mockClient, {
+      verificationToken: 'token',
+      clientSignature: 'sig',
+      projectId: 'my-custom-project-id',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: 'my-custom-project-id/auth/login/otp',
+      }),
+    )
+  })
+})

--- a/packages/core/src/actions/wallet/wallet.test.ts
+++ b/packages/core/src/actions/wallet/wallet.test.ts
@@ -1,0 +1,474 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Client } from '../../client/types.js'
+import { getUserWallet } from './getUserWallet.js'
+import { signRawPayload } from './signRawPayload.js'
+import { signTransaction } from './signTransaction.js'
+
+// Create a mock client with configurable request implementation
+function createMockClient(
+  requestImpl?: (params: {
+    path: string
+    method?: string
+    body?: unknown
+    headers?: Record<string, string>
+    stamp?: boolean
+    stampPostion?: string
+  }) => Promise<unknown>,
+): Client {
+  return {
+    transport: {
+      name: 'test',
+      key: 'test',
+      url: 'https://test.example.com',
+      timeoutMs: 5000,
+      type: 'rest',
+    },
+    request: vi.fn(
+      requestImpl || (async () => ({})),
+    ) as unknown as Client['request'],
+    indexedDbStamper: {} as Client['indexedDbStamper'],
+    webauthnStamper: {} as Client['webauthnStamper'],
+    key: 'test-client',
+    name: 'Test Client',
+    type: 'zeroDevWalletClient',
+    uid: 'test-uid',
+    extend: vi.fn() as unknown as Client['extend'],
+  }
+}
+
+describe('signTransaction', () => {
+  it('sends sign transaction request with correct parameters', async () => {
+    const signatureHex = 'abcdef1234567890'
+    const mockClient = createMockClient(async () => ({
+      signature: signatureHex,
+    }))
+
+    const result = await signTransaction(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'bearer-token-jwt',
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      unsignedTransaction: 'f86c808504a817c80082520894...',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith({
+      path: 'proj-456/sign/transaction',
+      body: {
+        type: 'ACTIVITY_TYPE_SIGN_TRANSACTION_V2',
+        timestampMs: expect.any(String),
+        organizationId: 'org-123',
+        parameters: {
+          signWith: '0x1234567890abcdef1234567890abcdef12345678',
+          type: 'TRANSACTION_TYPE_ETHEREUM',
+          unsignedTransaction: 'f86c808504a817c80082520894...',
+        },
+      },
+      headers: {
+        Authorization: 'Bearer bearer-token-jwt',
+      },
+      stamp: true,
+      stampPostion: 'headers',
+    })
+    expect(result).toBe(`0x${signatureHex}`)
+  })
+
+  it('returns signature with 0x prefix', async () => {
+    const mockClient = createMockClient(async () => ({
+      signature: 'deadbeef',
+    }))
+
+    const result = await signTransaction(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'token',
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      unsignedTransaction: 'unsigned-tx',
+    })
+
+    expect(result).toBe('0xdeadbeef')
+    expect(result.startsWith('0x')).toBe(true)
+  })
+
+  it('includes authorization header with bearer token', async () => {
+    const mockClient = createMockClient(async () => ({ signature: 'sig' }))
+
+    await signTransaction(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'my-secret-token',
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      unsignedTransaction: 'tx',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer my-secret-token',
+        },
+      }),
+    )
+  })
+
+  it('requests stamping in headers', async () => {
+    const mockClient = createMockClient(async () => ({ signature: 'sig' }))
+
+    await signTransaction(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'token',
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      unsignedTransaction: 'tx',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stamp: true,
+        stampPostion: 'headers',
+      }),
+    )
+  })
+
+  it('includes timestamp in milliseconds', async () => {
+    const mockClient = createMockClient(async () => ({ signature: 'sig' }))
+
+    await signTransaction(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'token',
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      unsignedTransaction: 'tx',
+    })
+
+    const requestCall = vi.mocked(mockClient.request).mock.calls[0][0]
+    const timestampMs = (requestCall as { body: { timestampMs: string } }).body
+      .timestampMs
+    expect(parseInt(timestampMs, 10)).toBeGreaterThan(0)
+    expect(parseInt(timestampMs, 10).toString()).toBe(timestampMs)
+  })
+
+  it('unconditionally prepends 0x (double prefix if server returns 0x)', async () => {
+    // The source unconditionally does `0x${signature}`, so if server returns '0xdeadbeef',
+    // result will be '0x0xdeadbeef' - documenting this behavior
+    const mockClient = createMockClient(async () => ({
+      signature: '0xdeadbeef',
+    }))
+
+    const result = await signTransaction(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'token',
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      unsignedTransaction: 'tx',
+    })
+
+    expect(result).toBe('0x0xdeadbeef')
+  })
+
+  it('includes timestamp close to current time', async () => {
+    const before = Date.now()
+    const mockClient = createMockClient(async () => ({ signature: 'sig' }))
+
+    await signTransaction(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'token',
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      unsignedTransaction: 'tx',
+    })
+
+    const after = Date.now()
+    const requestCall = vi.mocked(mockClient.request).mock.calls[0][0]
+    const timestampMs = Number.parseInt(
+      (requestCall as { body: { timestampMs: string } }).body.timestampMs,
+      10,
+    )
+    expect(timestampMs).toBeGreaterThanOrEqual(before)
+    expect(timestampMs).toBeLessThanOrEqual(after)
+  })
+
+  it('propagates signing errors', async () => {
+    const mockClient = createMockClient(async () => {
+      throw new Error('Signing failed: insufficient funds')
+    })
+
+    await expect(
+      signTransaction(mockClient, {
+        organizationId: 'org-123',
+        projectId: 'proj-456',
+        token: 'token',
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        unsignedTransaction: 'tx',
+      }),
+    ).rejects.toThrow('Signing failed: insufficient funds')
+  })
+})
+
+describe('getUserWallet', () => {
+  it('sends get user wallet request with correct parameters', async () => {
+    const mockClient = createMockClient(async () => ({
+      walletAddresses: [
+        '0x1234567890abcdef1234567890abcdef12345678',
+        '0xabcdef1234567890abcdef1234567890abcdef12',
+      ],
+      userId: 'user-123',
+    }))
+
+    const result = await getUserWallet(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'bearer-token-jwt',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith({
+      path: 'proj-456/user-wallet',
+      body: {
+        organizationId: 'org-123',
+      },
+      headers: {
+        Authorization: 'Bearer bearer-token-jwt',
+      },
+      stamp: true,
+      stampPostion: 'headers',
+    })
+    expect(result).toEqual({
+      walletAddresses: [
+        '0x1234567890abcdef1234567890abcdef12345678',
+        '0xabcdef1234567890abcdef1234567890abcdef12',
+      ],
+      userId: 'user-123',
+    })
+  })
+
+  it('returns wallet addresses without userId', async () => {
+    const mockClient = createMockClient(async () => ({
+      walletAddresses: ['0x1234567890abcdef1234567890abcdef12345678'],
+    }))
+
+    const result = await getUserWallet(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'token',
+    })
+
+    expect(result.walletAddresses).toEqual([
+      '0x1234567890abcdef1234567890abcdef12345678',
+    ])
+    expect(result.userId).toBeUndefined()
+  })
+
+  it('returns empty wallet addresses array', async () => {
+    const mockClient = createMockClient(async () => ({
+      walletAddresses: [],
+    }))
+
+    const result = await getUserWallet(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'token',
+    })
+
+    expect(result.walletAddresses).toEqual([])
+  })
+
+  it('includes authorization header with bearer token', async () => {
+    const mockClient = createMockClient(async () => ({ walletAddresses: [] }))
+
+    await getUserWallet(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'my-secret-token',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer my-secret-token',
+        },
+      }),
+    )
+  })
+
+  it('requests stamping in headers', async () => {
+    const mockClient = createMockClient(async () => ({ walletAddresses: [] }))
+
+    await getUserWallet(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'token',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stamp: true,
+        stampPostion: 'headers',
+      }),
+    )
+  })
+
+  it('propagates errors', async () => {
+    const mockClient = createMockClient(async () => {
+      throw new Error('User not found')
+    })
+
+    await expect(
+      getUserWallet(mockClient, {
+        organizationId: 'org-123',
+        projectId: 'proj-456',
+        token: 'token',
+      }),
+    ).rejects.toThrow('User not found')
+  })
+})
+
+describe('signRawPayload', () => {
+  it('sends sign raw payload request with default encoding and hash function', async () => {
+    const signatureHex = '0x1234567890abcdef' as const
+    const mockClient = createMockClient(async () => ({
+      signature: signatureHex,
+    }))
+
+    const result = await signRawPayload(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'bearer-token',
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      payload: 'deadbeef1234567890',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith({
+      path: 'proj-456/sign/raw-payload',
+      body: {
+        type: 'ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2',
+        timestampMs: expect.any(String),
+        organizationId: 'org-123',
+        parameters: {
+          signWith: '0x1234567890abcdef1234567890abcdef12345678',
+          payload: 'deadbeef1234567890',
+          encoding: 'PAYLOAD_ENCODING_HEXADECIMAL',
+          hashFunction: 'HASH_FUNCTION_NO_OP',
+        },
+      },
+      headers: {
+        Authorization: 'Bearer bearer-token',
+      },
+      stamp: true,
+      stampPostion: 'headers',
+    })
+    expect(result).toBe(signatureHex)
+  })
+
+  it('allows custom encoding type', async () => {
+    const mockClient = createMockClient(async () => ({ signature: '0xsig' }))
+
+    await signRawPayload(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'token',
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      payload: 'payload',
+      encoding: 'PAYLOAD_ENCODING_EIP712',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          parameters: expect.objectContaining({
+            encoding: 'PAYLOAD_ENCODING_EIP712',
+          }),
+        }),
+      }),
+    )
+  })
+
+  it('allows custom hash function', async () => {
+    const mockClient = createMockClient(async () => ({ signature: '0xsig' }))
+
+    await signRawPayload(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'token',
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      payload: 'payload',
+      hashFunction: 'HASH_FUNCTION_NO_OP',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          parameters: expect.objectContaining({
+            hashFunction: 'HASH_FUNCTION_NO_OP',
+          }),
+        }),
+      }),
+    )
+  })
+
+  it('returns signature as-is without adding 0x prefix', async () => {
+    // Unlike signTransaction, signRawPayload does NOT prepend 0x
+    const mockClient = createMockClient(async () => ({
+      signature: 'abcdef123456',
+    }))
+
+    const result = await signRawPayload(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'token',
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      payload: 'payload',
+    })
+
+    // Returned as-is, no 0x prepended
+    expect(result).toBe('abcdef123456')
+  })
+
+  it('returns signature with 0x prefix unchanged', async () => {
+    const mockClient = createMockClient(async () => ({
+      signature: '0xabcdef123456',
+    }))
+
+    const result = await signRawPayload(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'token',
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      payload: 'payload',
+    })
+
+    expect(result).toBe('0xabcdef123456')
+  })
+
+  it('requests stamping in headers', async () => {
+    const mockClient = createMockClient(async () => ({ signature: '0xsig' }))
+
+    await signRawPayload(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'token',
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      payload: 'payload',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stamp: true,
+        stampPostion: 'headers',
+      }),
+    )
+  })
+
+  it('propagates signing errors', async () => {
+    const mockClient = createMockClient(async () => {
+      throw new Error('Invalid payload encoding')
+    })
+
+    await expect(
+      signRawPayload(mockClient, {
+        organizationId: 'org-123',
+        projectId: 'proj-456',
+        token: 'token',
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        payload: 'invalid-payload',
+      }),
+    ).rejects.toThrow('Invalid payload encoding')
+  })
+})

--- a/packages/core/src/storage/adapters.test.ts
+++ b/packages/core/src/storage/adapters.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createWebStorageAdapter } from './adapters.js'
+
+// Create a mock Storage implementation
+function createMockStorage(): Storage {
+  const store = new Map<string, string>()
+  return {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value)
+    }),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key)
+    }),
+    clear: vi.fn(() => {
+      store.clear()
+    }),
+    key: vi.fn((index: number) => {
+      const keys = Array.from(store.keys())
+      return keys[index] ?? null
+    }),
+    get length() {
+      return store.size
+    },
+  }
+}
+
+describe('createWebStorageAdapter', () => {
+  let mockStorage: Storage
+
+  beforeEach(() => {
+    mockStorage = createMockStorage()
+  })
+
+  describe('getItem', () => {
+    it('retrieves item from storage', () => {
+      const adapter = createWebStorageAdapter(mockStorage)
+      mockStorage.setItem('test-key', 'test-value')
+
+      const result = adapter.getItem('test-key')
+
+      expect(result).toBe('test-value')
+      expect(mockStorage.getItem).toHaveBeenCalledWith('test-key')
+    })
+
+    it('returns null for non-existent key', () => {
+      const adapter = createWebStorageAdapter(mockStorage)
+
+      const result = adapter.getItem('nonexistent')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('setItem', () => {
+    it('stores item in storage', () => {
+      const adapter = createWebStorageAdapter(mockStorage)
+
+      adapter.setItem('test-key', 'test-value')
+
+      expect(mockStorage.setItem).toHaveBeenCalledWith('test-key', 'test-value')
+      expect(mockStorage.getItem('test-key')).toBe('test-value')
+    })
+
+    it('overwrites existing items', () => {
+      const adapter = createWebStorageAdapter(mockStorage)
+
+      adapter.setItem('key', 'value1')
+      adapter.setItem('key', 'value2')
+
+      expect(mockStorage.getItem('key')).toBe('value2')
+    })
+  })
+
+  describe('removeItem', () => {
+    it('removes item from storage', () => {
+      const adapter = createWebStorageAdapter(mockStorage)
+      mockStorage.setItem('to-remove', 'value')
+
+      adapter.removeItem('to-remove')
+
+      expect(mockStorage.removeItem).toHaveBeenCalledWith('to-remove')
+      expect(mockStorage.getItem('to-remove')).toBeNull()
+    })
+
+    it('does not throw for non-existent key', () => {
+      const adapter = createWebStorageAdapter(mockStorage)
+
+      expect(() => adapter.removeItem('nonexistent')).not.toThrow()
+    })
+  })
+
+  describe('synchronous operations', () => {
+    it('all operations are synchronous', () => {
+      const adapter = createWebStorageAdapter(mockStorage)
+
+      // All these should be sync (no promises)
+      const setResult = adapter.setItem('key', 'value')
+      const getResult = adapter.getItem('key')
+      const removeResult = adapter.removeItem('key')
+
+      expect(setResult).toBeUndefined()
+      expect(getResult).toBe('value')
+      expect(removeResult).toBeUndefined()
+    })
+  })
+})

--- a/packages/core/src/storage/manager.test.ts
+++ b/packages/core/src/storage/manager.test.ts
@@ -1,0 +1,481 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ZeroDevWalletSession } from '../types/session.js'
+import { createStorageManager, type StorageAdapter } from './manager.js'
+
+// Create a mock in-memory storage adapter
+function createMockAdapter(): StorageAdapter & { store: Map<string, string> } {
+  const store = new Map<string, string>()
+  return {
+    store,
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value)
+    }),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key)
+    }),
+  }
+}
+
+// Helper to create a valid session
+function createSession(
+  overrides: Partial<ZeroDevWalletSession> = {},
+): ZeroDevWalletSession {
+  return {
+    id: `session-${Math.random().toString(36).slice(2)}`,
+    userId: 'user-123',
+    organizationId: 'org-456',
+    stamperType: 'iframe',
+    expiry: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now (in seconds)
+    createdAt: Date.now(),
+    ...overrides,
+  }
+}
+
+describe('createStorageManager', () => {
+  let adapter: ReturnType<typeof createMockAdapter>
+
+  beforeEach(() => {
+    adapter = createMockAdapter()
+  })
+
+  describe('storeSession', () => {
+    it('stores session data under the given key', async () => {
+      const manager = createStorageManager(adapter)
+      const session = createSession({ id: 'test-session' })
+      const sessionKey = 'session:test@example.com'
+
+      await manager.storeSession(session, sessionKey)
+
+      expect(adapter.setItem).toHaveBeenCalledWith(
+        sessionKey,
+        JSON.stringify(session),
+      )
+    })
+
+    it('adds session key to the sessions list', async () => {
+      const manager = createStorageManager(adapter)
+      const session = createSession()
+      const sessionKey = 'session:user1'
+
+      await manager.storeSession(session, sessionKey)
+
+      const sessionsList = JSON.parse(
+        adapter.store.get('@zerodev/sessions') || '[]',
+      )
+      expect(sessionsList).toContain(sessionKey)
+    })
+
+    it('does not duplicate session key in list', async () => {
+      const manager = createStorageManager(adapter)
+      const session1 = createSession({ id: 'session-1' })
+      const session2 = createSession({ id: 'session-2' })
+      const sessionKey = 'session:user1'
+
+      await manager.storeSession(session1, sessionKey)
+      await manager.storeSession(session2, sessionKey) // Same key, different session
+
+      const sessionsList = JSON.parse(
+        adapter.store.get('@zerodev/sessions') || '[]',
+      )
+      expect(sessionsList.filter((k: string) => k === sessionKey).length).toBe(
+        1,
+      )
+    })
+
+    it('sets the session as active', async () => {
+      const manager = createStorageManager(adapter)
+      const session = createSession()
+      const sessionKey = 'session:active-user'
+
+      await manager.storeSession(session, sessionKey)
+
+      expect(adapter.store.get('@zerodev/active_session')).toBe(sessionKey)
+    })
+  })
+
+  describe('getActiveSession', () => {
+    it('returns the active session', async () => {
+      const manager = createStorageManager(adapter)
+      const session = createSession({ id: 'active-session' })
+      const sessionKey = 'session:active'
+
+      await manager.storeSession(session, sessionKey)
+      const result = await manager.getActiveSession()
+
+      expect(result).toEqual(session)
+    })
+
+    it('returns undefined when no active session', async () => {
+      const manager = createStorageManager(adapter)
+
+      const result = await manager.getActiveSession()
+
+      expect(result).toBeUndefined()
+    })
+
+    it('returns undefined when active session key points to nothing', async () => {
+      const manager = createStorageManager(adapter)
+      adapter.store.set('@zerodev/active_session', 'nonexistent-key')
+
+      const result = await manager.getActiveSession()
+
+      expect(result).toBeUndefined()
+    })
+
+    it('returns undefined when active session is expired', async () => {
+      const manager = createStorageManager(adapter)
+      const expiredSession = createSession({
+        expiry: Math.floor(Date.now() / 1000) - 3600,
+      })
+      const sessionKey = 'session:expired-active'
+
+      adapter.store.set(sessionKey, JSON.stringify(expiredSession))
+      adapter.store.set('@zerodev/sessions', JSON.stringify([sessionKey]))
+      adapter.store.set('@zerodev/active_session', sessionKey)
+
+      const result = await manager.getActiveSession()
+
+      expect(result).toBeUndefined()
+      // The expired session data should be cleaned up
+      expect(adapter.store.has(sessionKey)).toBe(false)
+    })
+  })
+
+  describe('getActiveSessionKey', () => {
+    it('returns the active session key', async () => {
+      const manager = createStorageManager(adapter)
+      const session = createSession()
+      const sessionKey = 'session:user1'
+
+      await manager.storeSession(session, sessionKey)
+      const result = await manager.getActiveSessionKey()
+
+      expect(result).toBe(sessionKey)
+    })
+
+    it('returns undefined when no active session', async () => {
+      const manager = createStorageManager(adapter)
+
+      const result = await manager.getActiveSessionKey()
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('getSession', () => {
+    it('returns session by key', async () => {
+      const manager = createStorageManager(adapter)
+      const session = createSession({ id: 'specific-session' })
+      const sessionKey = 'session:specific'
+
+      await manager.storeSession(session, sessionKey)
+      const result = await manager.getSession(sessionKey)
+
+      expect(result).toEqual(session)
+    })
+
+    it('returns undefined for non-existent session', async () => {
+      const manager = createStorageManager(adapter)
+
+      const result = await manager.getSession('nonexistent')
+
+      expect(result).toBeUndefined()
+    })
+
+    it('clears and returns undefined for expired session', async () => {
+      const manager = createStorageManager(adapter)
+      const expiredSession = createSession({
+        expiry: Math.floor(Date.now() / 1000) - 3600, // 1 hour ago (in seconds)
+      })
+      const sessionKey = 'session:expired'
+
+      // Store directly to bypass any validation
+      adapter.store.set(sessionKey, JSON.stringify(expiredSession))
+      adapter.store.set('@zerodev/sessions', JSON.stringify([sessionKey]))
+
+      const result = await manager.getSession(sessionKey)
+
+      expect(result).toBeUndefined()
+      expect(adapter.store.has(sessionKey)).toBe(false)
+    })
+
+    it('returns session when expiry is 0 (falsy but not expired)', async () => {
+      const manager = createStorageManager(adapter)
+      const sessionWithZeroExpiry = createSession({ expiry: 0 })
+      const sessionKey = 'session:zero-expiry'
+
+      adapter.store.set(sessionKey, JSON.stringify(sessionWithZeroExpiry))
+      adapter.store.set('@zerodev/sessions', JSON.stringify([sessionKey]))
+
+      const result = await manager.getSession(sessionKey)
+
+      // expiry: 0 is falsy, so the expiry check is skipped and session is returned
+      expect(result).toEqual(sessionWithZeroExpiry)
+    })
+
+    it('clears and returns undefined for malformed JSON', async () => {
+      const manager = createStorageManager(adapter)
+      const sessionKey = 'session:malformed'
+
+      adapter.store.set(sessionKey, 'not-valid-json')
+      adapter.store.set('@zerodev/sessions', JSON.stringify([sessionKey]))
+
+      const result = await manager.getSession(sessionKey)
+
+      expect(result).toBeUndefined()
+      expect(adapter.store.has(sessionKey)).toBe(false)
+    })
+  })
+
+  describe('listSessionKeys', () => {
+    it('returns all stored session keys', async () => {
+      const manager = createStorageManager(adapter)
+      const session1 = createSession()
+      const session2 = createSession()
+
+      await manager.storeSession(session1, 'session:user1')
+      await manager.storeSession(session2, 'session:user2')
+
+      const keys = await manager.listSessionKeys()
+
+      expect(keys).toContain('session:user1')
+      expect(keys).toContain('session:user2')
+      expect(keys.length).toBe(2)
+    })
+
+    it('returns empty array when no sessions', async () => {
+      const manager = createStorageManager(adapter)
+
+      const keys = await manager.listSessionKeys()
+
+      expect(keys).toEqual([])
+    })
+
+    it('removes keys that have no corresponding session data', async () => {
+      const manager = createStorageManager(adapter)
+      const session = createSession()
+
+      await manager.storeSession(session, 'session:valid')
+      // Manually add a key without session data
+      const existingKeys = JSON.parse(
+        adapter.store.get('@zerodev/sessions') || '[]',
+      )
+      existingKeys.push('session:orphan')
+      adapter.store.set('@zerodev/sessions', JSON.stringify(existingKeys))
+
+      const keys = await manager.listSessionKeys()
+
+      expect(keys).toContain('session:valid')
+      expect(keys).not.toContain('session:orphan')
+    })
+  })
+
+  describe('listSessions', () => {
+    it('returns all valid sessions', async () => {
+      const manager = createStorageManager(adapter)
+      const session1 = createSession({ id: 'session-1' })
+      const session2 = createSession({ id: 'session-2' })
+
+      await manager.storeSession(session1, 'session:user1')
+      await manager.storeSession(session2, 'session:user2')
+
+      const sessions = await manager.listSessions()
+
+      expect(sessions.length).toBe(2)
+      expect(sessions.map((s) => s.id)).toContain('session-1')
+      expect(sessions.map((s) => s.id)).toContain('session-2')
+    })
+
+    it('filters out expired sessions', async () => {
+      const manager = createStorageManager(adapter)
+      const validSession = createSession({ id: 'valid' })
+      const expiredSession = createSession({
+        id: 'expired',
+        expiry: Math.floor(Date.now() / 1000) - 3600,
+      })
+
+      await manager.storeSession(validSession, 'session:valid')
+      // Manually store expired session
+      adapter.store.set('session:expired', JSON.stringify(expiredSession))
+      const keys = JSON.parse(adapter.store.get('@zerodev/sessions') || '[]')
+      keys.push('session:expired')
+      adapter.store.set('@zerodev/sessions', JSON.stringify(keys))
+
+      const sessions = await manager.listSessions()
+
+      expect(sessions.length).toBe(1)
+      expect(sessions[0]?.id).toBe('valid')
+    })
+  })
+
+  describe('setActiveSession', () => {
+    it('sets active session to existing session', async () => {
+      const manager = createStorageManager(adapter)
+      const session1 = createSession({ id: 'session-1' })
+      const session2 = createSession({ id: 'session-2' })
+
+      await manager.storeSession(session1, 'session:user1')
+      await manager.storeSession(session2, 'session:user2')
+
+      // session:user2 is active after storing
+      await manager.setActiveSession('session:user1')
+
+      const activeKey = await manager.getActiveSessionKey()
+      expect(activeKey).toBe('session:user1')
+    })
+
+    it('throws when session does not exist', async () => {
+      const manager = createStorageManager(adapter)
+
+      await expect(manager.setActiveSession('nonexistent')).rejects.toThrow(
+        'Session not found: nonexistent',
+      )
+    })
+
+    it('throws when session is expired', async () => {
+      const manager = createStorageManager(adapter)
+      const expiredSession = createSession({
+        expiry: Math.floor(Date.now() / 1000) - 3600,
+      })
+      adapter.store.set('session:expired', JSON.stringify(expiredSession))
+      adapter.store.set(
+        '@zerodev/sessions',
+        JSON.stringify(['session:expired']),
+      )
+
+      await expect(manager.setActiveSession('session:expired')).rejects.toThrow(
+        'Session not found: session:expired',
+      )
+    })
+  })
+
+  describe('clearSession', () => {
+    it('removes session data', async () => {
+      const manager = createStorageManager(adapter)
+      const session = createSession()
+      const sessionKey = 'session:to-clear'
+
+      await manager.storeSession(session, sessionKey)
+      await manager.clearSession(sessionKey)
+
+      expect(adapter.store.has(sessionKey)).toBe(false)
+    })
+
+    it('removes session from keys list', async () => {
+      const manager = createStorageManager(adapter)
+      const session = createSession()
+      const sessionKey = 'session:to-clear'
+
+      await manager.storeSession(session, sessionKey)
+      await manager.clearSession(sessionKey)
+
+      const keys = await manager.listSessionKeys()
+      expect(keys).not.toContain(sessionKey)
+    })
+
+    it('clears active session if it was the cleared one', async () => {
+      const manager = createStorageManager(adapter)
+      const session = createSession()
+      const sessionKey = 'session:active-to-clear'
+
+      await manager.storeSession(session, sessionKey)
+      // Session is automatically set as active
+      await manager.clearSession(sessionKey)
+
+      const activeKey = await manager.getActiveSessionKey()
+      expect(activeKey).toBeUndefined()
+    })
+
+    it('handles clearing a nonexistent session key gracefully', async () => {
+      const manager = createStorageManager(adapter)
+
+      // Should not throw when clearing a key that was never stored
+      await manager.clearSession('session:never-existed')
+
+      const keys = await manager.listSessionKeys()
+      expect(keys).toEqual([])
+    })
+
+    it('does not affect active session if clearing different session', async () => {
+      const manager = createStorageManager(adapter)
+      const session1 = createSession()
+      const session2 = createSession()
+
+      await manager.storeSession(session1, 'session:1')
+      await manager.storeSession(session2, 'session:2') // This becomes active
+      await manager.clearSession('session:1')
+
+      const activeKey = await manager.getActiveSessionKey()
+      expect(activeKey).toBe('session:2')
+    })
+  })
+
+  describe('clearAllSessions', () => {
+    it('removes all session data', async () => {
+      const manager = createStorageManager(adapter)
+      const session1 = createSession()
+      const session2 = createSession()
+
+      await manager.storeSession(session1, 'session:1')
+      await manager.storeSession(session2, 'session:2')
+      await manager.clearAllSessions()
+
+      expect(adapter.store.has('session:1')).toBe(false)
+      expect(adapter.store.has('session:2')).toBe(false)
+    })
+
+    it('clears sessions list', async () => {
+      const manager = createStorageManager(adapter)
+      const session = createSession()
+
+      await manager.storeSession(session, 'session:1')
+      await manager.clearAllSessions()
+
+      expect(adapter.store.has('@zerodev/sessions')).toBe(false)
+    })
+
+    it('clears active session', async () => {
+      const manager = createStorageManager(adapter)
+      const session = createSession()
+
+      await manager.storeSession(session, 'session:1')
+      await manager.clearAllSessions()
+
+      expect(adapter.store.has('@zerodev/active_session')).toBe(false)
+    })
+
+    it('handles empty state gracefully', async () => {
+      const manager = createStorageManager(adapter)
+
+      await expect(manager.clearAllSessions()).resolves.toBeUndefined()
+    })
+  })
+
+  describe('async adapter support', () => {
+    it('works with async adapter methods', async () => {
+      const asyncAdapter: StorageAdapter = {
+        getItem: vi.fn(async (key: string) => {
+          await new Promise((r) => setTimeout(r, 1))
+          return adapter.store.get(key) ?? null
+        }),
+        setItem: vi.fn(async (key: string, value: string) => {
+          await new Promise((r) => setTimeout(r, 1))
+          adapter.store.set(key, value)
+        }),
+        removeItem: vi.fn(async (key: string) => {
+          await new Promise((r) => setTimeout(r, 1))
+          adapter.store.delete(key)
+        }),
+      }
+
+      const manager = createStorageManager(asyncAdapter)
+      const session = createSession()
+
+      await manager.storeSession(session, 'session:async')
+      const result = await manager.getSession('session:async')
+
+      expect(result).toEqual(session)
+    })
+  })
+})

--- a/packages/core/src/utils/buildClientSignature.test.ts
+++ b/packages/core/src/utils/buildClientSignature.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { IndexedDbStamper } from '../stampers/types.js'
+import { buildClientSignature } from './buildClientSignature.js'
+
+// Helper to create base64url encoded string
+function base64UrlEncode(str: string): string {
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+}
+
+// Helper to create a JWT with specific payload
+function createTestJwt(payload: Record<string, unknown>): string {
+  const header = base64UrlEncode(JSON.stringify({ alg: 'ES256', typ: 'JWT' }))
+  const payloadEncoded = base64UrlEncode(JSON.stringify(payload))
+  const signature = base64UrlEncode('test-signature')
+  return `${header}.${payloadEncoded}.${signature}`
+}
+
+// Create a valid DER signature hex
+// Format: 30 44 02 20 [r 32 bytes] 02 20 [s 32 bytes]
+function createValidDerSignature(): string {
+  const r = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2'
+  const s = '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+  return `30440220${r}0220${s}`
+}
+
+// Create a mock stamper
+function createMockStamper(
+  signatureHex: string = createValidDerSignature(),
+): IndexedDbStamper {
+  return {
+    stamp: vi.fn().mockResolvedValue({
+      stampHeaderName: 'X-Stamp',
+      stampHeaderValue: base64UrlEncode(
+        JSON.stringify({ signature: signatureHex }),
+      ),
+    }),
+    getPublicKey: vi.fn().mockResolvedValue('mock-public-key'),
+    clear: vi.fn().mockResolvedValue(undefined),
+    resetKeyPair: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+describe('buildClientSignature', () => {
+  describe('successful signature building', () => {
+    it('extracts tokenId from JWT and signs the payload, returning raw signature', async () => {
+      const tokenId = 'test-token-id-123'
+      const publicKey =
+        '02abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab'
+      const verificationToken = createTestJwt({
+        id: tokenId,
+        exp: Date.now() + 3600000,
+      })
+      const r =
+        'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2'
+      const s =
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+      const stamper = createMockStamper(`30440220${r}0220${s}`)
+
+      const result = await buildClientSignature({
+        verificationToken,
+        publicKey,
+        stamper,
+      })
+
+      // Verify the stamper was called with correct message
+      expect(stamper.stamp).toHaveBeenCalledOnce()
+      const stampedMessage = JSON.parse(
+        (stamper.stamp as ReturnType<typeof vi.fn>).mock.calls[0][0],
+      )
+      expect(stampedMessage).toEqual({
+        login: { publicKey },
+        tokenId,
+        type: 'USAGE_TYPE_LOGIN',
+      })
+      // Verify the return value is the raw r||s signature
+      expect(result).toBe(r + s)
+      expect(result.length).toBe(128)
+    })
+
+    it('returns raw signature from DER format', async () => {
+      const tokenId = 'test-token-id'
+      const publicKey = `03${'ab'.repeat(32)}`
+      const verificationToken = createTestJwt({ id: tokenId })
+
+      // Create a valid DER signature that will be returned by the stamper
+      // Format: 30 44 02 20 [r] 02 20 [s]
+      const r =
+        'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2'
+      const s =
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+      const derSignature = `30440220${r}0220${s}`
+      const stamper = createMockStamper(derSignature)
+
+      const result = await buildClientSignature({
+        verificationToken,
+        publicKey,
+        stamper,
+      })
+
+      expect(result).toBe(r + s)
+      expect(result.length).toBe(128) // 64 bytes = 128 hex chars
+    })
+  })
+
+  describe('error handling', () => {
+    it('throws on invalid JWT format (not 3 parts)', async () => {
+      const invalidJwt = 'header.payload' // missing signature part
+      const stamper = createMockStamper()
+
+      await expect(
+        buildClientSignature({
+          verificationToken: invalidJwt,
+          publicKey: `03${'ab'.repeat(32)}`,
+          stamper,
+        }),
+      ).rejects.toThrow('Invalid JWT format')
+    })
+
+    it('throws on JWT missing id field', async () => {
+      const jwtWithoutId = createTestJwt({
+        exp: Date.now() + 3600000,
+        sub: 'user123',
+      })
+      const stamper = createMockStamper()
+
+      await expect(
+        buildClientSignature({
+          verificationToken: jwtWithoutId,
+          publicKey: `03${'ab'.repeat(32)}`,
+          stamper,
+        }),
+      ).rejects.toThrow('JWT payload missing id field')
+    })
+
+    it('throws on JWT with empty string id (falsy value)', async () => {
+      const jwtWithEmptyId = createTestJwt({ id: '' })
+      const stamper = createMockStamper()
+
+      await expect(
+        buildClientSignature({
+          verificationToken: jwtWithEmptyId,
+          publicKey: `03${'ab'.repeat(32)}`,
+          stamper,
+        }),
+      ).rejects.toThrow('JWT payload missing id field')
+    })
+
+    it('throws on JWT with id: 0 (falsy value)', async () => {
+      const jwtWithZeroId = createTestJwt({ id: 0 })
+      const stamper = createMockStamper()
+
+      await expect(
+        buildClientSignature({
+          verificationToken: jwtWithZeroId,
+          publicKey: `03${'ab'.repeat(32)}`,
+          stamper,
+        }),
+      ).rejects.toThrow('JWT payload missing id field')
+    })
+
+    it('throws when stamper fails', async () => {
+      const verificationToken = createTestJwt({ id: 'token-123' })
+      const stamper = createMockStamper()
+      vi.mocked(stamper.stamp).mockRejectedValue(new Error('Stamper error'))
+
+      await expect(
+        buildClientSignature({
+          verificationToken,
+          publicKey: `03${'ab'.repeat(32)}`,
+          stamper,
+        }),
+      ).rejects.toThrow('Stamper error')
+    })
+  })
+
+  describe('base64url decoding', () => {
+    it('handles JWT with padding-needed base64url', async () => {
+      // Create a JWT where payload needs padding when decoded
+      const tokenId = 'a' // Short id creates payload that needs padding
+      const verificationToken = createTestJwt({ id: tokenId })
+      const stamper = createMockStamper()
+
+      await buildClientSignature({
+        verificationToken,
+        publicKey: `03${'ab'.repeat(32)}`,
+        stamper,
+      })
+
+      const stampedMessage = JSON.parse(
+        (stamper.stamp as ReturnType<typeof vi.fn>).mock.calls[0][0],
+      )
+      expect(stampedMessage.tokenId).toBe(tokenId)
+    })
+
+    it('handles JWT with special base64url characters', async () => {
+      // Token ID with characters that would be + or / in base64
+      const tokenId = 'test+token/id==' // Will be encoded differently
+      const verificationToken = createTestJwt({ id: tokenId })
+      const stamper = createMockStamper()
+
+      await buildClientSignature({
+        verificationToken,
+        publicKey: `03${'ab'.repeat(32)}`,
+        stamper,
+      })
+
+      const stampedMessage = JSON.parse(
+        (stamper.stamp as ReturnType<typeof vi.fn>).mock.calls[0][0],
+      )
+      expect(stampedMessage.tokenId).toBe(tokenId)
+    })
+  })
+})

--- a/packages/core/src/utils/derToRawSignature.test.ts
+++ b/packages/core/src/utils/derToRawSignature.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest'
+import { derToRawSignature } from './derToRawSignature.js'
+
+describe('derToRawSignature', () => {
+  describe('valid conversions', () => {
+    it('converts a standard 70-byte DER signature to 64-byte raw', () => {
+      // Standard DER signature with 32-byte r and 32-byte s (no padding needed)
+      // 30 44 - SEQUENCE of 68 bytes
+      // 02 20 - INTEGER of 32 bytes (r)
+      // [32 bytes of r]
+      // 02 20 - INTEGER of 32 bytes (s)
+      // [32 bytes of s]
+      const r =
+        'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2'
+      const s =
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+      // 30 44 02 20 [r] 02 20 [s]
+      const derHex = `30440220${r}0220${s}`
+
+      const result = derToRawSignature(derHex)
+
+      expect(result).toBe(r + s)
+      expect(result.length).toBe(128) // 64 bytes = 128 hex chars
+    })
+
+    it('converts DER signature with leading zero in r', () => {
+      // When r has high bit set, DER prepends 0x00 to keep it positive
+      // r starts with 0x00 (33 bytes total in DER), s is 32 bytes
+      const rWithHighBit =
+        'f1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2' // starts with f
+      const s =
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+      // DER format: 30 45 02 21 00[r with high bit] 02 20 [s]
+      const derHex = `3045022100${rWithHighBit}0220${s}`
+
+      const result = derToRawSignature(derHex)
+
+      expect(result).toBe(rWithHighBit + s)
+    })
+
+    it('converts DER signature with leading zero in s', () => {
+      // s has high bit set, so DER prepends 0x00
+      const r =
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+      const sWithHighBit =
+        'f1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2'
+      // DER format: 30 45 02 20 [r] 02 21 00[s with high bit]
+      const derHex = `30450220${r}022100${sWithHighBit}`
+
+      const result = derToRawSignature(derHex)
+
+      expect(result).toBe(r + sWithHighBit)
+    })
+
+    it('converts DER signature with leading zeros in both r and s', () => {
+      // Both r and s have high bit set
+      const rWithHighBit =
+        'f1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2'
+      const sWithHighBit =
+        'e1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b3'
+      // DER format: 30 46 02 21 00[r] 02 21 00[s]
+      const derHex = `3046022100${rWithHighBit}022100${sWithHighBit}`
+
+      const result = derToRawSignature(derHex)
+
+      expect(result).toBe(rWithHighBit + sWithHighBit)
+    })
+
+    it('handles DER signature with short r value (needs left-padding)', () => {
+      // r is only 31 bytes (needs padding to 32)
+      const shortR =
+        'b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2' // 31 bytes = 62 hex chars
+      const s =
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+      // DER format: 30 43 02 1f [31-byte r] 02 20 [s]
+      const derHex = `3043021f${shortR}0220${s}`
+
+      const result = derToRawSignature(derHex)
+
+      // r should be left-padded with 00 to make 32 bytes
+      expect(result).toBe(`00${shortR}${s}`)
+    })
+
+    it('handles 0x prefix in input', () => {
+      const r =
+        'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2'
+      const s =
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+      const derHex = `0x30440220${r}0220${s}`
+
+      const result = derToRawSignature(derHex)
+
+      expect(result).toBe(r + s)
+    })
+    it('handles DER signature with short s value (needs left-padding)', () => {
+      const r =
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+      const shortS =
+        'b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2' // 31 bytes = 62 hex chars
+      // DER format: 30 43 02 20 [32-byte r] 02 1f [31-byte s]
+      const derHex = `30430220${r}021f${shortS}`
+
+      const result = derToRawSignature(derHex)
+
+      // s should be left-padded with 00 to make 32 bytes
+      expect(result).toBe(`${r}00${shortS}`)
+    })
+
+    it('handles DER values with multiple leading zeros', () => {
+      // r has two leading zero bytes that need stripping, then needs padding back to 32
+      const rCore =
+        'b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3' // 30 bytes
+      const s =
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+      // DER format: r has 2 leading zeros (32 bytes in DER = 0x00 0x00 + 30 bytes core)
+      const derHex = `30440220${'0000'}${rCore}0220${s}`
+
+      const result = derToRawSignature(derHex)
+
+      // After stripping leading zeros from r (30 bytes left), must pad back to 32
+      expect(result).toBe(`0000${rCore}${s}`)
+      expect(result.length).toBe(128)
+    })
+
+    it('handles padTo32Bytes truncation for oversized values', () => {
+      // Construct a DER signature where r is 33 bytes (without leading zero)
+      // This is unlikely in real P-256 but tests the defensive truncation path
+      const rOversize =
+        'ff' +
+        'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2' // 33 bytes
+      const s =
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+      // DER: 30 45 02 21 [33 bytes r] 02 20 [32 bytes s]
+      const derHex = `30450221${rOversize}0220${s}`
+
+      const result = derToRawSignature(derHex)
+
+      // After stripLeadingZeros (ff is not zero, all 33 bytes kept), padTo32Bytes truncates from end
+      expect(result.length).toBe(128)
+    })
+  })
+
+  describe('error handling', () => {
+    it('throws on missing SEQUENCE tag', () => {
+      // First byte should be 0x30 (SEQUENCE)
+      const invalidDer = `0144022020${'00'.repeat(32)}022020${'00'.repeat(32)}`
+
+      expect(() => derToRawSignature(invalidDer)).toThrow(
+        'Invalid DER signature: expected SEQUENCE tag (0x30)',
+      )
+    })
+
+    it('throws on missing INTEGER tag for r', () => {
+      // After SEQUENCE, should have 0x02 (INTEGER) for r
+      const invalidDer = `3044032020${'00'.repeat(32)}022020${'00'.repeat(32)}`
+
+      expect(() => derToRawSignature(invalidDer)).toThrow(
+        'Invalid DER signature: expected INTEGER tag (0x02) for r',
+      )
+    })
+
+    it('throws on missing INTEGER tag for s', () => {
+      // Second value should also have 0x02 (INTEGER) tag
+      const r =
+        'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2'
+      const invalidDer = `3044022020${r}032020${'00'.repeat(32)}`
+
+      expect(() => derToRawSignature(invalidDer)).toThrow(
+        'Invalid DER signature: expected INTEGER tag (0x02) for s',
+      )
+    })
+  })
+
+  describe('real-world test vectors', () => {
+    it('converts a known secp256r1 (P-256) DER signature with leading zero in r', () => {
+      // Real test vector from ECDSA P-256
+      // r starts with high bit set (e5), so DER prepends 00
+      // 30 45 = SEQUENCE of 69 bytes
+      // 02 21 00 [32-byte r with leading 00] = INTEGER of 33 bytes
+      // 02 20 [32-byte s] = INTEGER of 32 bytes
+      const rValue =
+        'e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5'
+      const sValue =
+        'a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1'
+      const derHex = `3045022100${rValue}0220${sValue}`
+
+      const result = derToRawSignature(derHex)
+
+      // The leading 00 should be stripped from r
+      expect(result).toBe(rValue + sValue)
+    })
+
+    it('converts a standard 70-byte P-256 signature', () => {
+      // Both r and s have low high bits (no leading zeros in DER)
+      const rValue =
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+      const sValue =
+        'fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321'
+      // 30 44 02 20 [r] 02 20 [s]
+      const derHex = `30440220${rValue}0220${sValue}`
+
+      const result = derToRawSignature(derHex)
+
+      expect(result).toBe(rValue + sValue)
+    })
+  })
+})

--- a/packages/core/src/utils/utils.test.ts
+++ b/packages/core/src/utils/utils.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  base64UrlEncode,
+  generateCompressedPublicKeyFromKeyPair,
+  generateRandomBuffer,
+  humanReadableDateTime,
+  normalizeTimestamp,
+  parseSession,
+  pointEncode,
+  uint8ArrayToHexString,
+} from './utils.js'
+
+// Helper to create base64-encoded JWT payload
+function createJwtPayload(payload: Record<string, unknown>): string {
+  const payloadEncoded = Buffer.from(JSON.stringify(payload)).toString('base64')
+  return `header.${payloadEncoded}.signature`
+}
+
+describe('parseSession', () => {
+  it('parses a valid JWT into session object', () => {
+    const payload = {
+      exp: 1700000000,
+      public_key: 'test-public-key',
+      session_type: 'SESSION_TYPE_READ_WRITE',
+      user_id: 'user-123',
+      organization_id: 'org-456',
+    }
+    const jwt = createJwtPayload(payload)
+
+    const result = parseSession(jwt)
+
+    expect(result).toEqual({
+      sessionType: 'SESSION_TYPE_READ_WRITE',
+      userId: 'user-123',
+      organizationId: 'org-456',
+      expiry: 1700000000,
+      token: 'test-public-key',
+    })
+  })
+
+  it('returns session object as-is if not a string', () => {
+    const session = {
+      id: 'session-id',
+      userId: 'user-123',
+      organizationId: 'org-456',
+      stamperType: 'iframe' as const,
+      expiry: 1700000000,
+      createdAt: 1699900000,
+    }
+
+    const result = parseSession(session)
+
+    expect(result).toBe(session)
+  })
+
+  it('throws on invalid JWT missing payload', () => {
+    const invalidJwt = 'header'
+
+    expect(() => parseSession(invalidJwt)).toThrow(
+      'Invalid JWT: Missing payload',
+    )
+  })
+
+  it('throws on JWT missing required fields', () => {
+    const payload = {
+      exp: 1700000000,
+      // missing public_key, session_type, user_id, organization_id
+    }
+    const jwt = createJwtPayload(payload)
+
+    expect(() => parseSession(jwt)).toThrow(
+      'JWT payload missing required fields',
+    )
+  })
+
+  it('throws on malformed base64 payload (non-JSON)', () => {
+    // base64 of "not-json" = "bm90LWpzb24="
+    const jwt = 'header.bm90LWpzb24.signature'
+
+    expect(() => parseSession(jwt)).toThrow()
+  })
+
+  it('throws when only some required fields are present', () => {
+    const payload = {
+      exp: 1700000000,
+      public_key: 'key',
+      // missing session_type, user_id, organization_id
+    }
+    const jwt = createJwtPayload(payload)
+
+    expect(() => parseSession(jwt)).toThrow(
+      'JWT payload missing required fields',
+    )
+  })
+
+  it('throws when exp is missing', () => {
+    const payload = {
+      public_key: 'key',
+      session_type: 'SESSION_TYPE_READ_WRITE',
+      user_id: 'user',
+      organization_id: 'org',
+      // missing exp
+    }
+    const jwt = createJwtPayload(payload)
+
+    expect(() => parseSession(jwt)).toThrow(
+      'JWT payload missing required fields',
+    )
+  })
+})
+
+describe('normalizeTimestamp', () => {
+  it('converts seconds to milliseconds when value is small', () => {
+    const secondsTimestamp = 1700000000 // Less than 1e10
+
+    const result = normalizeTimestamp(secondsTimestamp)
+
+    expect(result).toBe(1700000000000) // Converted to ms
+  })
+
+  it('keeps milliseconds timestamp unchanged', () => {
+    const msTimestamp = 1700000000000 // Greater than 1e10
+
+    const result = normalizeTimestamp(msTimestamp)
+
+    expect(result).toBe(1700000000000)
+  })
+
+  it('handles boundary value (exactly 1e10)', () => {
+    const boundaryValue = 10000000000 // Exactly 1e10 (year ~2286 in seconds)
+
+    const result = normalizeTimestamp(boundaryValue)
+
+    // 1e10 is NOT less than 1e10, so it's treated as milliseconds
+    expect(result).toBe(10000000000)
+  })
+
+  it('handles zero', () => {
+    const result = normalizeTimestamp(0)
+
+    expect(result).toBe(0)
+  })
+
+  it('treats negative values as seconds (multiplied by 1000)', () => {
+    const result = normalizeTimestamp(-1)
+
+    // -1 < 1e10, so it's multiplied by 1000
+    expect(result).toBe(-1000)
+  })
+})
+
+describe('generateRandomBuffer', () => {
+  it('returns an ArrayBuffer of 32 bytes', () => {
+    const buffer = generateRandomBuffer()
+
+    expect(buffer).toBeInstanceOf(ArrayBuffer)
+    expect(buffer.byteLength).toBe(32)
+  })
+
+  it('returns different values on each call', () => {
+    const buffer1 = generateRandomBuffer()
+    const buffer2 = generateRandomBuffer()
+
+    const arr1 = new Uint8Array(buffer1)
+    const arr2 = new Uint8Array(buffer2)
+
+    // Very unlikely to be equal (2^256 possibilities)
+    expect(arr1).not.toEqual(arr2)
+  })
+})
+
+describe('base64UrlEncode', () => {
+  it('encodes ArrayBuffer to base64url string', () => {
+    const data = new Uint8Array([72, 101, 108, 108, 111]) // "Hello"
+    const buffer = data.buffer
+
+    const result = base64UrlEncode(buffer)
+
+    expect(result).toBe('SGVsbG8')
+    // Standard base64 would be "SGVsbG8="
+    // base64url removes padding
+  })
+
+  it('replaces + with - and / with _', () => {
+    // Create data that would have + and / in standard base64
+    // 0xfb, 0xef, 0xbe -> base64 "++--" would have special chars
+    const data = new Uint8Array([251, 239, 190])
+    const buffer = data.buffer
+
+    const result = base64UrlEncode(buffer)
+
+    expect(result).not.toContain('+')
+    expect(result).not.toContain('/')
+    expect(result).not.toContain('=')
+  })
+
+  it('handles empty buffer', () => {
+    const buffer = new ArrayBuffer(0)
+
+    const result = base64UrlEncode(buffer)
+
+    expect(result).toBe('')
+  })
+})
+
+describe('pointEncode', () => {
+  it('compresses uncompressed P-256 public key with even y', () => {
+    // Create a valid uncompressed key (0x04 prefix + 32-byte x + 32-byte y)
+    const raw = new Uint8Array(65)
+    raw[0] = 0x04 // Uncompressed prefix
+    // x coordinate (32 bytes)
+    for (let i = 1; i <= 32; i++) {
+      raw[i] = i
+    }
+    // y coordinate (32 bytes) - last byte is even
+    for (let i = 33; i <= 64; i++) {
+      raw[i] = i - 32
+    }
+    raw[64] = 0x02 // Even y coordinate
+
+    const result = pointEncode(raw)
+
+    expect(result.length).toBe(33)
+    expect(result[0]).toBe(0x02) // Even y -> 0x02 prefix
+    // Rest should be x coordinate
+    expect(result.slice(1)).toEqual(raw.slice(1, 33))
+  })
+
+  it('compresses uncompressed P-256 public key with odd y', () => {
+    const raw = new Uint8Array(65)
+    raw[0] = 0x04
+    for (let i = 1; i <= 32; i++) {
+      raw[i] = i
+    }
+    for (let i = 33; i <= 64; i++) {
+      raw[i] = i - 32
+    }
+    raw[64] = 0x03 // Odd y coordinate (last bit is 1)
+
+    const result = pointEncode(raw)
+
+    expect(result.length).toBe(33)
+    expect(result[0]).toBe(0x03) // Odd y -> 0x03 prefix
+  })
+
+  it('throws on wrong length', () => {
+    const raw = new Uint8Array(64) // Should be 65
+    raw[0] = 0x04
+
+    expect(() => pointEncode(raw)).toThrow('Invalid uncompressed P-256 key')
+  })
+
+  it('throws on wrong prefix', () => {
+    const raw = new Uint8Array(65)
+    raw[0] = 0x02 // Should be 0x04
+
+    expect(() => pointEncode(raw)).toThrow('Invalid uncompressed P-256 key')
+  })
+})
+
+describe('uint8ArrayToHexString', () => {
+  it('converts bytes to lowercase hex string', () => {
+    const input = new Uint8Array([0x00, 0x01, 0xff, 0xab, 0xcd])
+
+    const result = uint8ArrayToHexString(input)
+
+    expect(result).toBe('0001ffabcd')
+  })
+
+  it('handles empty array', () => {
+    const input = new Uint8Array([])
+
+    const result = uint8ArrayToHexString(input)
+
+    expect(result).toBe('')
+  })
+
+  it('pads single-digit hex values with zero', () => {
+    const input = new Uint8Array([0x0f, 0x00, 0x01])
+
+    const result = uint8ArrayToHexString(input)
+
+    expect(result).toBe('0f0001')
+  })
+})
+
+describe('generateCompressedPublicKeyFromKeyPair', () => {
+  // Helper to create a mock 65-byte uncompressed P-256 public key
+  function createUncompressedKey(lastYByte: number): ArrayBuffer {
+    const raw = new Uint8Array(65)
+    raw[0] = 0x04
+    for (let i = 1; i <= 32; i++) {
+      raw[i] = i
+    }
+    for (let i = 33; i <= 64; i++) {
+      raw[i] = i - 32
+    }
+    raw[64] = lastYByte
+    return raw.buffer
+  }
+
+  it('returns compressed hex string from key pair with even y', async () => {
+    const mockKeyPair = {
+      publicKey: {} as CryptoKey,
+      privateKey: {} as CryptoKey,
+    }
+    const rawBuffer = createUncompressedKey(0x02) // even y
+
+    vi.spyOn(crypto.subtle, 'exportKey').mockResolvedValueOnce(rawBuffer)
+
+    const result = await generateCompressedPublicKeyFromKeyPair(mockKeyPair)
+
+    expect(crypto.subtle.exportKey).toHaveBeenCalledWith(
+      'raw',
+      mockKeyPair.publicKey,
+    )
+    // 33 bytes = 66 hex chars
+    expect(result.length).toBe(66)
+    // Even y -> 02 prefix
+    expect(result.startsWith('02')).toBe(true)
+  })
+
+  it('returns compressed hex string from key pair with odd y', async () => {
+    const mockKeyPair = {
+      publicKey: {} as CryptoKey,
+      privateKey: {} as CryptoKey,
+    }
+    const rawBuffer = createUncompressedKey(0x03) // odd y
+
+    vi.spyOn(crypto.subtle, 'exportKey').mockResolvedValueOnce(rawBuffer)
+
+    const result = await generateCompressedPublicKeyFromKeyPair(mockKeyPair)
+
+    expect(result.length).toBe(66)
+    // Odd y -> 03 prefix
+    expect(result.startsWith('03')).toBe(true)
+  })
+
+  it('produces consistent output for same key', async () => {
+    const mockKeyPair = {
+      publicKey: {} as CryptoKey,
+      privateKey: {} as CryptoKey,
+    }
+    const rawBuffer = createUncompressedKey(0x02)
+
+    vi.spyOn(crypto.subtle, 'exportKey')
+      .mockResolvedValueOnce(rawBuffer)
+      .mockResolvedValueOnce(createUncompressedKey(0x02))
+
+    const result1 = await generateCompressedPublicKeyFromKeyPair(mockKeyPair)
+    const result2 = await generateCompressedPublicKeyFromKeyPair(mockKeyPair)
+
+    expect(result1).toBe(result2)
+  })
+
+  it('propagates crypto.subtle.exportKey errors', async () => {
+    const mockKeyPair = {
+      publicKey: {} as CryptoKey,
+      privateKey: {} as CryptoKey,
+    }
+
+    vi.spyOn(crypto.subtle, 'exportKey').mockRejectedValueOnce(
+      new Error('Key not extractable'),
+    )
+
+    await expect(
+      generateCompressedPublicKeyFromKeyPair(mockKeyPair),
+    ).rejects.toThrow('Key not extractable')
+  })
+})
+
+describe('humanReadableDateTime', () => {
+  it('returns a formatted date time string', () => {
+    // Mock Date to get consistent output
+    const mockDate = new Date('2024-01-15T10:30:45')
+    vi.setSystemTime(mockDate)
+
+    const result = humanReadableDateTime()
+
+    // The format depends on locale, but we can check it doesn't contain / or :
+    expect(result).not.toContain('/')
+    expect(result).not.toContain(':')
+
+    vi.useRealTimers()
+  })
+
+  it('replaces / with - and : with .', () => {
+    const mockDate = new Date('2024-12-25T23:59:59')
+    vi.setSystemTime(mockDate)
+
+    const result = humanReadableDateTime()
+
+    expect(result).not.toContain('/')
+    expect(result).not.toContain(':')
+
+    vi.useRealTimers()
+  })
+})

--- a/packages/react/src/actions.test.ts
+++ b/packages/react/src/actions.test.ts
@@ -1,0 +1,895 @@
+import type { Config, Connector } from '@wagmi/core'
+import { connect as wagmiConnect } from '@wagmi/core/actions'
+import {
+  createIframeStamper,
+  exportPrivateKey as exportPrivateKeySdk,
+  exportWallet as exportWalletSdk,
+} from '@zerodev/wallet-core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  authenticateOAuth,
+  exportPrivateKey,
+  exportWallet,
+  getUserEmail,
+  loginPasskey,
+  refreshSession,
+  registerPasskey,
+  sendOTP,
+  verifyOTP,
+} from './actions.js'
+
+// Mock wagmi connect
+vi.mock('@wagmi/core/actions', () => ({
+  connect: vi.fn().mockResolvedValue({}),
+}))
+
+// Mock OAuth utilities
+vi.mock('./oauth.js', () => ({
+  buildBackendOAuthUrl: vi.fn().mockReturnValue('https://oauth.example.com'),
+  openOAuthPopup: vi.fn(),
+  listenForOAuthMessage: vi.fn(),
+}))
+
+// Mock core SDK
+vi.mock('@zerodev/wallet-core', () => ({
+  createIframeStamper: vi.fn(),
+  exportPrivateKey: vi.fn(),
+  exportWallet: vi.fn(),
+}))
+
+// Create a mock wallet instance
+function createMockWallet() {
+  return {
+    auth: vi.fn().mockResolvedValue({ otpId: 'otp-123' }),
+    getSession: vi
+      .fn()
+      .mockResolvedValue({ id: 'session-123', expiry: 9999999999 }),
+    toAccount: vi.fn().mockResolvedValue({ address: '0x1234abcd' }),
+    getPublicKey: vi.fn().mockResolvedValue('03abcdef123'),
+    refreshSession: vi.fn().mockResolvedValue({ id: 'new-session-456' }),
+    client: {
+      getUserEmail: vi.fn().mockResolvedValue({ email: 'user@example.com' }),
+    },
+  }
+}
+
+// Create a mock store
+function createMockStore(
+  wallet: ReturnType<typeof createMockWallet> | null = createMockWallet(),
+  session: { id: string } | null = null,
+  oauthConfig: { backendUrl: string; projectId: string } | null = {
+    backendUrl: 'https://api.example.com',
+    projectId: 'proj-123',
+  },
+) {
+  const state = {
+    wallet,
+    session,
+    oauthConfig,
+    setEoaAccount: vi.fn(),
+    setSession: vi.fn(),
+  }
+  return {
+    getState: vi.fn().mockReturnValue(state),
+    subscribe: vi.fn(),
+    setState: vi.fn(),
+  }
+}
+
+// Create a mock connector
+function createMockConnector(store = createMockStore()) {
+  return {
+    id: 'zerodev-wallet',
+    name: 'ZeroDev Wallet',
+    type: 'zerodev-wallet',
+    getStore: vi.fn().mockResolvedValue(store),
+  } as unknown as Connector
+}
+
+// Create a mock config
+function createMockConfig(connector = createMockConnector()) {
+  return {
+    connectors: [connector],
+    chains: [],
+    state: { chainId: 1, connections: new Map() },
+    storage: null,
+  } as unknown as Config
+}
+
+describe('React Actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('registerPasskey', () => {
+    it('calls wallet.auth with passkey register mode', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await registerPasskey(config, { email: 'user@example.com' })
+
+      expect(wallet.auth).toHaveBeenCalledWith({
+        type: 'passkey',
+        email: 'user@example.com',
+        mode: 'register',
+      })
+    })
+
+    it('sets session and account with correct values after registration', async () => {
+      const wallet = createMockWallet()
+      wallet.getSession.mockResolvedValue({ id: 'sess-abc', expiry: 999 })
+      wallet.toAccount.mockResolvedValue({ address: '0xdeadbeef' })
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await registerPasskey(config, { email: 'user@example.com' })
+
+      expect(store.getState().setEoaAccount).toHaveBeenCalledWith({
+        address: '0xdeadbeef',
+      })
+      expect(store.getState().setSession).toHaveBeenCalledWith({
+        id: 'sess-abc',
+        expiry: 999,
+      })
+    })
+
+    it('sets session to null when getSession returns falsy', async () => {
+      const wallet = createMockWallet()
+      wallet.getSession.mockResolvedValue(null)
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await registerPasskey(config, { email: 'user@example.com' })
+
+      expect(store.getState().setSession).toHaveBeenCalledWith(null)
+    })
+
+    it('calls wagmiConnect after registration', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await registerPasskey(config, { email: 'user@example.com' })
+
+      expect(wagmiConnect).toHaveBeenCalledWith(config, { connector })
+    })
+
+    it('throws when wallet is not initialized', async () => {
+      const store = createMockStore(null)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await expect(
+        registerPasskey(config, { email: 'user@example.com' }),
+      ).rejects.toThrow('Wallet not initialized')
+    })
+
+    it('uses provided connector instead of finding one', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const customConnector = createMockConnector(store)
+      const config = createMockConfig()
+
+      await registerPasskey(config, {
+        email: 'user@example.com',
+        connector: customConnector,
+      })
+
+      expect(customConnector.getStore).toHaveBeenCalled()
+    })
+  })
+
+  describe('loginPasskey', () => {
+    it('calls wallet.auth with passkey login mode', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await loginPasskey(config, { email: 'user@example.com' })
+
+      expect(wallet.auth).toHaveBeenCalledWith({
+        type: 'passkey',
+        email: 'user@example.com',
+        mode: 'login',
+      })
+    })
+
+    it('sets session and account with correct values after login', async () => {
+      const wallet = createMockWallet()
+      wallet.getSession.mockResolvedValue({ id: 'login-sess' })
+      wallet.toAccount.mockResolvedValue({ address: '0xabc' })
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await loginPasskey(config, { email: 'user@example.com' })
+
+      expect(store.getState().setEoaAccount).toHaveBeenCalledWith({
+        address: '0xabc',
+      })
+      expect(store.getState().setSession).toHaveBeenCalledWith({
+        id: 'login-sess',
+      })
+    })
+
+    it('calls wagmiConnect after login', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await loginPasskey(config, { email: 'user@example.com' })
+
+      expect(wagmiConnect).toHaveBeenCalledWith(config, { connector })
+    })
+
+    it('throws when wallet is not initialized', async () => {
+      const store = createMockStore(null)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await expect(
+        loginPasskey(config, { email: 'user@example.com' }),
+      ).rejects.toThrow('Wallet not initialized')
+    })
+  })
+
+  describe('sendOTP', () => {
+    it('calls wallet.auth with otp sendOtp mode', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await sendOTP(config, { email: 'user@example.com' })
+
+      expect(wallet.auth).toHaveBeenCalledWith({
+        type: 'otp',
+        mode: 'sendOtp',
+        email: 'user@example.com',
+        contact: { type: 'email', contact: 'user@example.com' },
+      })
+    })
+
+    it('does not include emailCustomization when not provided', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await sendOTP(config, { email: 'user@example.com' })
+
+      const authCall = wallet.auth.mock.calls[0][0]
+      expect(authCall).not.toHaveProperty('emailCustomization')
+    })
+
+    it('returns otpId from wallet auth', async () => {
+      const wallet = createMockWallet()
+      wallet.auth.mockResolvedValue({ otpId: 'otp-456' })
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      const result = await sendOTP(config, { email: 'user@example.com' })
+
+      expect(result).toEqual({ otpId: 'otp-456' })
+    })
+
+    it('includes email customization when provided', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await sendOTP(config, {
+        email: 'user@example.com',
+        emailCustomization: { magicLinkTemplate: 'https://app.com/verify/%s' },
+      })
+
+      expect(wallet.auth).toHaveBeenCalledWith({
+        type: 'otp',
+        mode: 'sendOtp',
+        email: 'user@example.com',
+        contact: { type: 'email', contact: 'user@example.com' },
+        emailCustomization: {
+          magicLinkTemplate: 'https://app.com/verify/%s',
+        },
+      })
+    })
+
+    it('throws when wallet is not initialized', async () => {
+      const store = createMockStore(null)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await expect(
+        sendOTP(config, { email: 'user@example.com' }),
+      ).rejects.toThrow('Wallet not initialized')
+    })
+  })
+
+  describe('verifyOTP', () => {
+    it('calls wallet.auth with otp verifyOtp mode', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await verifyOTP(config, { code: '123456', otpId: 'otp-123' })
+
+      expect(wallet.auth).toHaveBeenCalledWith({
+        type: 'otp',
+        mode: 'verifyOtp',
+        otpId: 'otp-123',
+        otpCode: '123456',
+      })
+    })
+
+    it('sets session and account with correct values after verification', async () => {
+      const wallet = createMockWallet()
+      wallet.getSession.mockResolvedValue({ id: 'verify-sess' })
+      wallet.toAccount.mockResolvedValue({ address: '0xverified' })
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await verifyOTP(config, { code: '123456', otpId: 'otp-123' })
+
+      expect(store.getState().setEoaAccount).toHaveBeenCalledWith({
+        address: '0xverified',
+      })
+      expect(store.getState().setSession).toHaveBeenCalledWith({
+        id: 'verify-sess',
+      })
+    })
+
+    it('calls wagmiConnect after verification', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await verifyOTP(config, { code: '123456', otpId: 'otp-123' })
+
+      expect(wagmiConnect).toHaveBeenCalledWith(config, { connector })
+    })
+
+    it('throws when wallet is not initialized', async () => {
+      const store = createMockStore(null)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await expect(
+        verifyOTP(config, { code: '123456', otpId: 'otp-123' }),
+      ).rejects.toThrow('Wallet not initialized')
+    })
+  })
+
+  describe('refreshSession', () => {
+    it('calls wallet.refreshSession with current session id', async () => {
+      const wallet = createMockWallet()
+      const currentSession = { id: 'current-session-123' }
+      const store = createMockStore(wallet, currentSession)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await refreshSession(config)
+
+      expect(wallet.refreshSession).toHaveBeenCalledWith('current-session-123')
+    })
+
+    it('updates session in store with new session and returns it', async () => {
+      const wallet = createMockWallet()
+      wallet.refreshSession.mockResolvedValue({ id: 'new-session-456' })
+      const currentSession = { id: 'current-session-123' }
+      const store = createMockStore(wallet, currentSession)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      const result = await refreshSession(config)
+
+      expect(store.getState().setSession).toHaveBeenCalledWith({
+        id: 'new-session-456',
+      })
+      expect(result).toEqual({ id: 'new-session-456' })
+    })
+
+    it('sets session to null when refresh returns falsy', async () => {
+      const wallet = createMockWallet()
+      wallet.refreshSession.mockResolvedValue(null)
+      const currentSession = { id: 'current-session-123' }
+      const store = createMockStore(wallet, currentSession)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await refreshSession(config)
+
+      expect(store.getState().setSession).toHaveBeenCalledWith(null)
+    })
+
+    it('throws when no active session', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet, null)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await expect(refreshSession(config)).rejects.toThrow(
+        'No active session to refresh',
+      )
+    })
+
+    it('throws when wallet is not initialized', async () => {
+      const store = createMockStore(null)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await expect(refreshSession(config)).rejects.toThrow(
+        'No active session to refresh',
+      )
+    })
+  })
+
+  describe('getUserEmail', () => {
+    it('calls wallet.client.getUserEmail with parameters', async () => {
+      const wallet = createMockWallet()
+      const session = {
+        id: 'session-123',
+        organizationId: 'org-123',
+        token: 'test-token',
+      }
+      const store = createMockStore(wallet, session)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await getUserEmail(config)
+
+      expect(wallet.client.getUserEmail).toHaveBeenCalledWith({
+        organizationId: 'org-123',
+        projectId: 'proj-123',
+        token: 'test-token',
+      })
+    })
+
+    it('returns email from wallet client', async () => {
+      const wallet = createMockWallet()
+      wallet.client.getUserEmail.mockResolvedValue({ email: 'test@test.com' })
+      const session = {
+        id: 'session-123',
+        organizationId: 'org-123',
+        token: 'test-token',
+      }
+      const store = createMockStore(wallet, session)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      const result = await getUserEmail(config)
+
+      expect(result).toEqual({ email: 'test@test.com' })
+    })
+
+    it('throws when wallet is not initialized', async () => {
+      const store = createMockStore(null)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await expect(
+        getUserEmail(config, {
+          organizationId: 'org-123',
+          projectId: 'proj-456',
+        }),
+      ).rejects.toThrow('Wallet not initialized')
+    })
+  })
+
+  describe('authenticateOAuth', () => {
+    let mockOpenOAuthPopup: ReturnType<typeof vi.fn>
+    let mockListenForOAuthMessage: ReturnType<typeof vi.fn>
+    let mockBuildBackendOAuthUrl: ReturnType<typeof vi.fn>
+
+    beforeEach(async () => {
+      const oauthModule = await import('./oauth.js')
+      mockOpenOAuthPopup = vi.mocked(oauthModule.openOAuthPopup)
+      mockListenForOAuthMessage = vi.mocked(oauthModule.listenForOAuthMessage)
+      mockBuildBackendOAuthUrl = vi.mocked(oauthModule.buildBackendOAuthUrl)
+    })
+
+    it('throws when wallet is not initialized', async () => {
+      const store = createMockStore(null)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await expect(
+        authenticateOAuth(config, { provider: 'google' }),
+      ).rejects.toThrow('Wallet not initialized')
+    })
+
+    it('throws when oauthConfig is missing', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet, null, null)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await expect(
+        authenticateOAuth(config, { provider: 'google' }),
+      ).rejects.toThrow(
+        'Wallet not initialized. Please wait for connector setup.',
+      )
+    })
+
+    it('throws when publicKey is null', async () => {
+      const wallet = createMockWallet()
+      wallet.getPublicKey.mockResolvedValue(null)
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await expect(
+        authenticateOAuth(config, { provider: 'google' }),
+      ).rejects.toThrow('Failed to get wallet public key')
+    })
+
+    it('throws when popup is blocked', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      mockOpenOAuthPopup.mockReturnValue(null)
+
+      await expect(
+        authenticateOAuth(config, { provider: 'google' }),
+      ).rejects.toThrow('Failed to open google login window')
+    })
+
+    it('builds OAuth URL with correct parameters', async () => {
+      const wallet = createMockWallet()
+      wallet.getPublicKey.mockResolvedValue('03abcdef123456')
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      mockOpenOAuthPopup.mockReturnValue({ closed: false } as Window)
+      mockListenForOAuthMessage.mockImplementation(() => {
+        return () => {}
+      })
+
+      authenticateOAuth(config, { provider: 'google' }).catch(() => {})
+
+      await new Promise((r) => setTimeout(r, 10))
+
+      expect(mockBuildBackendOAuthUrl).toHaveBeenCalledWith({
+        provider: 'google',
+        backendUrl: 'https://api.example.com',
+        projectId: 'proj-123',
+        publicKey: '03abcdef123456',
+        returnTo: expect.stringContaining('oauth_success=true'),
+      })
+    })
+
+    it('completes full OAuth success flow', async () => {
+      const wallet = createMockWallet()
+      wallet.getSession.mockResolvedValue({ id: 'oauth-session' })
+      wallet.toAccount.mockResolvedValue({ address: '0xoauth' })
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      mockOpenOAuthPopup.mockReturnValue({ closed: false } as Window)
+      // Simulate the success callback being called immediately
+      mockListenForOAuthMessage.mockImplementation(
+        (_win: Window, _origin: string, onSuccess: () => void) => {
+          // Call onSuccess asynchronously to simulate real behavior
+          setTimeout(() => onSuccess(), 0)
+          return () => {}
+        },
+      )
+
+      await authenticateOAuth(config, { provider: 'google' })
+
+      expect(wallet.auth).toHaveBeenCalledWith({
+        type: 'oauth',
+        provider: 'google',
+      })
+      expect(store.getState().setEoaAccount).toHaveBeenCalledWith({
+        address: '0xoauth',
+      })
+      expect(store.getState().setSession).toHaveBeenCalledWith({
+        id: 'oauth-session',
+      })
+      expect(wagmiConnect).toHaveBeenCalledWith(config, { connector })
+    })
+
+    it('rejects when wallet.auth fails in success callback', async () => {
+      const wallet = createMockWallet()
+      wallet.auth.mockRejectedValue(new Error('Auth backend error'))
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      mockOpenOAuthPopup.mockReturnValue({ closed: false } as Window)
+      mockListenForOAuthMessage.mockImplementation(
+        (_win: Window, _origin: string, onSuccess: () => void) => {
+          setTimeout(() => onSuccess(), 0)
+          return () => {}
+        },
+      )
+
+      await expect(
+        authenticateOAuth(config, { provider: 'google' }),
+      ).rejects.toThrow('Auth backend error')
+    })
+
+    it('rejects when onError callback is called', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      mockOpenOAuthPopup.mockReturnValue({ closed: false } as Window)
+      mockListenForOAuthMessage.mockImplementation(
+        (
+          _win: Window,
+          _origin: string,
+          _onSuccess: () => void,
+          onError: (error: Error) => void,
+        ) => {
+          setTimeout(() => onError(new Error('Window closed')), 0)
+          return () => {}
+        },
+      )
+
+      await expect(
+        authenticateOAuth(config, { provider: 'google' }),
+      ).rejects.toThrow('Window closed')
+    })
+  })
+
+  describe('exportWallet', () => {
+    it('throws when wallet is not initialized', async () => {
+      const store = createMockStore(null)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await expect(
+        exportWallet(config, { iframeContainerId: 'export-container' }),
+      ).rejects.toThrow('Wallet not initialized')
+    })
+
+    it('throws when iframe container not found', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await expect(
+        exportWallet(config, { iframeContainerId: 'nonexistent-container' }),
+      ).rejects.toThrow('Iframe container not found')
+    })
+
+    it('completes full export wallet flow', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      // Create DOM element for iframe container
+      const container = document.createElement('div')
+      container.id = 'export-wallet-container'
+      document.body.appendChild(container)
+
+      const mockStamper = {
+        init: vi.fn().mockResolvedValue('target-public-key'),
+        injectWalletExportBundle: vi.fn().mockResolvedValue(true),
+      }
+      vi.mocked(createIframeStamper).mockResolvedValue(mockStamper as never)
+      vi.mocked(exportWalletSdk).mockResolvedValue({
+        exportBundle: 'wallet-bundle-data',
+        organizationId: 'org-abc',
+      } as never)
+
+      await exportWallet(config, {
+        iframeContainerId: 'export-wallet-container',
+      })
+
+      expect(createIframeStamper).toHaveBeenCalledWith({
+        iframeUrl: 'https://export.turnkey.com',
+        iframeContainer: container,
+        iframeElementId: 'export-wallet-iframe',
+      })
+      expect(mockStamper.init).toHaveBeenCalled()
+      expect(exportWalletSdk).toHaveBeenCalledWith({
+        wallet,
+        targetPublicKey: 'target-public-key',
+      })
+      expect(mockStamper.injectWalletExportBundle).toHaveBeenCalledWith(
+        'wallet-bundle-data',
+        'org-abc',
+      )
+
+      document.body.removeChild(container)
+    })
+
+    it('throws when inject bundle returns non-true', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      const container = document.createElement('div')
+      container.id = 'export-fail-container'
+      document.body.appendChild(container)
+
+      const mockStamper = {
+        init: vi.fn().mockResolvedValue('pub-key'),
+        injectWalletExportBundle: vi.fn().mockResolvedValue(false),
+      }
+      vi.mocked(createIframeStamper).mockResolvedValue(mockStamper as never)
+      vi.mocked(exportWalletSdk).mockResolvedValue({
+        exportBundle: 'bundle',
+        organizationId: 'org',
+      } as never)
+
+      await expect(
+        exportWallet(config, { iframeContainerId: 'export-fail-container' }),
+      ).rejects.toThrow('Failed to inject export bundle')
+
+      document.body.removeChild(container)
+    })
+  })
+
+  describe('exportPrivateKey', () => {
+    it('throws when wallet is not initialized', async () => {
+      const store = createMockStore(null)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await expect(
+        exportPrivateKey(config, { iframeContainerId: 'export-container' }),
+      ).rejects.toThrow('Wallet not initialized')
+    })
+
+    it('throws when iframe container not found', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      await expect(
+        exportPrivateKey(config, {
+          iframeContainerId: 'nonexistent-container',
+        }),
+      ).rejects.toThrow('Iframe container not found')
+    })
+
+    it('completes full export private key flow with defaults', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      const container = document.createElement('div')
+      container.id = 'export-pk-container'
+      document.body.appendChild(container)
+
+      const mockStamper = {
+        init: vi.fn().mockResolvedValue('target-pub-key'),
+        injectKeyExportBundle: vi.fn().mockResolvedValue(true),
+      }
+      vi.mocked(createIframeStamper).mockResolvedValue(mockStamper as never)
+      vi.mocked(exportPrivateKeySdk).mockResolvedValue({
+        exportBundle: 'pk-bundle-data',
+        organizationId: 'org-xyz',
+      } as never)
+
+      await exportPrivateKey(config, {
+        iframeContainerId: 'export-pk-container',
+      })
+
+      expect(createIframeStamper).toHaveBeenCalledWith({
+        iframeUrl: 'https://export.turnkey.com',
+        iframeContainer: container,
+        iframeElementId: 'export-private-key-iframe',
+      })
+      expect(exportPrivateKeySdk).toHaveBeenCalledWith({
+        wallet,
+        targetPublicKey: 'target-pub-key',
+      })
+      // Default keyFormat is 'Hexadecimal'
+      expect(mockStamper.injectKeyExportBundle).toHaveBeenCalledWith(
+        'pk-bundle-data',
+        'org-xyz',
+        'Hexadecimal',
+      )
+
+      document.body.removeChild(container)
+    })
+
+    it('passes address and custom keyFormat when provided', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      const container = document.createElement('div')
+      container.id = 'export-pk-custom'
+      document.body.appendChild(container)
+
+      const mockStamper = {
+        init: vi.fn().mockResolvedValue('pub'),
+        injectKeyExportBundle: vi.fn().mockResolvedValue(true),
+      }
+      vi.mocked(createIframeStamper).mockResolvedValue(mockStamper as never)
+      vi.mocked(exportPrivateKeySdk).mockResolvedValue({
+        exportBundle: 'bundle',
+        organizationId: 'org',
+      } as never)
+
+      await exportPrivateKey(config, {
+        iframeContainerId: 'export-pk-custom',
+        address: '0xmyaddress',
+        keyFormat: 'Solana',
+      })
+
+      expect(exportPrivateKeySdk).toHaveBeenCalledWith({
+        wallet,
+        targetPublicKey: 'pub',
+        address: '0xmyaddress',
+      })
+      expect(mockStamper.injectKeyExportBundle).toHaveBeenCalledWith(
+        'bundle',
+        'org',
+        'Solana',
+      )
+
+      document.body.removeChild(container)
+    })
+
+    it('throws when inject key bundle returns non-true', async () => {
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      const container = document.createElement('div')
+      container.id = 'export-pk-fail'
+      document.body.appendChild(container)
+
+      const mockStamper = {
+        init: vi.fn().mockResolvedValue('pub'),
+        injectKeyExportBundle: vi.fn().mockResolvedValue(false),
+      }
+      vi.mocked(createIframeStamper).mockResolvedValue(mockStamper as never)
+      vi.mocked(exportPrivateKeySdk).mockResolvedValue({
+        exportBundle: 'bundle',
+        organizationId: 'org',
+      } as never)
+
+      await expect(
+        exportPrivateKey(config, { iframeContainerId: 'export-pk-fail' }),
+      ).rejects.toThrow('Failed to inject export bundle')
+
+      document.body.removeChild(container)
+    })
+  })
+
+  describe('connector lookup', () => {
+    it('throws when ZeroDev connector not found in config', async () => {
+      const config = {
+        connectors: [{ id: 'other-connector' }],
+        chains: [],
+        state: { chainId: 1, connections: new Map() },
+        storage: null,
+      } as unknown as Config
+
+      await expect(
+        registerPasskey(config, { email: 'user@example.com' }),
+      ).rejects.toThrow('ZeroDev connector not found in Wagmi config')
+    })
+  })
+})

--- a/packages/react/src/oauth.test.ts
+++ b/packages/react/src/oauth.test.ts
@@ -1,0 +1,445 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildBackendOAuthUrl,
+  generateOAuthNonce,
+  handleOAuthCallback,
+  listenForOAuthMessage,
+  OAUTH_PROVIDERS,
+  openOAuthPopup,
+} from './oauth.js'
+
+describe('OAuth utilities', () => {
+  describe('OAUTH_PROVIDERS', () => {
+    it('has google provider', () => {
+      expect(OAUTH_PROVIDERS.GOOGLE).toBe('google')
+    })
+  })
+
+  describe('generateOAuthNonce', () => {
+    it('generates consistent nonce from public key', () => {
+      const publicKey = '0x1234567890abcdef'
+
+      const nonce1 = generateOAuthNonce(publicKey)
+      const nonce2 = generateOAuthNonce(publicKey)
+
+      expect(nonce1).toBe(nonce2)
+    })
+
+    it('returns nonce without 0x prefix', () => {
+      const publicKey =
+        '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+
+      const nonce = generateOAuthNonce(publicKey)
+
+      expect(nonce).not.toMatch(/^0x/)
+    })
+
+    it('generates different nonces for different keys', () => {
+      const key1 =
+        '0x1111111111111111111111111111111111111111111111111111111111111111'
+      const key2 =
+        '0x2222222222222222222222222222222222222222222222222222222222222222'
+
+      const nonce1 = generateOAuthNonce(key1)
+      const nonce2 = generateOAuthNonce(key2)
+
+      expect(nonce1).not.toBe(nonce2)
+    })
+  })
+
+  describe('buildBackendOAuthUrl', () => {
+    it('builds correct URL for Google OAuth', () => {
+      const url = buildBackendOAuthUrl({
+        provider: 'google',
+        backendUrl: 'https://api.example.com',
+        projectId: 'proj-123',
+        publicKey: '0xabcdef1234567890',
+        returnTo: 'https://app.example.com/callback',
+      })
+
+      const parsedUrl = new URL(url)
+      expect(parsedUrl.origin).toBe('https://api.example.com')
+      expect(parsedUrl.pathname).toBe('/oauth/google/login')
+      expect(parsedUrl.searchParams.get('project_id')).toBe('proj-123')
+      expect(parsedUrl.searchParams.get('pub_key')).toBe('abcdef1234567890') // 0x stripped
+      expect(parsedUrl.searchParams.get('return_to')).toBe(
+        'https://app.example.com/callback',
+      )
+    })
+
+    it('strips 0x prefix from public key', () => {
+      const url = buildBackendOAuthUrl({
+        provider: 'google',
+        backendUrl: 'https://api.example.com',
+        projectId: 'proj-123',
+        publicKey: '0x0123456789',
+        returnTo: 'https://app.example.com',
+      })
+
+      const parsedUrl = new URL(url)
+      expect(parsedUrl.searchParams.get('pub_key')).toBe('0123456789')
+    })
+
+    it('handles public key without 0x prefix', () => {
+      const url = buildBackendOAuthUrl({
+        provider: 'google',
+        backendUrl: 'https://api.example.com',
+        projectId: 'proj-123',
+        publicKey: 'abcdef123456',
+        returnTo: 'https://app.example.com',
+      })
+
+      const parsedUrl = new URL(url)
+      expect(parsedUrl.searchParams.get('pub_key')).toBe('abcdef123456')
+    })
+
+    it('throws on unsupported provider', () => {
+      expect(() =>
+        buildBackendOAuthUrl({
+          provider: 'facebook' as 'google',
+          backendUrl: 'https://api.example.com',
+          projectId: 'proj-123',
+          publicKey: '0xabcdef',
+          returnTo: 'https://app.example.com',
+        }),
+      ).toThrow('Unsupported OAuth provider: facebook')
+    })
+
+    it('encodes special characters in return URL', () => {
+      const url = buildBackendOAuthUrl({
+        provider: 'google',
+        backendUrl: 'https://api.example.com',
+        projectId: 'proj-123',
+        publicKey: '0xabcdef',
+        returnTo: 'https://app.example.com?foo=bar&baz=qux',
+      })
+
+      const parsedUrl = new URL(url)
+      expect(parsedUrl.searchParams.get('return_to')).toBe(
+        'https://app.example.com?foo=bar&baz=qux',
+      )
+    })
+  })
+
+  describe('openOAuthPopup', () => {
+    const originalOpen = window.open
+
+    beforeEach(() => {
+      window.open = vi.fn()
+    })
+
+    afterEach(() => {
+      window.open = originalOpen
+    })
+
+    it('opens a popup with about:blank initially', () => {
+      const mockWindow = { location: { href: '' } }
+      vi.mocked(window.open).mockReturnValue(mockWindow as Window)
+
+      openOAuthPopup('https://oauth.example.com')
+
+      expect(window.open).toHaveBeenCalledWith(
+        'about:blank',
+        '_blank',
+        expect.stringContaining('width=500,height=600'),
+      )
+    })
+
+    it('sets the URL after opening', () => {
+      const mockWindow = { location: { href: '' } }
+      vi.mocked(window.open).mockReturnValue(mockWindow as Window)
+
+      openOAuthPopup('https://oauth.example.com/login')
+
+      expect(mockWindow.location.href).toBe('https://oauth.example.com/login')
+    })
+
+    it('returns the window object', () => {
+      const mockWindow = { location: { href: '' } }
+      vi.mocked(window.open).mockReturnValue(mockWindow as Window)
+
+      const result = openOAuthPopup('https://oauth.example.com')
+
+      expect(result).toBe(mockWindow)
+    })
+
+    it('returns null if popup was blocked', () => {
+      vi.mocked(window.open).mockReturnValue(null)
+
+      const result = openOAuthPopup('https://oauth.example.com')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('listenForOAuthMessage', () => {
+    let mockWindow: { closed: boolean }
+    let onSuccessMock: ReturnType<typeof vi.fn>
+    let onErrorMock: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+      mockWindow = { closed: false }
+      onSuccessMock = vi.fn()
+      onErrorMock = vi.fn()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('calls onSuccess when oauth_success message received', () => {
+      const cleanup = listenForOAuthMessage(
+        mockWindow as Window,
+        'https://app.example.com',
+        onSuccessMock as () => void,
+        onErrorMock as (error: Error) => void,
+      )
+
+      // Simulate receiving a message
+      const event = new MessageEvent('message', {
+        data: { type: 'oauth_success' },
+        origin: 'https://app.example.com',
+      })
+      window.dispatchEvent(event)
+
+      expect(onSuccessMock).toHaveBeenCalledOnce()
+      expect(onErrorMock).not.toHaveBeenCalled()
+      cleanup()
+    })
+
+    it('calls onError when oauth_error message received', () => {
+      const cleanup = listenForOAuthMessage(
+        mockWindow as Window,
+        'https://app.example.com',
+        onSuccessMock as () => void,
+        onErrorMock as (error: Error) => void,
+      )
+
+      const event = new MessageEvent('message', {
+        data: { type: 'oauth_error', error: 'Access denied' },
+        origin: 'https://app.example.com',
+      })
+      window.dispatchEvent(event)
+
+      expect(onErrorMock).toHaveBeenCalledOnce()
+      expect(onErrorMock).toHaveBeenCalledWith(new Error('Access denied'))
+      expect(onSuccessMock).not.toHaveBeenCalled()
+      cleanup()
+    })
+
+    it('ignores messages from wrong origin', () => {
+      const cleanup = listenForOAuthMessage(
+        mockWindow as Window,
+        'https://app.example.com',
+        onSuccessMock as () => void,
+        onErrorMock as (error: Error) => void,
+      )
+
+      const event = new MessageEvent('message', {
+        data: { type: 'oauth_success' },
+        origin: 'https://malicious.example.com',
+      })
+      window.dispatchEvent(event)
+
+      expect(onSuccessMock).not.toHaveBeenCalled()
+      expect(onErrorMock).not.toHaveBeenCalled()
+      cleanup()
+    })
+
+    it('calls onError when window is closed', () => {
+      const cleanup = listenForOAuthMessage(
+        mockWindow as Window,
+        'https://app.example.com',
+        onSuccessMock as () => void,
+        onErrorMock as (error: Error) => void,
+      )
+
+      mockWindow.closed = true
+      vi.advanceTimersByTime(600)
+
+      expect(onErrorMock).toHaveBeenCalledWith(
+        new Error('Authentication window was closed'),
+      )
+      cleanup()
+    })
+
+    it('uses fallback error message when oauth_error has no error field', () => {
+      const cleanup = listenForOAuthMessage(
+        mockWindow as Window,
+        'https://app.example.com',
+        onSuccessMock as () => void,
+        onErrorMock as (error: Error) => void,
+      )
+
+      const event = new MessageEvent('message', {
+        data: { type: 'oauth_error' },
+        origin: 'https://app.example.com',
+      })
+      window.dispatchEvent(event)
+
+      expect(onErrorMock).toHaveBeenCalledWith(
+        new Error('OAuth authentication failed'),
+      )
+      cleanup()
+    })
+
+    it('ignores messages with non-object data', () => {
+      const cleanup = listenForOAuthMessage(
+        mockWindow as Window,
+        'https://app.example.com',
+        onSuccessMock as () => void,
+        onErrorMock as (error: Error) => void,
+      )
+
+      // null data
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: null,
+          origin: 'https://app.example.com',
+        }),
+      )
+      // string data
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: 'some-string',
+          origin: 'https://app.example.com',
+        }),
+      )
+      // number data
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: 42,
+          origin: 'https://app.example.com',
+        }),
+      )
+
+      expect(onSuccessMock).not.toHaveBeenCalled()
+      expect(onErrorMock).not.toHaveBeenCalled()
+      cleanup()
+    })
+
+    it('calling cleanup multiple times is safe', () => {
+      const cleanup = listenForOAuthMessage(
+        mockWindow as Window,
+        'https://app.example.com',
+        onSuccessMock as () => void,
+        onErrorMock as (error: Error) => void,
+      )
+
+      cleanup()
+      cleanup()
+      cleanup()
+
+      // Should not throw and subsequent messages should be ignored
+      const event = new MessageEvent('message', {
+        data: { type: 'oauth_success' },
+        origin: 'https://app.example.com',
+      })
+      window.dispatchEvent(event)
+
+      expect(onSuccessMock).not.toHaveBeenCalled()
+    })
+
+    it('returns cleanup function that stops listening', () => {
+      const cleanup = listenForOAuthMessage(
+        mockWindow as Window,
+        'https://app.example.com',
+        onSuccessMock as () => void,
+        onErrorMock as (error: Error) => void,
+      )
+
+      cleanup()
+
+      // Message after cleanup should be ignored
+      const event = new MessageEvent('message', {
+        data: { type: 'oauth_success' },
+        origin: 'https://app.example.com',
+      })
+      window.dispatchEvent(event)
+
+      expect(onSuccessMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleOAuthCallback', () => {
+    const originalLocation = window.location
+    const originalOpener = window.opener
+    const originalClose = window.close
+
+    beforeEach(() => {
+      // @ts-expect-error - Mocking location
+      delete window.location
+      // @ts-expect-error - Mocking location with partial properties
+      window.location = {
+        ...originalLocation,
+        search: '',
+        origin: 'https://app.example.com',
+      } as Location
+
+      window.opener = {
+        postMessage: vi.fn(),
+      } as unknown as Window
+
+      window.close = vi.fn()
+    })
+
+    afterEach(() => {
+      // @ts-expect-error - Restoring original location
+      window.location = originalLocation
+      window.opener = originalOpener
+      window.close = originalClose
+    })
+
+    it('returns true and posts success message on oauth_success=true', () => {
+      window.location.search = '?oauth_success=true'
+
+      const result = handleOAuthCallback()
+
+      expect(result).toBe(true)
+      expect(window.opener?.postMessage).toHaveBeenCalledWith(
+        { type: 'oauth_success' },
+        'https://app.example.com',
+      )
+      expect(window.close).toHaveBeenCalled()
+    })
+
+    it('returns false and posts error message on error param', () => {
+      window.location.search = '?error=access_denied'
+
+      const result = handleOAuthCallback()
+
+      expect(result).toBe(false)
+      expect(window.opener?.postMessage).toHaveBeenCalledWith(
+        { type: 'oauth_error', error: 'access_denied' },
+        'https://app.example.com',
+      )
+      expect(window.close).toHaveBeenCalled()
+    })
+
+    it('supports custom success param name', () => {
+      window.location.search = '?custom_param=true'
+
+      const result = handleOAuthCallback('custom_param')
+
+      expect(result).toBe(true)
+    })
+
+    it('returns false when no opener', () => {
+      window.opener = null
+      window.location.search = '?oauth_success=true'
+
+      const result = handleOAuthCallback()
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false when no relevant params', () => {
+      window.location.search = '?some_other_param=value'
+
+      const result = handleOAuthCallback()
+
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,21 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.7
         version: 2.29.7(@types/node@20.19.11)
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.11
+      '@vitest/coverage-v8':
+        specifier: ^4.0.18
+        version: 4.0.18(vitest@4.0.18(@types/node@20.19.11)(happy-dom@20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(yaml@2.8.1))
+      happy-dom:
+        specifier: ^20.6.0
+        version: 20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -26,6 +38,9 @@ importers:
       typescript:
         specifier: ~5.9.0
         version: 5.9.2
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@20.19.11)(happy-dom@20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(yaml@2.8.1)
 
   packages/core:
     dependencies:
@@ -97,12 +112,37 @@ packages:
   '@adraffy/ens-normalize@1.11.0':
     resolution: {integrity: sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==}
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.0':
+    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
   '@base-org/account@2.4.0':
     resolution: {integrity: sha512-A4Umpi8B9/pqR78D1Yoze4xHyQaujioVRqqO3d6xuDFw9VRtjg6tK3bPlwE0aW+nVH/ntllCpPa2PbI8Rnjcug==}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@2.2.4':
     resolution: {integrity: sha512-TBHU5bUy/Ok6m8c0y3pZiuO/BZoY/OcGxoLlrfQof5s8ISVwbVBdFINPQZyFfKwil8XibYWb7JMwnT8wT4WVPg==}
@@ -228,6 +268,162 @@ packages:
     peerDependencies:
       '@noble/ciphers': ^1.0.0
 
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@ethereumjs/common@3.2.0':
     resolution: {integrity: sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==}
 
@@ -257,6 +453,16 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@lit-labs/ssr-dom-shim@1.4.0':
     resolution: {integrity: sha512-ficsEARKnmmW5njugNYKipTm4SFnbik7CXtoencDZzmzo/dQ+2Q0bgkzJuoJP20Aj0F+izzJjOqsnkd6F/o1bw==}
@@ -422,6 +628,127 @@ packages:
 
   '@reown/appkit@1.7.8':
     resolution: {integrity: sha512-51kTleozhA618T1UvMghkhKfaPcc9JlKwLJ5uV+riHyvSoWPKPRIa5A6M1Wano5puNyW0s3fwywhyqTHSilkaA==}
+
+  '@rollup/rollup-android-arm-eabi@4.54.0':
+    resolution: {integrity: sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.54.0':
+    resolution: {integrity: sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.54.0':
+    resolution: {integrity: sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.54.0':
+    resolution: {integrity: sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.54.0':
+    resolution: {integrity: sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.54.0':
+    resolution: {integrity: sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.54.0':
+    resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.54.0':
+    resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.54.0':
+    resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.54.0':
+    resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.54.0':
+    resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.54.0':
+    resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.54.0':
+    resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.54.0':
+    resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.54.0':
+    resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.54.0':
+    resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.54.0':
+    resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openharmony-arm64@4.54.0':
+    resolution: {integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.54.0':
+    resolution: {integrity: sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.54.0':
+    resolution: {integrity: sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.54.0':
+    resolution: {integrity: sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.54.0':
+    resolution: {integrity: sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==}
+    cpu: [x64]
+    os: [win32]
 
   '@safe-global/safe-apps-provider@0.18.6':
     resolution: {integrity: sha512-4LhMmjPWlIO8TTDC2AwLk44XKXaK6hfBTWyljDm0HQ6TWlOEijVWNrt2s3OCVMSxlXAcEzYfqyu1daHZooTC2Q==}
@@ -721,6 +1048,9 @@ packages:
   '@solana/web3.js@1.98.4':
     resolution: {integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swc/helpers@0.5.17':
     resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
 
@@ -731,6 +1061,25 @@ packages:
     resolution: {integrity: sha512-wAHc/cgKzW7LZNFloThyHnV/AX9gTg3w5yAv0gvQHPZoCnepwqCMtzbuPbb2UvfvO32XZ46e8bPOYbfZhzVnnQ==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@turnkey/api-key-stamper@0.4.7':
     resolution: {integrity: sha512-/0/kW7v+uCnmHnGMoHSXn4Vb/MxLAIivGxX/T0L4vVoIiJalQmqcCtgiWnPWZDiJNGjMKp+jd/8j6VXgbVVozg==}
@@ -764,11 +1113,23 @@ packages:
     resolution: {integrity: sha512-jdN17QEnn7RBykEOhtKIialWmDjnDAH8DzbyITwn8jsKcwT1TBNYge89hTUTjbdsDLBAqQw8cHujPdy0RaAqvw==}
     engines: {node: '>=18.0.0'}
 
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/lodash@4.17.20':
     resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
@@ -791,11 +1152,52 @@ packages:
   '@types/uuid@8.3.4':
     resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
   '@types/ws@7.4.7':
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vitest/coverage-v8@4.0.18':
+    resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
+    peerDependencies:
+      '@vitest/browser': 4.0.18
+      vitest: 4.0.18
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
   '@wagmi/connectors@7.0.0':
     resolution: {integrity: sha512-K/E/9LawQO4Pxji2O1DVFwJnczOpX5W1w9zt7jeIeS14X/a6gZQ5gdd6bZN8xMbTmyGPe729dIytU3Z/uM/dSg==}
@@ -1010,6 +1412,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -1021,9 +1427,19 @@ packages:
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.11:
+    resolution: {integrity: sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -1104,6 +1520,10 @@ packages:
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -1241,6 +1661,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   derive-valtio@0.1.0:
     resolution: {integrity: sha512-OCg2UsLbXK7GmmpzMXhYkdO64vhJ1ROUUGaTFyHjVwEdMEcTTRj7W1TxLbSBxdY8QLBPCcp66MTyaSy0RpO17A==}
     peerDependencies:
@@ -1262,6 +1686,9 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1297,6 +1724,10 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -1308,6 +1739,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1326,10 +1760,18 @@ packages:
   es6-promisify@5.0.0:
     resolution: {integrity: sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==}
 
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   eth-rpc-errors@4.0.3:
     resolution: {integrity: sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==}
@@ -1346,6 +1788,10 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -1380,6 +1826,15 @@ packages:
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1417,6 +1872,11 @@ packages:
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1459,6 +1919,14 @@ packages:
   h3@1.15.4:
     resolution: {integrity: sha512-z5cFQWDffyOe4vQ9xIqNfCZdV4p//vy6fBnr8Q1AWnVZ0teurKMG66rLj++TKwKPUP3u7iMUvrvKaEUiQw2QWQ==}
 
+  happy-dom@20.6.0:
+    resolution: {integrity: sha512-a+Sz2bPai3rajDuE82Y4B0OxlXJ19ckUjyfWDmeCAs8ZbEbnqtwzV9d4CVhQjWIuOBTOw8rhlxNeaSCHeknXRQ==}
+    engines: {node: '>=20.0.0'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
@@ -1477,6 +1945,9 @@ packages:
   hono@4.10.4:
     resolution: {integrity: sha512-YG/fo7zlU3KwrBL5vDpWKisLYiM+nVstBQqfr7gCPbSYURnNEP9BDxEMz8KfsDR9JX0lJWDRNc6nXX31v7ZEyg==}
     engines: {node: '>=16.9.0'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   human-id@4.1.2:
     resolution: {integrity: sha512-v/J+4Z/1eIJovEBdlV5TYj1IR+ZiohcYGRY+qN/oC9dAfKzVT023N/Bgw37hrKCoVRBvk3bqyzpr2PP5YeTMSg==}
@@ -1593,6 +2064,18 @@ packages:
     peerDependencies:
       ws: '*'
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jayson@4.2.0:
     resolution: {integrity: sha512-VfJ9t1YLwacIubLhONk0KFeosUBwstRWQ0IRT1KDjEjnVnSOVHC3uwugyV7L0c7R9lpVyrUGT2XWiBA1UTtpyg==}
     engines: {node: '>=8'}
@@ -1600,6 +2083,12 @@ packages:
 
   jose@6.1.1:
     resolution: {integrity: sha512-GWSqjfOPf4cWOkBzw5THBjtGPhXKqYnfRBzh4Ni+ArTrQQ9unvmsA3oFLqaYKoKe5sjWmGu5wVKg9Ft1i+LQfg==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -1651,6 +2140,20 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1707,6 +2210,11 @@ packages:
     resolution: {integrity: sha512-jtpsQDetTnvS2Ts1fiRdci5rx0VYws5jGyC+4IYOTnIQ/wwdf6JdomlHBwqC3bJYOvaKu0C2GSZ1A60anrYpaA==}
     engines: {node: '>=20.17'}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
@@ -1732,6 +2240,9 @@ packages:
 
   obj-multiplex@1.0.0:
     resolution: {integrity: sha512-0GNJAOsHoBHeNTvl5Vt6IWnpUEcc3uSRxzBri7EDyIcMgYvnY2JL2qdeV5zTMjWQX5OHcD5amcW2HFfDh0gjIA==}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
@@ -1830,12 +2341,19 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
 
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
@@ -1900,6 +2418,10 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   preact@10.24.2:
     resolution: {integrity: sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==}
 
@@ -1907,6 +2429,10 @@ packages:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -1943,6 +2469,14 @@ packages:
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
+  react-dom@19.2.4:
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+    peerDependencies:
+      react: ^19.2.4
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react@19.2.0:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
@@ -1989,6 +2523,11 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rollup@4.54.0:
+    resolution: {integrity: sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   rpc-websockets@9.3.1:
     resolution: {integrity: sha512-bY6a+i/lEtBJ/mUxwsCTgevoV1P0foXTVA7UoThzaIWbM+3NDqorf8NBWs5DmqKTFeA1IoNzgvkWjFCPgnzUiQ==}
 
@@ -2011,6 +2550,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
@@ -2035,6 +2577,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2058,6 +2603,10 @@ packages:
   sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
@@ -2071,6 +2620,12 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stream-chain@2.2.5:
     resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
@@ -2123,6 +2678,10 @@ packages:
     resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
     engines: {node: '>=14.0.0'}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -2132,6 +2691,21 @@ packages:
 
   thread-stream@0.15.2:
     resolution: {integrity: sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2293,6 +2867,80 @@ packages:
       typescript:
         optional: true
 
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   wagmi@3.0.0:
     resolution: {integrity: sha512-EGAjC620mLTfaGcGR1dUJTAqg6ClqS5/cT5xU+6VdpVxlYX8vNqlNrZxTF9H+u2HPZap39N8WuwKGJTG8/Ar2Q==}
     peerDependencies:
@@ -2310,6 +2958,10 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
@@ -2323,6 +2975,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@6.2.0:
@@ -2471,7 +3128,26 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.0': {}
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/runtime@7.28.4': {}
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@base-org/account@2.4.0(@types/react@19.2.2)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)':
     dependencies:
@@ -2498,6 +3174,8 @@ snapshots:
       - ws
       - zod
     optional: true
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.2.4':
     optionalDependencies:
@@ -2728,6 +3406,84 @@ snapshots:
       '@noble/ciphers': 1.3.0
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
   '@ethereumjs/common@3.2.0':
     dependencies:
       '@ethereumjs/util': 8.1.0
@@ -2767,6 +3523,15 @@ snapshots:
       iconv-lite: 0.7.0
     optionalDependencies:
       '@types/node': 20.19.11
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@lit-labs/ssr-dom-shim@1.4.0':
     optional: true
@@ -3288,6 +4053,72 @@ snapshots:
       - uploadthing
       - utf-8-validate
       - zod
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.54.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.54.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.54.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.54.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.54.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.54.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.54.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.54.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.54.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.54.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.54.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.54.0':
     optional: true
 
   '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12)':
@@ -3820,6 +4651,8 @@ snapshots:
       - utf-8-validate
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@swc/helpers@0.5.17':
     dependencies:
       tslib: 2.8.1
@@ -3831,6 +4664,26 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.90.7
       react: 19.2.0
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 10.4.1
+      react: 19.2.0
+      react-dom: 19.2.4(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
 
   '@turnkey/api-key-stamper@0.4.7':
     dependencies:
@@ -3871,6 +4724,13 @@ snapshots:
     dependencies:
       sha256-uint8array: 0.10.7
 
+  '@types/aria-query@5.0.4': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 20.19.11
@@ -3880,6 +4740,10 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
     optional: true
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/lodash@4.17.20':
     optional: true
@@ -3903,6 +4767,8 @@ snapshots:
   '@types/uuid@8.3.4':
     optional: true
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
   '@types/ws@7.4.7':
     dependencies:
       '@types/node': 20.19.11
@@ -3911,7 +4777,59 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 20.19.11
-    optional: true
+
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@20.19.11)(happy-dom@20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(yaml@2.8.1))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.18
+      ast-v8-to-istanbul: 0.3.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 4.0.18(@types/node@20.19.11)(happy-dom@20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(yaml@2.8.1)
+
+  '@vitest/expect@4.0.18':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@20.19.11)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@20.19.11)(yaml@2.8.1)
+
+  '@vitest/pretty-format@4.0.18':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
 
   '@wagmi/connectors@7.0.0(bf2e6a1434d90506f121461321763d24)':
     dependencies:
@@ -4576,6 +5494,8 @@ snapshots:
       color-convert: 2.0.1
     optional: true
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   anymatch@3.1.3:
@@ -4588,7 +5508,19 @@ snapshots:
     dependencies:
       sprintf-js: 1.0.3
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   array-union@2.1.0: {}
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.11:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   asynckit@0.4.0:
     optional: true
@@ -4697,6 +5629,8 @@ snapshots:
 
   camelcase@5.3.1:
     optional: true
+
+  chai@6.2.2: {}
 
   chalk@5.6.2:
     optional: true
@@ -4833,6 +5767,8 @@ snapshots:
   delayed-stream@1.0.0:
     optional: true
 
+  dequal@2.0.3: {}
+
   derive-valtio@0.1.0(valtio@1.13.2(@types/react@19.2.2)(react@19.2.0)):
     dependencies:
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.0)
@@ -4852,6 +5788,8 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dom-accessibility-api@0.5.16: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -4910,6 +5848,8 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  entities@6.0.1: {}
+
   environment@1.1.0: {}
 
   es-define-property@1.0.1:
@@ -4917,6 +5857,8 @@ snapshots:
 
   es-errors@1.3.0:
     optional: true
+
+  es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -4942,7 +5884,40 @@ snapshots:
       es6-promise: 4.2.8
     optional: true
 
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
   esprima@4.0.1: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
 
   eth-rpc-errors@4.0.3:
     dependencies:
@@ -4964,6 +5939,8 @@ snapshots:
 
   events@3.3.0:
     optional: true
+
+  expect-type@1.3.0: {}
 
   extendable-error@0.1.7: {}
 
@@ -5002,6 +5979,10 @@ snapshots:
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   fill-range@7.1.1:
     dependencies:
@@ -5043,6 +6024,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2:
     optional: true
@@ -5106,6 +6090,20 @@ snapshots:
       uncrypto: 0.1.3
     optional: true
 
+  happy-dom@20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      '@types/node': 20.19.11
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 6.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  has-flag@4.0.0: {}
+
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
@@ -5126,6 +6124,8 @@ snapshots:
 
   hono@4.10.4:
     optional: true
+
+  html-escaper@2.0.2: {}
 
   human-id@4.1.2: {}
 
@@ -5237,6 +6237,19 @@ snapshots:
     dependencies:
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jayson@4.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:
       '@types/connect': 3.4.38
@@ -5258,6 +6271,10 @@ snapshots:
 
   jose@6.1.1:
     optional: true
+
+  js-tokens@10.0.0: {}
+
+  js-tokens@4.0.0: {}
 
   js-yaml@3.14.1:
     dependencies:
@@ -5334,6 +6351,22 @@ snapshots:
   lru-cache@10.4.3:
     optional: true
 
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.3
+
   math-intrinsics@1.1.0:
     optional: true
 
@@ -5381,6 +6414,8 @@ snapshots:
 
   nano-spawn@1.0.3: {}
 
+  nanoid@3.3.11: {}
+
   node-fetch-native@1.6.7:
     optional: true
 
@@ -5403,6 +6438,8 @@ snapshots:
       once: 1.4.0
       readable-stream: 2.3.8
     optional: true
+
+  obug@2.1.1: {}
 
   ofetch@1.5.1:
     dependencies:
@@ -5566,9 +6603,13 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
+
+  picomatch@4.0.3: {}
 
   pidtree@0.6.0: {}
 
@@ -5628,10 +6669,22 @@ snapshots:
   possible-typed-array-names@1.1.0:
     optional: true
 
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   preact@10.24.2:
     optional: true
 
   prettier@2.8.8: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   process-nextick-args@2.0.1:
     optional: true
@@ -5676,6 +6729,13 @@ snapshots:
 
   radix3@1.1.2:
     optional: true
+
+  react-dom@19.2.4(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react@19.2.0: {}
 
@@ -5727,6 +6787,34 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rollup@4.54.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.54.0
+      '@rollup/rollup-android-arm64': 4.54.0
+      '@rollup/rollup-darwin-arm64': 4.54.0
+      '@rollup/rollup-darwin-x64': 4.54.0
+      '@rollup/rollup-freebsd-arm64': 4.54.0
+      '@rollup/rollup-freebsd-x64': 4.54.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.54.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.54.0
+      '@rollup/rollup-linux-arm64-gnu': 4.54.0
+      '@rollup/rollup-linux-arm64-musl': 4.54.0
+      '@rollup/rollup-linux-loong64-gnu': 4.54.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.54.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.54.0
+      '@rollup/rollup-linux-riscv64-musl': 4.54.0
+      '@rollup/rollup-linux-s390x-gnu': 4.54.0
+      '@rollup/rollup-linux-x64-gnu': 4.54.0
+      '@rollup/rollup-linux-x64-musl': 4.54.0
+      '@rollup/rollup-openharmony-arm64': 4.54.0
+      '@rollup/rollup-win32-arm64-msvc': 4.54.0
+      '@rollup/rollup-win32-ia32-msvc': 4.54.0
+      '@rollup/rollup-win32-x64-gnu': 4.54.0
+      '@rollup/rollup-win32-x64-msvc': 4.54.0
+      fsevents: 2.3.3
+
   rpc-websockets@9.3.1:
     dependencies:
       '@swc/helpers': 0.5.17
@@ -5763,6 +6851,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  scheduler@0.27.0: {}
+
   semver@7.7.3: {}
 
   set-blocking@2.0.0:
@@ -5785,6 +6875,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
 
@@ -5820,6 +6912,8 @@ snapshots:
       atomic-sleep: 1.0.0
     optional: true
 
+  source-map-js@1.2.1: {}
+
   spawndamnit@3.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -5832,6 +6926,10 @@ snapshots:
     optional: true
 
   sprintf-js@1.0.3: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   stream-chain@2.2.5:
     optional: true
@@ -5890,6 +6988,10 @@ snapshots:
   superstruct@2.0.2:
     optional: true
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   term-size@2.2.1: {}
 
   text-encoding-utf-8@1.0.2:
@@ -5899,6 +7001,17 @@ snapshots:
     dependencies:
       real-require: 0.1.0
     optional: true
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -6061,6 +7174,57 @@ snapshots:
       - utf-8-validate
       - zod
 
+  vite@7.3.1(@types/node@20.19.11)(yaml@2.8.1):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.54.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.11
+      fsevents: 2.3.3
+      yaml: 2.8.1
+
+  vitest@4.0.18(@types/node@20.19.11)(happy-dom@20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(yaml@2.8.1):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.11)(yaml@2.8.1))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@20.19.11)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.11
+      happy-dom: 20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   wagmi@3.0.0(c70f6029f74d83c530f8bb10a730427a):
     dependencies:
       '@tanstack/react-query': 5.90.7(react@19.2.0)
@@ -6089,6 +7253,8 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  whatwg-mimetype@3.0.0: {}
+
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
@@ -6111,6 +7277,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@6.2.0:
     dependencies:

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./templates/typescript/tsconfig.base.json",
+  "include": ["packages/core/src/**/*.ts", "packages/react/src/**/*.ts"],
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'happy-dom',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['packages/*/src/**/*.ts'],
+      exclude: [
+        'packages/*/src/**/*.test.ts',
+        'packages/*/src/**/*.test-d.ts',
+        'packages/*/src/**/*.bench.ts',
+        'packages/*/src/**/index.ts',
+        'packages/*/src/**/types.ts',
+        'packages/*/src/**/types/**',
+      ],
+    },
+    include: ['packages/*/src/**/*.test.ts'],
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,15 @@
+import path from 'node:path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@zerodev/wallet-core': path.resolve(
+        __dirname,
+        'packages/core/src/index.ts',
+      ),
+    },
+  },
   test: {
     globals: true,
     environment: 'happy-dom',


### PR DESCRIPTION
## Summary
- Adds 214 unit tests across 10 test files covering core and react packages
- Core: auth (getUserEmail, passkey, session), OTP, wallet actions, storage adapters/manager, utilities (signature encoding, helpers)
- React: actions (login, register, OAuth, session, getUserEmail), OAuth helpers
- Fixes getUserEmail tests to match updated implementation (session-based auth headers, EIP-191 stamping)

## Test plan
- [x] `pnpm test` — 214 tests passing