### PR TITLE
feat: expose iframe applySettings and iframeStyles in export actions

### DIFF
--- a/packages/core/src/stampers/iframeStamper.ts
+++ b/packages/core/src/stampers/iframeStamper.ts
@@ -45,5 +45,8 @@ export async function createIframeStamper(cfg: {
         keyFormat ? KeyFormat[keyFormat] : KeyFormat.Hexadecimal,
       )
     },
+    async applySettings(settings: { styles?: Record<string, string> }) {
+      return await inner.applySettings(settings)
+    },
   }
 }

--- a/packages/core/src/stampers/types.ts
+++ b/packages/core/src/stampers/types.ts
@@ -27,6 +27,7 @@ export type IframeStamper = Stamper & {
     organizationId: string,
     keyFormat?: KeyFormat,
   ): Promise<boolean>
+  applySettings(settings: { styles?: Record<string, string> }): Promise<boolean>
 }
 
 export type IndexedDbStamper = Stamper & {

--- a/packages/react/src/actions.ts
+++ b/packages/react/src/actions.ts
@@ -370,6 +370,7 @@ export async function exportWallet(
   config: Config,
   parameters: {
     iframeContainerId: string
+    iframeStyles?: Record<string, string>
     connector?: Connector
   },
 ): Promise<void> {
@@ -393,6 +394,11 @@ export async function exportWallet(
   })
 
   const publicKey = await iframeStamper.init()
+
+  if (parameters.iframeStyles) {
+    await iframeStamper.applySettings({ styles: parameters.iframeStyles })
+  }
+
   const { exportBundle, organizationId } = await exportWalletSdk({
     wallet,
     targetPublicKey: publicKey,
@@ -410,6 +416,7 @@ export async function exportWallet(
 export declare namespace exportWallet {
   type Parameters = {
     iframeContainerId: string
+    iframeStyles?: Record<string, string>
     connector?: Connector
   }
   type ReturnType = void
@@ -423,6 +430,7 @@ export async function exportPrivateKey(
   config: Config,
   parameters: {
     iframeContainerId: string
+    iframeStyles?: Record<string, string>
     address?: string
     keyFormat?: 'Hexadecimal' | 'Solana'
     connector?: Connector
@@ -448,6 +456,11 @@ export async function exportPrivateKey(
   })
 
   const publicKey = await iframeStamper.init()
+
+  if (parameters.iframeStyles) {
+    await iframeStamper.applySettings({ styles: parameters.iframeStyles })
+  }
+
   const { exportBundle, organizationId } = await exportPrivateKeySdk({
     wallet,
     targetPublicKey: publicKey,
@@ -467,6 +480,7 @@ export async function exportPrivateKey(
 export declare namespace exportPrivateKey {
   type Parameters = {
     iframeContainerId: string
+    iframeStyles?: Record<string, string>
     address?: string
     keyFormat?: 'Hexadecimal' | 'Solana'
     connector?: Connector


### PR DESCRIPTION
## Summary
- Expose `applySettings()` on `IframeStamper` type and implementation, delegating to Turnkey's `IframeStamper.applySettings()` for customizing the export iframe appearance (colors, fonts, padding, etc.)
- Accept optional `iframeStyles` parameter in `exportWallet` and `exportPrivateKey` React actions — styles are applied after iframe init, before injecting the export bundle

## Changed files
- `packages/core/src/stampers/types.ts` — add `applySettings` to `IframeStamper` type
- `packages/core/src/stampers/iframeStamper.ts` — expose `applySettings` delegating to inner stamper
- `packages/react/src/actions.ts` — accept `iframeStyles` in `exportWallet` and `exportPrivateKey`

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (214 tests)
- [x] Manual: export wallet/private key with custom styles in demo app