### PR TITLE
release: @zerodev/wallet-core@0.0.1-alpha.12 and @zerodev/wallet-react@0.0.1-alpha.13

### DIFF
--- a/.changeset/neat-apples-repair.md
+++ b/.changeset/neat-apples-repair.md
@@ -1,0 +1,6 @@
+---
+"@zerodev/wallet-core": patch
+"@zerodev/wallet-react": patch
+---
+
+feat: expose applySettings on iframe stamper and accept iframeStyles in export actions

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -16,6 +16,7 @@
     "humble-sheep-kiss",
     "loud-jobs-cheat",
     "lucky-corners-sneeze",
+    "neat-apples-repair",
     "neat-birds-count",
     "rare-buttons-rescue",
     "shaggy-ants-lay",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @zerodev/wallet-core
 
+## 0.0.1-alpha.12
+
+### Patch Changes
+
+- feat: expose applySettings on iframe stamper and accept iframeStyles in export actions
+
 ## 0.0.1-alpha.11
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-core",
-  "version": "0.0.1-alpha.11",
+  "version": "0.0.1-alpha.12",
   "description": "ZeroDev Wallet SDK built on Turnkey",
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @zerodev/wallet-react
 
+## 0.0.1-alpha.13
+
+### Patch Changes
+
+- feat: expose applySettings on iframe stamper and accept iframeStyles in export actions
+- Updated dependencies
+  - @zerodev/wallet-core@0.0.1-alpha.12
+
 ## 0.0.1-alpha.12
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-react",
-  "version": "0.0.1-alpha.12",
+  "version": "0.0.1-alpha.13",
   "description": "React hooks for ZeroDev Wallet SDK",
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",


### PR DESCRIPTION
## Summary
- Bump `@zerodev/wallet-core` to `0.0.1-alpha.12`
- Bump `@zerodev/wallet-react` to `0.0.1-alpha.13`
- Includes changeset for iframe `applySettings` and `iframeStyles` in export actions (#57)

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] Published to npm