### PR TITLE
release: @zerodev/wallet-core@0.0.1-alpha.10 and @zerodev/wallet-react@0.0.1-alpha.11

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -19,6 +19,7 @@
     "rare-buttons-rescue",
     "shaggy-ants-lay",
     "shy-chefs-behave",
+    "thin-trees-grow",
     "warm-files-post",
     "wise-shrimps-show"
   ]

--- a/.changeset/thin-trees-grow.md
+++ b/.changeset/thin-trees-grow.md
@@ -1,0 +1,5 @@
+---
+"@zerodev/wallet-core": patch
+---
+
+feat: Added new getAuthProxyConfigId action that fetches the auth proxy config ID from GET /server-info/auth-proxy-id and updated DEFAULT_ORGANIZATION_ID and KMS_SERVER_URL to staging environment

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @zerodev/wallet-core
 
+## 0.0.1-alpha.10
+
+### Patch Changes
+
+- feat: Added new getAuthProxyConfigId action that fetches the auth proxy config ID from GET /server-info/auth-proxy-id and updated DEFAULT_ORGANIZATION_ID and KMS_SERVER_URL to staging environment
+
 ## 0.0.1-alpha.9
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-core",
-  "version": "0.0.1-alpha.9",
+  "version": "0.0.1-alpha.10",
   "description": "ZeroDev Wallet SDK built on Turnkey",
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @zerodev/wallet-react
 
+## 0.0.1-alpha.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @zerodev/wallet-core@0.0.1-alpha.10
+
 ## 0.0.1-alpha.10
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-react",
-  "version": "0.0.1-alpha.10",
+  "version": "0.0.1-alpha.11",
   "description": "React hooks for ZeroDev Wallet SDK",
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",


### PR DESCRIPTION
## Summary
- Bump `@zerodev/wallet-core` to `0.0.1-alpha.10`
- Bump `@zerodev/wallet-react` to `0.0.1-alpha.11`