### PR TITLE
release: @zerodev/wallet-core@0.0.1-alpha.11 and @zerodev/wallet-react@0.0.1-alpha.12

### DIFF
--- a/.changeset/humble-sheep-kiss.md
+++ b/.changeset/humble-sheep-kiss.md
@@ -1,0 +1,6 @@
+---
+"@zerodev/wallet-core": patch
+"@zerodev/wallet-react": patch
+---
+
+fix: resolve session token dynamically so signing survives session refresh

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -13,6 +13,7 @@
     "floppy-glasses-attack",
     "free-grapes-teach",
     "giant-garlics-make",
+    "humble-sheep-kiss",
     "loud-jobs-cheat",
     "lucky-corners-sneeze",
     "neat-birds-count",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @zerodev/wallet-core
 
+## 0.0.1-alpha.11
+
+### Patch Changes
+
+- fix: resolve session token dynamically so signing survives session refresh
+
 ## 0.0.1-alpha.10
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-core",
-  "version": "0.0.1-alpha.10",
+  "version": "0.0.1-alpha.11",
   "description": "ZeroDev Wallet SDK built on Turnkey",
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @zerodev/wallet-react
 
+## 0.0.1-alpha.12
+
+### Patch Changes
+
+- fix: resolve session token dynamically so signing survives session refresh
+- Updated dependencies
+  - @zerodev/wallet-core@0.0.1-alpha.11
+
 ## 0.0.1-alpha.11
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-react",
-  "version": "0.0.1-alpha.11",
+  "version": "0.0.1-alpha.12",
   "description": "React hooks for ZeroDev Wallet SDK",
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",


### PR DESCRIPTION
## Summary
- Bump `@zerodev/wallet-core` to `0.0.1-alpha.11`
- Bump `@zerodev/wallet-react` to `0.0.1-alpha.12`
- Includes fix for signing after session refresh (dynamic token resolution)