### PR TITLE
release: @zerodev/wallet-core@0.0.1-alpha.13 and @zerodev/wallet-react@0.0.1-alpha.14

### DIFF
--- a/.changeset/add-otp-code-customization.md
+++ b/.changeset/add-otp-code-customization.md
@@ -1,0 +1,6 @@
+---
+"@zerodev/wallet-core": patch
+"@zerodev/wallet-react": patch
+---
+
+Add optional `otpCodeCustomization` parameter to OTP and magic link send flows for configuring code length (6-9) and alphanumeric mode

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -6,6 +6,7 @@
     "@zerodev/wallet-react": "0.0.1-alpha.0"
   },
   "changesets": [
+    "add-otp-code-customization",
     "busy-facts-brake",
     "calm-badgers-walk",
     "dry-cobras-smash",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @zerodev/wallet-core
 
+## 0.0.1-alpha.13
+
+### Patch Changes
+
+- Add optional `otpCodeCustomization` parameter to OTP and magic link send flows for configuring code length (6-9) and alphanumeric mode
+
 ## 0.0.1-alpha.12
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-core",
-  "version": "0.0.1-alpha.12",
+  "version": "0.0.1-alpha.13",
   "description": "ZeroDev Wallet SDK built on Turnkey",
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @zerodev/wallet-react
 
+## 0.0.1-alpha.14
+
+### Patch Changes
+
+- Add optional `otpCodeCustomization` parameter to OTP and magic link send flows for configuring code length (6-9) and alphanumeric mode
+- Updated dependencies
+  - @zerodev/wallet-core@0.0.1-alpha.13
+
 ## 0.0.1-alpha.13
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-react",
-  "version": "0.0.1-alpha.13",
+  "version": "0.0.1-alpha.14",
   "description": "React hooks for ZeroDev Wallet SDK",
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",


### PR DESCRIPTION
## Summary
- Bump `@zerodev/wallet-core` from `0.0.1-alpha.12` to `0.0.1-alpha.13`
- Bump `@zerodev/wallet-react` from `0.0.1-alpha.13` to `0.0.1-alpha.14`

## Changelog
- Add optional `otpCodeCustomization` parameter to OTP and magic link send flows for configuring code length (6-9) and alphanumeric mode