### PR TITLE
feat: add otpCodeCustomization to OTP and magic link flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ const { otpId } = await sendMagicLink.mutateAsync({
   redirectURL: 'https://yourapp.com/verify',
 })
 
+// With custom OTP code settings
+const { otpId } = await sendMagicLink.mutateAsync({
+  email: 'user@example.com',
+  redirectURL: 'https://yourapp.com/verify',
+  otpCodeCustomization: { length: 8, alphanumeric: false },
+})
+
 // Verify (on /verify page, extract code from URL)
 const code = new URLSearchParams(window.location.search).get('code')
 await verifyMagicLink.mutateAsync({ otpId, code })
@@ -129,11 +136,33 @@ const { otpId } = await sendOTP.mutateAsync({
   email: 'user@example.com'
 })
 
+// With custom OTP code settings
+const { otpId } = await sendOTP.mutateAsync({
+  email: 'user@example.com',
+  otpCodeCustomization: { length: 8, alphanumeric: false },
+})
+
 // Verify OTP code
 await verifyOTP.mutateAsync({
-  code: '123456',
+  code: '12345678',
   otpId,
 })
+```
+
+### OTP Code Customization
+
+Both `sendOTP` and `sendMagicLink` accept an optional `otpCodeCustomization` parameter to configure the generated code:
+
+| Field | Type | Description |
+|---|---|---|
+| `length` | `6 \| 7 \| 8 \| 9` | Code length (default: 6) |
+| `alphanumeric` | `boolean` | Use alphanumeric characters instead of digits only (default: false) |
+
+```typescript
+otpCodeCustomization: {
+  length: 8,        // 8-digit code
+  alphanumeric: false, // numeric only
+}
 ```
 
 ## Send Transaction

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -91,6 +91,15 @@ const { otpId } = await wallet.auth({
   redirectURL: 'https://yourapp.com/verify',
 });
 
+// With custom OTP code settings
+const { otpId } = await wallet.auth({
+  type: 'magicLink',
+  mode: 'send',
+  email: 'user@example.com',
+  redirectURL: 'https://yourapp.com/verify',
+  otpCodeCustomization: { length: 8, alphanumeric: false },
+});
+
 // After user clicks link (on /verify page), extract code from URL
 const code = new URLSearchParams(window.location.search).get('code');
 await wallet.auth({
@@ -112,14 +121,32 @@ const { otpId } = await wallet.auth({
   contact: { type: 'email', contact: 'user@example.com' }
 });
 
+// With custom OTP code settings
+const { otpId } = await wallet.auth({
+  type: 'otp',
+  mode: 'sendOtp',
+  email: 'user@example.com',
+  contact: { type: 'email', contact: 'user@example.com' },
+  otpCodeCustomization: { length: 8, alphanumeric: false },
+});
+
 // Step 2: Verify OTP code
 await wallet.auth({
   type: 'otp',
   mode: 'verifyOtp',
   otpId,
-  otpCode: '123456',
+  otpCode: '12345678',
 });
 ```
+
+### OTP Code Customization
+
+Both OTP and magic link `send` modes accept an optional `otpCodeCustomization` parameter:
+
+| Field | Type | Description |
+|---|---|---|
+| `length` | `6 \| 7 \| 8 \| 9` | Code length (default: 6) |
+| `alphanumeric` | `boolean` | Use alphanumeric characters instead of digits only (default: false) |
 
 ### OAuth (Google)
 

