### PR TITLE
fix: signing after passkey login survives session refresh

### DIFF
--- a/packages/core/src/adapters/viem.ts
+++ b/packages/core/src/adapters/viem.ts
@@ -24,13 +24,13 @@ export interface ToViemAccountParams {
   client: ZeroDevWalletClient
   organizationId: string
   projectId: string
-  token: string
+  getToken: () => string | Promise<string>
 }
 
 export async function toViemAccount(
   params: ToViemAccountParams,
 ): Promise<LocalAccount> {
-  const { client, organizationId, projectId, token } = params
+  const { client, organizationId, projectId, getToken } = params
 
   let address: Hex = zeroAddress
 
@@ -38,7 +38,7 @@ export async function toViemAccount(
     const walletResponse = await client.getUserWallet({
       organizationId,
       projectId,
-      token,
+      token: await getToken(),
     })
     address = walletResponse.walletAddresses[0]
   } catch {
@@ -53,7 +53,7 @@ export async function toViemAccount(
     return await client.signRawPayload({
       organizationId,
       projectId,
-      token,
+      token: await getToken(),
       address,
       payload,
       encoding,
@@ -79,7 +79,7 @@ export async function toViemAccount(
     const signature = await client.signTransaction({
       organizationId,
       projectId,
-      token,
+      token: await getToken(),
       address,
       unsignedTransaction: nonHexPrefixedSerializedTx,
     })

--- a/packages/core/src/core/createZeroDevWallet.ts
+++ b/packages/core/src/core/createZeroDevWallet.ts
@@ -440,7 +440,10 @@ export async function createZeroDevWallet(
         client,
         organizationId: session.organizationId,
         projectId,
-        token: session.token ?? '',
+        getToken: async () => {
+          const activeSession = await sessionStorageManager.getActiveSession()
+          return activeSession?.token ?? ''
+        },
       })
     },
   }

--- a/packages/react/src/connector.ts
+++ b/packages/react/src/connector.ts
@@ -107,12 +107,19 @@ export function zeroDevWallet(
   return createConnector<Provider, Properties>((wagmiConfig) => {
     let store: ReturnType<typeof createZeroDevWalletStore>
     let provider: ReturnType<typeof createProvider>
+    let initPromise: Promise<void> | null = null
 
     // Get transports from Wagmi config (uses user's RPC URLs)
     const transports = wagmiConfig.transports
 
-    // Lazy initialization - only runs on client side
+    // Lazy initialization - only runs on client side (idempotent)
     const initialize = async () => {
+      if (initPromise) return initPromise
+      initPromise = doInitialize()
+      return initPromise
+    }
+
+    const doInitialize = async () => {
       console.log('Initializing ZeroDevWallet connector...')
 
       // Initialize wallet SDK


### PR DESCRIPTION
## Summary
- **Idempotent connector init:** Memoize the `initialize()` promise so concurrent callers don't race to set up the wallet SDK multiple times
- **Dynamic token resolution:** Replace the static `token` string captured at `LocalAccount` creation time with a `getToken()` callback that reads the current active session at signing time. After `refreshSession()` generates a new key pair and token, all signing operations (`signMessage`, `signTransaction`, `signTypedData`, `signAuthorization`) automatically use the fresh token instead of the stale one that caused 400 "user not found" errors

## Test plan
- [x] `pnpm build` passes (core + react)
- [x] `pnpm test` — all 214 tests pass
- [x] `doorway-auth-prototype` builds successfully
- [x] Manual: login with passkey, wait for auto-refresh, sign a message — should succeed without 400 error