--- a/packages/core/src/actions/auth/index.ts
+++ b/packages/core/src/actions/auth/index.ts
@@ -35,6 +35,7 @@ export {
   loginWithStamp,
 } from './loginWithStamp.js'
 export {
+  type OtpCodeCustomization,
   type OtpContact,
   type RegisterWithOTPParameters,
   type RegisterWithOTPReturnType,

--- a/packages/core/src/actions/auth/registerWithOTP.ts
+++ b/packages/core/src/actions/auth/registerWithOTP.ts
@@ -8,6 +8,13 @@ export type OtpContact = {
   contact: string
 }
 
+export type OtpCodeCustomization = {
+  /** The length of the OTP code (must be between 6 and 9 inclusive) */
+  length: 6 | 7 | 8 | 9
+  /** Whether the OTP code should be alphanumeric */
+  alphanumeric: boolean
+}
+
 export type RegisterWithOTPParameters = {
   /** The email address to register */
   email: string
@@ -17,6 +24,8 @@ export type RegisterWithOTPParameters = {
   projectId: string
   /** Optional email customization settings */
   emailCustomization?: EmailCustomization
+  /** Optional OTP code customization settings */
+  otpCodeCustomization?: OtpCodeCustomization
 }
 
 export type RegisterWithOTPReturnType = {
@@ -50,7 +59,20 @@ export async function registerWithOTP(
   client: Client,
   params: RegisterWithOTPParameters,
 ): Promise<RegisterWithOTPReturnType> {
-  const { email, contact, projectId, emailCustomization } = params
+  const {
+    email,
+    contact,
+    projectId,
+    emailCustomization,
+    otpCodeCustomization,
+  } = params
+
+  if (
+    otpCodeCustomization &&
+    (otpCodeCustomization.length < 6 || otpCodeCustomization.length > 9)
+  ) {
+    throw new Error('OTP code length must be between 6 and 9')
+  }
 
   return await client.request({
     path: `${projectId}/auth/init/otp`,
@@ -59,6 +81,7 @@ export async function registerWithOTP(
       email,
       contact,
       emailCustomization,
+      otpCodeCustomization,
     },
   })
 }

--- a/packages/core/src/core/createZeroDevWallet.ts
+++ b/packages/core/src/core/createZeroDevWallet.ts
@@ -1,6 +1,9 @@
 import { getWebAuthnAttestation } from '@turnkey/http'
 import type { LocalAccount } from 'viem/accounts'
-import type { EmailCustomization } from '../actions/auth/index.js'
+import type {
+  EmailCustomization,
+  OtpCodeCustomization,
+} from '../actions/auth/index.js'
 import { toViemAccount } from '../adapters/viem.js'
 import {
   createAuthProxyClient,
@@ -61,6 +64,7 @@ export type AuthParams =
         contact: string
       }
       emailCustomization?: EmailCustomization
+      otpCodeCustomization?: OtpCodeCustomization
     }
   | {
       type: 'otp'
@@ -73,6 +77,7 @@ export type AuthParams =
       mode: 'send'
       email: string
       redirectURL: string
+      otpCodeCustomization?: OtpCodeCustomization
     }
   | {
       type: 'magicLink'
@@ -364,6 +369,9 @@ export async function createZeroDevWallet(
                 emailCustomization: {
                   magicLinkTemplate: `${params.redirectURL}${params.redirectURL.includes('?') ? '&' : '?'}code=%s`,
                 },
+                ...(params.otpCodeCustomization && {
+                  otpCodeCustomization: params.otpCodeCustomization,
+                }),
               }
             } else {
               otpParams = {
@@ -378,13 +386,15 @@ export async function createZeroDevWallet(
           }
 
           if (otpParams.mode === 'sendOtp') {
-            const { email, contact, emailCustomization } = otpParams
+            const { email, contact, emailCustomization, otpCodeCustomization } =
+              otpParams
 
             const data = await client.registerWithOTP({
               email,
               contact,
               projectId,
               ...(emailCustomization && { emailCustomization }),
+              ...(otpCodeCustomization && { otpCodeCustomization }),
             })
 
             return data

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -164,6 +164,13 @@ const { otpId } = await sendMagicLink.mutateAsync({
   redirectURL: 'https://yourapp.com/verify',
 })
 
+// With custom OTP code settings
+const { otpId } = await sendMagicLink.mutateAsync({
+  email: 'user@example.com',
+  redirectURL: 'https://yourapp.com/verify',
+  otpCodeCustomization: { length: 8, alphanumeric: false },
+})
+
 // Verify (on /verify page, extract code from URL)
 const code = new URLSearchParams(window.location.search).get('code')
 await verifyMagicLink.mutateAsync({ otpId, code })
@@ -180,12 +187,27 @@ const { otpId } = await sendOTP.mutateAsync({
   email: 'user@example.com'
 })
 
+// With custom OTP code settings
+const { otpId } = await sendOTP.mutateAsync({
+  email: 'user@example.com',
+  otpCodeCustomization: { length: 8, alphanumeric: false },
+})
+
 // Verify OTP code
 await verifyOTP.mutateAsync({
-  code: '123456',
+  code: '12345678',
   otpId,
 })
 ```
+
+### OTP Code Customization
+
+Both `useSendOTP` and `useSendMagicLink` accept an optional `otpCodeCustomization` parameter:
+
+| Field | Type | Description |
+|---|---|---|
+| `length` | `6 \| 7 \| 8 \| 9` | Code length (default: 6) |
+| `alphanumeric` | `boolean` | Use alphanumeric characters instead of digits only (default: false) |
 
 ## Configuration Options
 

--- a/packages/react/src/actions.ts
+++ b/packages/react/src/actions.ts
@@ -208,6 +208,7 @@ export async function sendOTP(
   parameters: {
     email: string
     emailCustomization?: { magicLinkTemplate?: string }
+    otpCodeCustomization?: { length: 6 | 7 | 8 | 9; alphanumeric: boolean }
     connector?: Connector
   },
 ): Promise<{ otpId: string }> {
@@ -227,6 +228,9 @@ export async function sendOTP(
     ...(parameters.emailCustomization && {
       emailCustomization: parameters.emailCustomization,
     }),
+    ...(parameters.otpCodeCustomization && {
+      otpCodeCustomization: parameters.otpCodeCustomization,
+    }),
   })
 
   return {
@@ -238,6 +242,7 @@ export declare namespace sendOTP {
   type Parameters = {
     email: string
     emailCustomization?: { magicLinkTemplate?: string }
+    otpCodeCustomization?: { length: 6 | 7 | 8 | 9; alphanumeric: boolean }
     connector?: Connector
   }
   type ReturnType = { otpId: string }
@@ -497,6 +502,7 @@ export async function sendMagicLink(
   parameters: {
     email: string
     redirectURL: string
+    otpCodeCustomization?: { length: 6 | 7 | 8 | 9; alphanumeric: boolean }
     connector?: Connector
   },
 ): Promise<{ otpId: string }> {
@@ -513,6 +519,9 @@ export async function sendMagicLink(
     mode: 'send',
     email: parameters.email,
     redirectURL: parameters.redirectURL,
+    ...(parameters.otpCodeCustomization && {
+      otpCodeCustomization: parameters.otpCodeCustomization,
+    }),
   })
 
   return {
@@ -524,6 +533,7 @@ export declare namespace sendMagicLink {
   type Parameters = {
     email: string
     redirectURL: string
+    otpCodeCustomization?: { length: 6 | 7 | 8 | 9; alphanumeric: boolean }
     connector?: Connector
   }
   type ReturnType = { otpId: string }


### PR DESCRIPTION
## Summary
- Add optional `otpCodeCustomization` parameter (`{ length: 6|7|8|9, alphanumeric: boolean }`) to OTP and magic link send flows
- Compile-time type constraint on `length` plus runtime validation in `registerWithOTP`
- Passes through to the backend's `POST /{projectId}/auth/init/otp` endpoint

## Changes
- `packages/core/src/actions/auth/registerWithOTP.ts` — new `OtpCodeCustomization` type, added to params and request body, runtime length validation
- `packages/core/src/actions/auth/index.ts` — export `OtpCodeCustomization`
- `packages/core/src/core/createZeroDevWallet.ts` — add to `sendOtp` and `magicLink send` AuthParams variants, pass through in both paths
- `packages/react/src/actions.ts` — add to `sendOTP` and `sendMagicLink` functions and namespace types
- `README.md`, `packages/core/README.md`, `packages/react/README.md` — document the new option

## Test plan
- [x] `pnpm build` passes
- [x] Manual test: call `sendOTP` with `otpCodeCustomization: { length: 8, alphanumeric: false }` and verify 8-digit code is received
- [x] Manual test: call `sendMagicLink` with `otpCodeCustomization` and verify code in magic link URL matches configured length
- [x] Verify omitting `otpCodeCustomization` still sends default 6-digit numeric code