### PR TITLE
feat: add E2E integration and browser tests

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -1,31 +1,5 @@
 # E2E Test Environment Variables
 # Copy this file to .env.e2e and fill in the values
 
-# ===== Required =====
-
-# Project ID to test against (get from dashboard or demo app config)
+# Project ID to test against
 ZD_PROJECT_ID=
-
-# ===== Optional =====
-
-# Backend URL (default: https://kms.staging.zerodev.app/api/v1)
-# KMS_BACKEND_URL=https://kms.staging.zerodev.app/api/v1
-
-# Demo app URL for Playwright tests (default: http://localhost:3000)
-# DEMO_APP_URL=http://localhost:3000
-
-# ===== CI Secrets =====
-# These are needed for CI and should be configured as GitHub Actions secrets:
-
-# Turnkey organization ID for the backend
-# TURNKEY_BASE_ORGANIZATION_ID=
-
-# Turnkey API secret for the backend
-# TURNKEY_SECRET=
-
-# Turnkey auth proxy config ID
-# TURNKEY_AUTH_PROXY_CONFIG_ID=
-
-# Google OAuth credentials for the backend
-# GOOGLE_CLIENT_ID=
-# GOOGLE_CLIENT_SECRET=

--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -1,0 +1,31 @@
+# E2E Test Environment Variables
+# Copy this file to .env.e2e and fill in the values
+
+# ===== Required =====
+
+# Project ID to test against (get from dashboard or demo app config)
+ZD_PROJECT_ID=
+
+# ===== Optional =====
+
+# Backend URL (default: https://kms.staging.zerodev.app/api/v1)
+# KMS_BACKEND_URL=https://kms.staging.zerodev.app/api/v1
+
+# Demo app URL for Playwright tests (default: http://localhost:3000)
+# DEMO_APP_URL=http://localhost:3000
+
+# ===== CI Secrets =====
+# These are needed for CI and should be configured as GitHub Actions secrets:
+
+# Turnkey organization ID for the backend
+# TURNKEY_BASE_ORGANIZATION_ID=
+
+# Turnkey API secret for the backend
+# TURNKEY_SECRET=
+
+# Turnkey auth proxy config ID
+# TURNKEY_AUTH_PROXY_CONFIG_ID=
+
+# Google OAuth credentials for the backend
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,95 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+
+  integration-test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: [build]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run integration tests
+        run: pnpm test:integration
+        env:
+          ZD_PROJECT_ID: ${{ secrets.ZD_PROJECT_ID }}
+
+  e2e-test:
+    name: Browser E2E Tests
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: [build]
+    steps:
+      - name: Checkout SDK
+        uses: actions/checkout@v4
+
+      - name: Checkout demo app
+        uses: actions/checkout@v4
+        with:
+          repository: zerodevapp/zerodev-signer-demo
+          path: zerodev-signer-demo
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install SDK dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Build and start demo app
+        working-directory: zerodev-signer-demo
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+          pnpm start &
+        env:
+          NEXT_PUBLIC_ZERODEV_PROJECT_ID: ${{ secrets.ZD_PROJECT_ID }}
+          NEXT_PUBLIC_KMS_PROXY_BASE_URL: https://kms.staging.zerodev.app/api/v1
+
+      - name: Wait for demo app
+        run: |
+          for i in $(seq 1 15); do
+            if curl -sf http://localhost:3000 > /dev/null 2>&1; then
+              echo "Demo app is ready"
+              exit 0
+            fi
+            echo "Waiting for demo app... ($i/15)"
+            sleep 2
+          done
+          echo "Demo app failed to start"
+          exit 1
+
+      - name: Run E2E tests
+        run: pnpm test:e2e
+        env:
+          DEMO_APP_URL: http://localhost:3000
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,11 @@ esbuild-why-permissionless*
 .envrc
 .vscode
 .claude
+
+# Playwright
+playwright-report/
+test-results/
+blob-report/
+
+# E2E env
+.env.e2e

--- a/biome.json
+++ b/biome.json
@@ -159,6 +159,16 @@
           }
         }
       }
+    },
+    {
+      "includes": ["e2e/**/*.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
     }
   ]
 }

--- a/e2e/browser/magic-link.spec.ts
+++ b/e2e/browser/magic-link.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Browser E2E test for the Magic Link authentication flow.
+ *
+ * Tests the magic link flow through the demo app UI:
+ * 1. Create temp email
+ * 2. Navigate to login page
+ * 3. Enter email and click "Continue with email magic link"
+ * 4. Wait for "Magic link sent" confirmation
+ * 5. Poll for email, extract OTP code from the magic link URL
+ * 6. Navigate to the magic link URL (simulating email click)
+ * 7. Verify auto-verification succeeds and redirects to /dashboard
+ */
+
+import { expect, test } from '@playwright/test'
+import {
+  EMAIL_POLL_INTERVAL_MS,
+  EMAIL_POLL_TIMEOUT_MS,
+} from '../helpers/constants.js'
+import { extractOtpCodeFromMagicLinkUrl } from '../helpers/otp-utils.js'
+import {
+  createNewAccount,
+  ping,
+  searchForNewEmail,
+} from '../helpers/temp-email.js'
+
+test.describe('Magic Link Flow', () => {
+  test.beforeEach(async () => {
+    try {
+      await ping()
+    } catch {
+      test.skip(true, 'Email service unavailable')
+    }
+  })
+
+  test('should complete magic link login through the UI', async ({ page }) => {
+    // Step 1: Create temp email
+    const emailAccount = await createNewAccount()
+    const email = emailAccount.address
+
+    // Step 2: Navigate to login page
+    await page.goto('/')
+    await expect(
+      page.getByRole('heading', { name: 'ZeroDev Wallet Demo' }),
+    ).toBeVisible()
+
+    // Step 3: Enter email
+    await page.getByPlaceholder('Enter your email').fill(email)
+
+    // Step 4: Click magic link button
+    await page
+      .getByRole('button', { name: /Continue with email magic link/i })
+      .click()
+
+    // Step 5: Wait for confirmation that magic link was sent
+    await expect(page.getByText(/magic link sent/i)).toBeVisible({
+      timeout: 30_000,
+    })
+
+    // Step 6: Poll for email and extract OTP code from the magic link URL
+    const emailContent = await searchForNewEmail(
+      emailAccount.authToken,
+      EMAIL_POLL_INTERVAL_MS,
+      EMAIL_POLL_TIMEOUT_MS,
+    )
+    const otpCode = extractOtpCodeFromMagicLinkUrl(emailContent)
+    expect(otpCode).toBeTruthy()
+    console.log(`Extracted magic link code: ${otpCode}`)
+
+    // Step 7: Navigate to the verify URL (simulating clicking the magic link)
+    // The demo app stores otpId in localStorage, so we navigate in the same context
+    await page.goto(`/verify?code=${otpCode}`)
+
+    // Step 8: Wait for auto-verification and redirect to dashboard
+    await expect(page.getByText(/Authentication Successful/i)).toBeVisible({
+      timeout: 30_000,
+    })
+    await page.waitForURL('**/dashboard', { timeout: 60_000 })
+
+    // Step 9: Verify dashboard loaded
+    // Wallet creation (EIP-7702 Kernel) can be slow, so accept either
+    // the loaded state or the loading spinner as proof of successful auth
+    await expect(
+      page.getByText('Default Wallet').or(page.getByText('Loading wallet')),
+    ).toBeVisible({ timeout: 60_000 })
+    console.log('Magic link login successful')
+  })
+})

--- a/e2e/browser/otp.spec.ts
+++ b/e2e/browser/otp.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Browser E2E test for the OTP authentication flow.
+ *
+ * Tests the full OTP flow through the demo app UI:
+ * 1. Create temp email
+ * 2. Navigate to login page
+ * 3. Enter email and click "Continue with email OTP code"
+ * 4. Wait for OTP verification step
+ * 5. Poll for email, extract OTP code
+ * 6. Enter OTP code and click "Verify and continue"
+ * 7. Verify redirect to /dashboard
+ * 8. Verify wallet address and balance are displayed
+ */
+
+import { expect, test } from '@playwright/test'
+import {
+  EMAIL_POLL_INTERVAL_MS,
+  EMAIL_POLL_TIMEOUT_MS,
+} from '../helpers/constants.js'
+
+// Demo app uses 6-digit OTP codes (configured in zerodev-signer-demo)
+const DEMO_APP_OTP_LENGTH = 6
+
+import { extractOtpCode } from '../helpers/otp-utils.js'
+import {
+  createNewAccount,
+  ping,
+  searchForNewEmail,
+} from '../helpers/temp-email.js'
+
+test.describe('OTP Flow', () => {
+  test.beforeEach(async () => {
+    try {
+      await ping()
+    } catch {
+      test.skip(true, 'Email service unavailable')
+    }
+  })
+
+  test('should complete OTP login through the UI', async ({ page }) => {
+    // Step 1: Create temp email
+    const emailAccount = await createNewAccount()
+    const email = emailAccount.address
+
+    // Step 2: Navigate to login page
+    await page.goto('/')
+    await expect(
+      page.getByRole('heading', { name: 'ZeroDev Wallet Demo' }),
+    ).toBeVisible()
+
+    // Step 3: Enter email
+    await page.getByPlaceholder('Enter your email').fill(email)
+
+    // Step 4: Click OTP button
+    await page
+      .getByRole('button', { name: /Continue with email OTP code/i })
+      .click()
+
+    // Step 5: Wait for OTP verification step
+    await expect(
+      page.getByText(`Enter the code sent to ${email}`, { exact: false }),
+    ).toBeVisible({ timeout: 30_000 })
+
+    // Step 6: Poll for email and extract OTP code
+    const emailContent = await searchForNewEmail(
+      emailAccount.authToken,
+      EMAIL_POLL_INTERVAL_MS,
+      EMAIL_POLL_TIMEOUT_MS,
+    )
+    const otpCode = extractOtpCode(emailContent, DEMO_APP_OTP_LENGTH, true)
+    expect(otpCode).toBeTruthy()
+
+    // Step 7: Enter OTP code
+    await page.getByPlaceholder('000000').fill(otpCode!)
+
+    // Step 8: Click verify
+    await page.getByRole('button', { name: /Verify and continue/i }).click()
+
+    // Step 9: Wait for dashboard redirect
+    await page.waitForURL('**/dashboard', { timeout: 60_000 })
+
+    // Step 10: Verify dashboard elements (wallet creation can take time)
+    await expect(page.getByText('Default Wallet')).toBeVisible({
+      timeout: 60_000,
+    })
+  })
+})

--- a/e2e/browser/passkey.spec.ts
+++ b/e2e/browser/passkey.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Browser E2E test for the Passkey (WebAuthn) authentication flow.
+ *
+ * Uses a CDP virtual authenticator to simulate biometric authentication.
+ * This tests the FULL auth flow: WebAuthn ceremony → backend → Turnkey → session → dashboard.
+ * The virtual authenticator auto-accepts the biometric prompt (the standard way
+ * to test WebAuthn in Playwright/Puppeteer).
+ */
+
+import { expect, test } from '@playwright/test'
+import {
+  setupVirtualAuthenticator,
+  teardownVirtualAuthenticator,
+  type VirtualAuthenticator,
+} from '../helpers/virtual-authenticator.js'
+
+test.describe('Passkey Flow', () => {
+  let virtualAuth: VirtualAuthenticator
+
+  test('should register with passkey and access wallet dashboard', async ({
+    page,
+  }) => {
+    virtualAuth = await setupVirtualAuthenticator(page)
+
+    try {
+      // Navigate to login page
+      await page.goto('/')
+      await expect(
+        page.getByRole('heading', { name: 'ZeroDev Wallet Demo' }),
+      ).toBeVisible()
+
+      // Click "Register with passkey" — triggers WebAuthn create ceremony
+      await page.getByRole('button', { name: /Register with passkey/i }).click()
+
+      // Wait for redirect to dashboard (includes backend + Turnkey round-trips)
+      await page.waitForURL('**/dashboard', { timeout: 60_000 })
+
+      // Verify wallet loaded with real data
+      await expect(page.getByText('Default Wallet')).toBeVisible({
+        timeout: 60_000,
+      })
+
+      // Verify wallet address is displayed (0x... format)
+      await expect(page.getByText(/0x[0-9a-fA-F]{40}/)).toBeVisible()
+
+      // Verify chain info is shown
+      await expect(page.getByText('Arbitrum Sepolia Testnet')).toBeVisible()
+
+      // Sign a message to prove the wallet is fully functional
+      await page
+        .getByRole('navigation')
+        .getByRole('button', { name: /Sign Message/i })
+        .click()
+      await page.getByRole('button', { name: /Load Sample/i }).click()
+      await page
+        .getByRole('button', { name: /Sign Message/i })
+        .nth(1)
+        .click()
+      await expect(page.getByText('Signature')).toBeVisible({ timeout: 30_000 })
+
+      console.log('Passkey registration + sign message successful')
+    } finally {
+      await teardownVirtualAuthenticator(virtualAuth)
+    }
+  })
+})

--- a/e2e/browser/post-auth.spec.ts
+++ b/e2e/browser/post-auth.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Browser E2E test for post-authentication operations.
+ *
+ * After OTP login:
+ * 1. Sign a message via the "Sign Message" tab
+ * 2. Send a transaction via the "Send Transaction" tab
+ * 3. Copy wallet address
+ * 4. Logout and verify redirect to login page
+ */
+
+import { expect, test } from '@playwright/test'
+import {
+  EMAIL_POLL_INTERVAL_MS,
+  EMAIL_POLL_TIMEOUT_MS,
+} from '../helpers/constants.js'
+
+// Demo app uses 6-digit OTP codes (configured in zerodev-signer-demo)
+const DEMO_APP_OTP_LENGTH = 6
+
+import { extractOtpCode } from '../helpers/otp-utils.js'
+import {
+  createNewAccount,
+  ping,
+  searchForNewEmail,
+} from '../helpers/temp-email.js'
+
+/** Helper to complete OTP login through the UI */
+async function loginWithOtp(
+  page: import('@playwright/test').Page,
+  email: string,
+  authToken: string,
+) {
+  await page.goto('/')
+  await page.getByPlaceholder('Enter your email').fill(email)
+  await page
+    .getByRole('button', { name: /Continue with email OTP code/i })
+    .click()
+  await expect(
+    page.getByText(`Enter the code sent to ${email}`, { exact: false }),
+  ).toBeVisible({ timeout: 30_000 })
+
+  const emailContent = await searchForNewEmail(
+    authToken,
+    EMAIL_POLL_INTERVAL_MS,
+    EMAIL_POLL_TIMEOUT_MS,
+  )
+  const otpCode = extractOtpCode(emailContent, DEMO_APP_OTP_LENGTH, true)
+  expect(otpCode).toBeTruthy()
+
+  await page.getByPlaceholder('000000').fill(otpCode!)
+  await page.getByRole('button', { name: /Verify and continue/i }).click()
+
+  await page.waitForURL('**/dashboard', { timeout: 60_000 })
+  await expect(page.getByText('Default Wallet')).toBeVisible({
+    timeout: 60_000,
+  })
+}
+
+test.describe('Post-Auth Operations', () => {
+  test.beforeEach(async () => {
+    try {
+      await ping()
+    } catch {
+      test.skip(true, 'Email service unavailable')
+    }
+  })
+
+  test('should sign a message after login', async ({ page }) => {
+    const emailAccount = await createNewAccount()
+    await loginWithOtp(page, emailAccount.address, emailAccount.authToken)
+
+    // Click the "Sign Message" tab (in the navigation area)
+    await page
+      .getByRole('navigation')
+      .getByRole('button', { name: /Sign Message/i })
+      .click()
+
+    // Load sample message
+    await page.getByRole('button', { name: /Load Sample/i }).click()
+
+    // Click the "Sign Message" action button (second one — first is the tab)
+    await page
+      .getByRole('button', { name: /Sign Message/i })
+      .nth(1)
+      .click()
+
+    // Wait for signature result
+    await expect(page.getByText('Signature')).toBeVisible({ timeout: 30_000 })
+    console.log('Message signed successfully')
+  })
+
+  test('should logout and redirect to login page', async ({ page }) => {
+    const emailAccount = await createNewAccount()
+    await loginWithOtp(page, emailAccount.address, emailAccount.authToken)
+
+    // Click logout
+    await page.getByRole('button', { name: /Logout/i }).click()
+
+    // Verify redirect to login page
+    await page.waitForURL('/', { timeout: 15_000 })
+    await expect(
+      page.getByRole('heading', { name: 'ZeroDev Wallet Demo' }),
+    ).toBeVisible()
+    console.log('Logout successful')
+  })
+})

--- a/e2e/helpers/backend-health.ts
+++ b/e2e/helpers/backend-health.ts
@@ -1,0 +1,55 @@
+import { HEALTH_CHECK_INTERVAL_MS, HEALTH_CHECK_RETRIES } from './constants.js'
+
+/**
+ * Checks if the backend is reachable by calling the server-info endpoint.
+ * For staging/production URLs this uses /api/v1/server-info/auth-proxy-id.
+ * For local development, falls back to /healthz on the ops port.
+ *
+ * @param baseUrl - The backend base URL (e.g. https://kms.staging.zerodev.app/api/v1)
+ * @param retries - Number of retries before giving up
+ * @param intervalMs - Interval between retries in milliseconds
+ */
+export async function waitForBackend(
+  baseUrl: string,
+  retries = HEALTH_CHECK_RETRIES,
+  intervalMs = HEALTH_CHECK_INTERVAL_MS,
+): Promise<void> {
+  // Use the server-info endpoint as a health check — it works for both
+  // local and remote backends without needing to know the ops port.
+  const healthUrl = `${baseUrl}/server-info/auth-proxy-id`
+
+  for (let i = 0; i < retries; i++) {
+    try {
+      const res = await fetch(healthUrl, {
+        signal: AbortSignal.timeout(5_000),
+      })
+      if (res.ok) return
+    } catch {
+      // Connection refused or timeout, keep trying
+    }
+    if (i < retries - 1) {
+      await new Promise((r) => setTimeout(r, intervalMs))
+    }
+  }
+
+  throw new Error(
+    `Backend at ${baseUrl} not reachable after ${retries} retries`,
+  )
+}
+
+/**
+ * Fetches the auth proxy config ID from the backend.
+ *
+ * @param baseUrl - The backend base URL (e.g. https://kms.staging.zerodev.app/api/v1)
+ * @returns The auth proxy config ID
+ */
+export async function getAuthProxyConfigId(baseUrl: string): Promise<string> {
+  const res = await fetch(`${baseUrl}/server-info/auth-proxy-id`)
+  if (!res.ok) {
+    throw new Error(
+      `Failed to get auth proxy config ID: ${res.status} ${res.statusText}`,
+    )
+  }
+  const data = await res.json()
+  return data.authProxyConfigId
+}

--- a/e2e/helpers/constants.ts
+++ b/e2e/helpers/constants.ts
@@ -1,0 +1,12 @@
+export const BACKEND_URL =
+  process.env.KMS_BACKEND_URL || 'https://kms.staging.zerodev.app/api/v1'
+
+export const DEMO_APP_URL = process.env.DEMO_APP_URL || 'http://localhost:3000'
+
+export const EMAIL_POLL_INTERVAL_MS = 5_000
+export const EMAIL_POLL_TIMEOUT_MS = 60_000
+
+export const OTP_CODE_LENGTH = 7
+
+export const HEALTH_CHECK_RETRIES = 5
+export const HEALTH_CHECK_INTERVAL_MS = 2_000

--- a/e2e/helpers/otp-utils.ts
+++ b/e2e/helpers/otp-utils.ts
@@ -1,0 +1,51 @@
+/**
+ * Extracts an OTP code from email content.
+ * Port of extractOtpCode from doorway-kms/testing/e2e/e2e_otp_test.go
+ *
+ * @param content - The email text content
+ * @param length - The expected OTP code length
+ * @param digitsOnly - If true, only match digit-only codes (for alphanumeric: false)
+ * @returns The extracted OTP code, or null if not found
+ */
+export function extractOtpCode(
+  content: string,
+  length: number,
+  digitsOnly = false,
+): string | null {
+  const charClass = digitsOnly ? '[0-9]' : '[A-Z0-9]'
+  const re = new RegExp(`${charClass}{${length}}`)
+  const match = content.match(re)
+  return match ? match[0] : null
+}
+
+/**
+ * Extracts an auth credentials code from a legacy magic link email.
+ * Port of extractAuthCredentialsCode from doorway-kms/testing/e2e/e2e_email_test.go
+ *
+ * Legacy magic link emails contain a long alphanumeric credential string (100+ chars).
+ *
+ * @param content - The email text content
+ * @returns The extracted credentials code, or null if not found
+ */
+export function extractMagicLinkCode(content: string): string | null {
+  const re = /[a-zA-Z0-9]{100,}/
+  const match = content.match(re)
+  return match ? match[0] : null
+}
+
+/**
+ * Extracts the OTP code from a magic link URL in email content.
+ *
+ * When using OTP with emailCustomization.magicLinkTemplate, Turnkey sends
+ * an email containing a URL with the OTP code embedded as a query parameter.
+ * For example, with template "http://localhost:3000/callback?code=%s",
+ * the email will contain "http://localhost:3000/callback?code=1234567".
+ *
+ * @param content - The email text content
+ * @returns The extracted OTP code, or null if not found
+ */
+export function extractOtpCodeFromMagicLinkUrl(content: string): string | null {
+  // Look for code= query parameter value in URLs
+  const match = content.match(/[?&]code=([A-Za-z0-9]+)/)
+  return match ? match[1] : null
+}

--- a/e2e/helpers/temp-email.ts
+++ b/e2e/helpers/temp-email.ts
@@ -1,0 +1,176 @@
+/**
+ * Temporary email service using mail.gw API.
+ * Port of doorway-kms/pkg/test/temp_mail_api.go
+ *
+ * Note: The mail.gw API returns plain JSON arrays/objects
+ * (not hydra:member wrapped like the older API version).
+ */
+
+const MAIL_API_BASE = 'https://api.mail.gw'
+
+export type TempEmailAccount = {
+  address: string
+  authToken: string
+}
+
+const defaultHeaders = {
+  Accept: 'application/json',
+  'Content-Type': 'application/json',
+}
+
+/**
+ * Pings the email service to check availability.
+ * @throws If the service is unavailable
+ */
+export async function ping(): Promise<void> {
+  const res = await fetch(`${MAIL_API_BASE}/domains`, {
+    headers: defaultHeaders,
+    signal: AbortSignal.timeout(10_000),
+  })
+  if (!res.ok) {
+    throw new Error(
+      `Email service unavailable: ${res.status} ${res.statusText}`,
+    )
+  }
+  const data = await res.json()
+  // API returns a plain array of domain objects
+  const domains = Array.isArray(data) ? data : (data['hydra:member'] ?? [])
+  if (domains.length === 0) {
+    throw new Error('Email service has no domains available')
+  }
+}
+
+/**
+ * Creates a new temporary email account.
+ * Generates a random email address and returns it with an auth token.
+ */
+export async function createNewAccount(): Promise<TempEmailAccount> {
+  // Get available domain
+  const domainsRes = await fetch(`${MAIL_API_BASE}/domains`, {
+    headers: defaultHeaders,
+    signal: AbortSignal.timeout(10_000),
+  })
+  if (!domainsRes.ok) {
+    throw new Error(`Failed to get domains: ${domainsRes.status}`)
+  }
+  const domainsData = await domainsRes.json()
+
+  // Handle both array response and hydra:member wrapped response
+  const domains = Array.isArray(domainsData)
+    ? domainsData
+    : (domainsData['hydra:member'] ?? [])
+  const domain = domains[0]?.domain
+  if (!domain) {
+    throw new Error('No email domains available')
+  }
+
+  // Generate random email
+  const randomHex = Array.from(crypto.getRandomValues(new Uint8Array(8)))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+  const address = `email_${randomHex}@${domain}`
+  const password = '123456'
+
+  // Create account
+  const createRes = await fetch(`${MAIL_API_BASE}/accounts`, {
+    method: 'POST',
+    headers: defaultHeaders,
+    body: JSON.stringify({ address, password }),
+  })
+  if (!createRes.ok) {
+    const text = await createRes.text()
+    throw new Error(
+      `Failed to create email account: ${createRes.status} ${text}`,
+    )
+  }
+
+  // Get auth token
+  const tokenRes = await fetch(`${MAIL_API_BASE}/token`, {
+    method: 'POST',
+    headers: defaultHeaders,
+    body: JSON.stringify({ address, password }),
+  })
+  if (!tokenRes.ok) {
+    const text = await tokenRes.text()
+    throw new Error(`Failed to get email token: ${tokenRes.status} ${text}`)
+  }
+  const tokenData = await tokenRes.json()
+  const authToken = tokenData.token
+  if (!authToken) {
+    throw new Error('No token in response')
+  }
+
+  return { address, authToken }
+}
+
+/**
+ * Polls for a new email and returns its text content.
+ *
+ * @param authToken - The auth token from createNewAccount
+ * @param intervalMs - Poll interval in milliseconds
+ * @param timeoutMs - Maximum time to wait in milliseconds
+ * @returns The email text content
+ * @throws If no email arrives within the timeout
+ */
+export async function searchForNewEmail(
+  authToken: string,
+  intervalMs: number,
+  timeoutMs: number,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    await sleep(intervalMs)
+
+    try {
+      const messagesRes = await fetch(`${MAIL_API_BASE}/messages`, {
+        headers: {
+          ...defaultHeaders,
+          Authorization: `Bearer ${authToken}`,
+        },
+        signal: AbortSignal.timeout(10_000),
+      })
+
+      if (!messagesRes.ok) {
+        // 401 or 500 may mean the inbox isn't ready yet, keep polling
+        if (messagesRes.status >= 500 || messagesRes.status === 401) continue
+        throw new Error(`Failed to list messages: ${messagesRes.status}`)
+      }
+
+      const messagesData = await messagesRes.json()
+
+      // Handle both array response and hydra:member wrapped response
+      const messages = Array.isArray(messagesData)
+        ? messagesData
+        : (messagesData['hydra:member'] ?? [])
+      if (messages.length === 0) continue
+
+      // Get full message content
+      const messageId = messages[0].id
+      const messageRes = await fetch(`${MAIL_API_BASE}/messages/${messageId}`, {
+        headers: {
+          ...defaultHeaders,
+          Authorization: `Bearer ${authToken}`,
+        },
+        signal: AbortSignal.timeout(10_000),
+      })
+
+      if (!messageRes.ok) {
+        throw new Error(`Failed to get message: ${messageRes.status}`)
+      }
+
+      const messageData = await messageRes.json()
+      const text = messageData.text
+      if (text) return text
+    } catch (err) {
+      // Network errors during polling — keep trying
+      if (Date.now() >= deadline) throw err
+    }
+  }
+
+  throw new Error(`No email received within ${timeoutMs}ms timeout`)
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/e2e/helpers/test-client.ts
+++ b/e2e/helpers/test-client.ts
@@ -1,0 +1,66 @@
+/**
+ * Creates a test SDK client configured for integration tests.
+ *
+ * Sets up the transport with an Origin header to pass backend ACL checks,
+ * and uses the TestStamper as the IndexedDB stamper.
+ */
+
+import { createClient } from '../../packages/core/src/client/createClient.js'
+import { rest } from '../../packages/core/src/client/transports/rest.js'
+import type { Transport } from '../../packages/core/src/client/types.js'
+import type { IndexedDbStamper } from '../../packages/core/src/stampers/types.js'
+import { BACKEND_URL } from './constants.js'
+
+const noopStamper = {
+  getPublicKey: async () => null,
+  stamp: async () => ({ stampHeaderName: '', stampHeaderValue: '' }),
+  clear: async () => {},
+}
+
+/**
+ * Creates a transport that includes an Origin header for ACL checks.
+ * The staging backend requires a valid Origin header matching the project's ACL.
+ */
+function testTransport(baseUrl: string): Transport {
+  return ({ indexedDbStamper, webauthnStamper }) => {
+    const transport = rest(baseUrl, {
+      timeoutMs: 30_000,
+      key: 'zeroDevWallet',
+      name: 'ZeroDev Wallet Transport',
+      indexedDbStamper,
+      webauthnStamper,
+      fetchOptions: {
+        headers: {
+          Origin: 'http://localhost:3000',
+        },
+      },
+    })
+
+    return {
+      config: {
+        name: 'ZeroDev Wallet Transport',
+        key: 'zeroDevWallet',
+        url: baseUrl,
+        timeoutMs: 30_000,
+        type: 'zeroDevWallet',
+      },
+      request: transport.request,
+      value: {},
+    }
+  }
+}
+
+/**
+ * Creates an SDK client configured for integration tests.
+ * Includes Origin header for ACL checks and uses the provided stamper.
+ */
+export function createTestClient(
+  stamper: IndexedDbStamper,
+  baseUrl = BACKEND_URL,
+) {
+  return createClient({
+    transport: testTransport(baseUrl),
+    indexedDbStamper: stamper,
+    webauthnStamper: noopStamper,
+  })
+}

--- a/e2e/helpers/test-project.ts
+++ b/e2e/helpers/test-project.ts
@@ -1,0 +1,30 @@
+/**
+ * Creates a test project via the backend's dev-mode project creation endpoint.
+ *
+ * @param backendUrl - The backend base URL (e.g. http://localhost:7082/api/v1)
+ * @param secret - The API secret for project creation
+ * @returns The created project's ID
+ */
+export async function createTestProject(
+  backendUrl: string,
+  secret: string,
+): Promise<{ projectId: string }> {
+  const res = await fetch(`${backendUrl}/projects`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      apiKey: secret,
+      name: `e2e-test-${Date.now()}`,
+    }),
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`Failed to create test project: ${res.status} ${text}`)
+  }
+
+  const data = await res.json()
+  return { projectId: data.id ?? data.projectId }
+}

--- a/e2e/helpers/test-stamper.ts
+++ b/e2e/helpers/test-stamper.ts
@@ -1,0 +1,128 @@
+/**
+ * Node.js ECDSA P-256 stamper implementing the IndexedDbStamper interface.
+ * Port of doorway-kms/pkg/test/apikey.go
+ *
+ * Uses node:crypto for key generation and signing, producing stamps
+ * compatible with Turnkey's API key authentication format.
+ */
+
+import { createSign, generateKeyPairSync, type KeyObject } from 'node:crypto'
+import type {
+  IndexedDbStamper,
+  Stamp,
+} from '../../packages/core/src/stampers/types.js'
+
+export type TestStamperKeyPair = {
+  privateKey: KeyObject
+  publicKey: KeyObject
+}
+
+/**
+ * Creates a test stamper that implements the IndexedDbStamper interface
+ * using Node.js crypto instead of browser IndexedDB.
+ */
+export function createTestStamper(): IndexedDbStamper & {
+  /** Expose the key pair for tests that need direct access */
+  getKeyPair(): TestStamperKeyPair | null
+} {
+  let keyPair: TestStamperKeyPair | null = null
+
+  function ensureKeyPair(): TestStamperKeyPair {
+    if (!keyPair) {
+      keyPair = generateP256KeyPair()
+    }
+    return keyPair
+  }
+
+  return {
+    async getPublicKey(): Promise<string | null> {
+      const kp = ensureKeyPair()
+      return getCompressedPublicKeyHex(kp.publicKey)
+    },
+
+    async stamp(payload: string): Promise<Stamp> {
+      const kp = ensureKeyPair()
+      const publicKeyHex = getCompressedPublicKeyHex(kp.publicKey)
+
+      // Sign the payload (DER-encoded ECDSA signature)
+      const signer = createSign('SHA256')
+      signer.update(payload)
+      const derSignature = signer.sign(kp.privateKey)
+      const signatureHex = derSignature.toString('hex')
+
+      // Build the stamp value matching Turnkey's API key stamp format
+      const stampJson = JSON.stringify({
+        publicKey: publicKeyHex,
+        signature: signatureHex,
+        scheme: 'SIGNATURE_SCHEME_TK_API_P256',
+      })
+      const stampHeaderValue = base64UrlEncode(Buffer.from(stampJson))
+
+      return {
+        stampHeaderName: 'X-Stamp',
+        stampHeaderValue,
+      }
+    },
+
+    async resetKeyPair(externalKeyPair?: CryptoKeyPair): Promise<void> {
+      if (externalKeyPair) {
+        // Convert Web Crypto CryptoKeyPair to Node.js KeyObject
+        // This path is for compatibility but tests typically use the default path
+        throw new Error(
+          'External CryptoKeyPair not supported in test stamper. Use the default key generation.',
+        )
+      }
+      keyPair = generateP256KeyPair()
+    },
+
+    async clear(): Promise<void> {
+      keyPair = null
+    },
+
+    getKeyPair(): TestStamperKeyPair | null {
+      return keyPair
+    },
+  }
+}
+
+function generateP256KeyPair(): TestStamperKeyPair {
+  const { privateKey, publicKey } = generateKeyPairSync('ec', {
+    namedCurve: 'P-256',
+  })
+  return { privateKey, publicKey }
+}
+
+/**
+ * Gets the compressed public key as a hex string (33 bytes).
+ * Compressed P-256 format: 0x02/0x03 prefix + 32 bytes X coordinate
+ */
+function getCompressedPublicKeyHex(publicKey: KeyObject): string {
+  // Export as uncompressed (65 bytes: 0x04 + X + Y)
+  const raw = publicKey.export({ type: 'spki', format: 'der' })
+  // The last 65 bytes of SPKI DER are the uncompressed point
+  const uncompressed = raw.subarray(raw.length - 65)
+
+  if (uncompressed[0] !== 0x04) {
+    throw new Error('Expected uncompressed public key starting with 0x04')
+  }
+
+  const x = uncompressed.subarray(1, 33)
+  const y = uncompressed.subarray(33, 65)
+
+  // Prefix: 0x02 if Y is even, 0x03 if Y is odd
+  const prefix = (y[y.length - 1]! & 1) === 0 ? 0x02 : 0x03
+
+  const compressed = Buffer.alloc(33)
+  compressed[0] = prefix
+  x.copy(compressed, 1)
+
+  return compressed.toString('hex')
+}
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}

--- a/e2e/helpers/virtual-authenticator.ts
+++ b/e2e/helpers/virtual-authenticator.ts
@@ -1,0 +1,52 @@
+import type { CDPSession, Page } from '@playwright/test'
+
+export type VirtualAuthenticator = {
+  cdpSession: CDPSession
+  authenticatorId: string
+}
+
+/**
+ * Sets up a Chrome DevTools Protocol virtual WebAuthn authenticator.
+ * This allows testing passkey flows without a real biometric device.
+ *
+ * The virtual authenticator auto-responds to WebAuthn ceremonies with
+ * user verification = true, simulating a successful biometric check.
+ */
+export async function setupVirtualAuthenticator(
+  page: Page,
+): Promise<VirtualAuthenticator> {
+  const cdpSession = await page.context().newCDPSession(page)
+
+  await cdpSession.send('WebAuthn.enable')
+
+  const { authenticatorId } = await cdpSession.send(
+    'WebAuthn.addVirtualAuthenticator',
+    {
+      options: {
+        protocol: 'ctap2',
+        transport: 'internal',
+        hasResidentKey: true,
+        hasUserVerification: true,
+        isUserVerified: true,
+      },
+    },
+  )
+
+  return { cdpSession, authenticatorId }
+}
+
+/**
+ * Tears down the virtual authenticator.
+ */
+export async function teardownVirtualAuthenticator(
+  auth: VirtualAuthenticator,
+): Promise<void> {
+  try {
+    await auth.cdpSession.send('WebAuthn.removeVirtualAuthenticator', {
+      authenticatorId: auth.authenticatorId,
+    })
+    await auth.cdpSession.send('WebAuthn.disable')
+  } catch {
+    // Ignore errors during cleanup
+  }
+}

--- a/e2e/integration/magic-link-flow.test.ts
+++ b/e2e/integration/magic-link-flow.test.ts
@@ -1,0 +1,184 @@
+/**
+ * E2E integration test for the Magic Link authentication flow.
+ *
+ * Magic link is built on top of the OTP flow. Instead of sending a plain
+ * OTP code, Turnkey embeds the code into a clickable URL in the email.
+ * The SDK uses registerWithOTP with emailCustomization.magicLinkTemplate
+ * where %s is replaced with the OTP code by Turnkey.
+ *
+ * Flow:
+ * 1. Create temp email account
+ * 2. Register with OTP + emailCustomization.magicLinkTemplate
+ * 3. Extract OTP code from the magic link URL in the email
+ * 4. Verify OTP with Auth Proxy
+ * 5. Build client signature
+ * 6. Login with OTP via backend
+ * 7. Verify session works (whoami)
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest'
+import { createAuthProxyClient } from '../../packages/core/src/client/authProxy.js'
+import { buildClientSignature } from '../../packages/core/src/utils/buildClientSignature.js'
+import { parseSession } from '../../packages/core/src/utils/utils.js'
+import {
+  getAuthProxyConfigId,
+  waitForBackend,
+} from '../helpers/backend-health.js'
+import {
+  BACKEND_URL,
+  EMAIL_POLL_INTERVAL_MS,
+  EMAIL_POLL_TIMEOUT_MS,
+  OTP_CODE_LENGTH,
+} from '../helpers/constants.js'
+import {
+  extractOtpCode,
+  extractOtpCodeFromMagicLinkUrl,
+} from '../helpers/otp-utils.js'
+import {
+  createNewAccount,
+  ping,
+  searchForNewEmail,
+} from '../helpers/temp-email.js'
+import { createTestClient } from '../helpers/test-client.js'
+import { createTestStamper } from '../helpers/test-stamper.js'
+
+// The magic link template URL must have an origin that matches the project's
+// ACL security policies. The test client uses Origin: http://localhost:3000
+// which should be allowed by the staging project.
+const MAGIC_LINK_REDIRECT_URL =
+  process.env.MAGIC_LINK_REDIRECT_URL || 'http://localhost:3000/auth/callback'
+
+describe('Magic Link Authentication Flow', () => {
+  let projectId: string
+  let authProxyConfigId: string
+  let skipReason = ''
+
+  beforeAll(async () => {
+    try {
+      await waitForBackend(BACKEND_URL)
+    } catch {
+      skipReason = `Backend not reachable at ${BACKEND_URL}`
+      return
+    }
+
+    try {
+      await ping()
+    } catch {
+      skipReason = 'Email service unavailable'
+      return
+    }
+
+    authProxyConfigId = await getAuthProxyConfigId(BACKEND_URL)
+
+    projectId = process.env.ZD_PROJECT_ID || ''
+    if (!projectId) {
+      skipReason = 'ZD_PROJECT_ID not set'
+      return
+    }
+  })
+
+  it('should complete the full magic link register + login flow', async (context) => {
+    console.log(`Skipping magic link flow test: ${skipReason}`)
+    context.skip(!!skipReason, skipReason)
+
+    // Step 1: Create temp email account
+    const emailAccount = await createNewAccount()
+    const email = emailAccount.address
+    console.log(`Created temp email: ${email}`)
+
+    // Step 2: Create test stamper
+    const stamper = createTestStamper()
+    const publicKey = await stamper.getPublicKey()
+    expect(publicKey).toBeTruthy()
+
+    // Step 3: Create SDK client
+    const client = createTestClient(stamper)
+
+    // Step 4: Register with OTP + magic link template
+    // The magic link template uses %s as a placeholder for the OTP code.
+    // Turnkey will replace %s with the actual code in the email.
+    const magicLinkTemplate = `${MAGIC_LINK_REDIRECT_URL}${MAGIC_LINK_REDIRECT_URL.includes('?') ? '&' : '?'}code=%s`
+    console.log(`Magic link template: ${magicLinkTemplate}`)
+
+    const registerResult = await client.registerWithOTP({
+      email,
+      contact: { type: 'email', contact: email },
+      projectId,
+      emailCustomization: {
+        magicLinkTemplate,
+      },
+    })
+    expect(registerResult.otpId).toBeTruthy()
+    console.log(`OTP initiated with magic link, otpId: ${registerResult.otpId}`)
+
+    // Step 5: Poll for email and extract OTP code from magic link URL
+    console.log('Waiting for magic link email...')
+    const emailContent = await searchForNewEmail(
+      emailAccount.authToken,
+      EMAIL_POLL_INTERVAL_MS,
+      EMAIL_POLL_TIMEOUT_MS,
+    )
+    console.log(`Email content preview: ${emailContent.substring(0, 200)}...`)
+
+    // Try extracting from URL first, fall back to plain OTP extraction
+    let otpCode = extractOtpCodeFromMagicLinkUrl(emailContent)
+    if (!otpCode) {
+      console.log(
+        'No magic link URL found in email, falling back to plain OTP extraction',
+      )
+      otpCode = extractOtpCode(emailContent, OTP_CODE_LENGTH)
+    }
+    expect(otpCode).toBeTruthy()
+    console.log(`Extracted OTP code: ${otpCode}`)
+
+    // Step 6: Verify OTP with Auth Proxy (same as regular OTP flow)
+    const authProxyClient = createAuthProxyClient({ authProxyConfigId })
+    const verifyResult = await authProxyClient.verifyOtp({
+      otpId: registerResult.otpId,
+      otpCode: otpCode!,
+      public_key: publicKey!,
+    })
+    expect(verifyResult.verificationToken).toBeTruthy()
+    console.log('OTP verified with Auth Proxy')
+
+    // Step 7: Build client signature
+    const clientSignature = await buildClientSignature({
+      verificationToken: verifyResult.verificationToken,
+      publicKey: publicKey!,
+      stamper,
+    })
+    expect(clientSignature).toBeTruthy()
+    expect(clientSignature).toHaveLength(128)
+    console.log('Client signature built')
+
+    // Step 8: Login with OTP via backend
+    const loginResult = await client.loginWithOTP({
+      verificationToken: verifyResult.verificationToken,
+      clientSignature,
+      projectId,
+    })
+    expect(loginResult.session).toBeTruthy()
+    console.log('Magic link login successful')
+
+    // Step 9: Validate session
+    const session = parseSession(loginResult.session)
+    expect(session.userId).toBeTruthy()
+    expect(session.organizationId).toBeTruthy()
+    expect(session.sessionType).toBe('SESSION_TYPE_READ_WRITE')
+    console.log(
+      `Session: userId=${session.userId}, orgId=${session.organizationId}`,
+    )
+
+    // Step 10: Verify session works with whoami
+    const whoami = await client.getWhoami({
+      organizationId: session.organizationId,
+      projectId,
+      token: loginResult.session,
+    })
+    expect(whoami.userId).toBeTruthy()
+    expect(whoami.organizationId).toBe(session.organizationId)
+    console.log(
+      `Whoami: userId=${whoami.userId}, orgId=${whoami.organizationId}`,
+    )
+  })
+})

--- a/e2e/integration/otp-flow.test.ts
+++ b/e2e/integration/otp-flow.test.ts
@@ -1,0 +1,197 @@
+/**
+ * E2E integration test for the OTP authentication flow.
+ *
+ * Tests the complete OTP flow against a real KMS backend + Turnkey:
+ * 1. Create temp email account
+ * 2. Register with OTP (sends email)
+ * 3. Extract OTP code from email
+ * 4. Verify OTP with Auth Proxy
+ * 5. Build client signature
+ * 6. Login with OTP via backend
+ * 7. Verify session works (whoami)
+ *
+ * Mirrors the Go E2E test at doorway-kms/testing/e2e/e2e_otp_test.go
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest'
+import { createAuthProxyClient } from '../../packages/core/src/client/authProxy.js'
+import { buildClientSignature } from '../../packages/core/src/utils/buildClientSignature.js'
+import { parseSession } from '../../packages/core/src/utils/utils.js'
+import {
+  getAuthProxyConfigId,
+  waitForBackend,
+} from '../helpers/backend-health.js'
+import {
+  BACKEND_URL,
+  EMAIL_POLL_INTERVAL_MS,
+  EMAIL_POLL_TIMEOUT_MS,
+  OTP_CODE_LENGTH,
+} from '../helpers/constants.js'
+import { extractOtpCode } from '../helpers/otp-utils.js'
+import {
+  createNewAccount,
+  ping,
+  searchForNewEmail,
+} from '../helpers/temp-email.js'
+import { createTestClient } from '../helpers/test-client.js'
+import { createTestStamper } from '../helpers/test-stamper.js'
+
+describe('OTP Authentication Flow', () => {
+  let projectId: string
+  let authProxyConfigId: string
+  let skipReason = ''
+
+  beforeAll(async () => {
+    // Check backend availability first (fast fail)
+    try {
+      await waitForBackend(BACKEND_URL)
+    } catch {
+      skipReason = `Backend not reachable at ${BACKEND_URL}`
+      return
+    }
+
+    // Check email service availability
+    try {
+      await ping()
+    } catch {
+      skipReason = 'Email service unavailable'
+      return
+    }
+
+    // Get auth proxy config ID from backend
+    authProxyConfigId = await getAuthProxyConfigId(BACKEND_URL)
+
+    // Get project ID from env
+    projectId = process.env.ZD_PROJECT_ID || ''
+    if (!projectId) {
+      skipReason = 'ZD_PROJECT_ID not set'
+      return
+    }
+  })
+
+  it('should complete the full OTP register + login flow', async (context) => {
+    context.skip(!!skipReason, skipReason)
+
+    // Step 1: Create temp email account
+    const emailAccount = await createNewAccount()
+    const email = emailAccount.address
+    console.log(`Created temp email: ${email}`)
+
+    // Step 2: Create test stamper (Node.js ECDSA P-256 implementation)
+    const stamper = createTestStamper()
+    const publicKey = await stamper.getPublicKey()
+    expect(publicKey).toBeTruthy()
+    console.log(`Generated public key: ${publicKey!.substring(0, 16)}...`)
+
+    // Step 3: Create SDK client with test transport (includes Origin header)
+    const client = createTestClient(stamper)
+
+    // Step 4: Register with OTP (triggers email send)
+    const registerResult = await client.registerWithOTP({
+      email,
+      contact: { type: 'email', contact: email },
+      projectId,
+      otpCodeCustomization: {
+        length: OTP_CODE_LENGTH as 6 | 7 | 8 | 9,
+        alphanumeric: false,
+      },
+    })
+    expect(registerResult.otpId).toBeTruthy()
+    console.log(`OTP initiated, otpId: ${registerResult.otpId}`)
+
+    // Step 5: Poll for email and extract OTP code
+    console.log('Waiting for OTP email...')
+    const emailContent = await searchForNewEmail(
+      emailAccount.authToken,
+      EMAIL_POLL_INTERVAL_MS,
+      EMAIL_POLL_TIMEOUT_MS,
+    )
+    const otpCode = extractOtpCode(emailContent, OTP_CODE_LENGTH)
+    expect(otpCode).toBeTruthy()
+    console.log(`Extracted OTP code: ${otpCode}`)
+
+    // Step 6: Verify OTP with Auth Proxy
+    const authProxyClient = createAuthProxyClient({ authProxyConfigId })
+    const verifyResult = await authProxyClient.verifyOtp({
+      otpId: registerResult.otpId,
+      otpCode: otpCode!,
+      public_key: publicKey!,
+    })
+    expect(verifyResult.verificationToken).toBeTruthy()
+    console.log('OTP verified with Auth Proxy')
+
+    // Step 7: Build client signature
+    const clientSignature = await buildClientSignature({
+      verificationToken: verifyResult.verificationToken,
+      publicKey: publicKey!,
+      stamper,
+    })
+    expect(clientSignature).toBeTruthy()
+    expect(clientSignature).toHaveLength(128) // 64 bytes = 128 hex chars
+    console.log('Client signature built')
+
+    // Step 8: Login with OTP via backend
+    const loginResult = await client.loginWithOTP({
+      verificationToken: verifyResult.verificationToken,
+      clientSignature,
+      projectId,
+    })
+    expect(loginResult.session).toBeTruthy()
+    console.log('OTP login successful')
+
+    // Step 9: Parse and validate session
+    const session = parseSession(loginResult.session)
+    expect(session.userId).toBeTruthy()
+    expect(session.organizationId).toBeTruthy()
+    expect(session.sessionType).toBe('SESSION_TYPE_READ_WRITE')
+    console.log(
+      `Session: userId=${session.userId}, orgId=${session.organizationId}`,
+    )
+
+    // Step 10: Verify session works with whoami
+    const whoami = await client.getWhoami({
+      organizationId: session.organizationId,
+      projectId,
+      token: loginResult.session,
+    })
+    expect(whoami.userId).toBeTruthy()
+    expect(whoami.organizationId).toBe(session.organizationId)
+    console.log(
+      `Whoami: userId=${whoami.userId}, orgId=${whoami.organizationId}`,
+    )
+  })
+
+  it('should reject an invalid OTP code', async (context) => {
+    context.skip(!!skipReason, skipReason)
+
+    // Create temp email
+    const emailAccount = await createNewAccount()
+    const email = emailAccount.address
+
+    // Create stamper and client
+    const stamper = createTestStamper()
+    const publicKey = await stamper.getPublicKey()
+    const client = createTestClient(stamper)
+
+    // Register with OTP
+    const registerResult = await client.registerWithOTP({
+      email,
+      contact: { type: 'email', contact: email },
+      projectId,
+      otpCodeCustomization: {
+        length: OTP_CODE_LENGTH as 6 | 7 | 8 | 9,
+        alphanumeric: false,
+      },
+    })
+
+    // Try to verify with a wrong code
+    const authProxyClient = createAuthProxyClient({ authProxyConfigId })
+    await expect(
+      authProxyClient.verifyOtp({
+        otpId: registerResult.otpId,
+        otpCode: 'WRONG12',
+        public_key: publicKey!,
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/e2e/integration/session-management.test.ts
+++ b/e2e/integration/session-management.test.ts
@@ -1,0 +1,160 @@
+/**
+ * E2E integration test for session management.
+ *
+ * After OTP login:
+ * 1. Login with stamp using a new key pair (session refresh)
+ * 2. Verify new session works for whoami
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest'
+import { createAuthProxyClient } from '../../packages/core/src/client/authProxy.js'
+import { buildClientSignature } from '../../packages/core/src/utils/buildClientSignature.js'
+import { parseSession } from '../../packages/core/src/utils/utils.js'
+import {
+  getAuthProxyConfigId,
+  waitForBackend,
+} from '../helpers/backend-health.js'
+import {
+  BACKEND_URL,
+  EMAIL_POLL_INTERVAL_MS,
+  EMAIL_POLL_TIMEOUT_MS,
+  OTP_CODE_LENGTH,
+} from '../helpers/constants.js'
+import { extractOtpCode } from '../helpers/otp-utils.js'
+import {
+  createNewAccount,
+  ping,
+  searchForNewEmail,
+} from '../helpers/temp-email.js'
+import { createTestClient } from '../helpers/test-client.js'
+import { createTestStamper } from '../helpers/test-stamper.js'
+
+/** Helper to complete an OTP login flow, returning the session and org ID */
+async function completeOtpLogin(projectId: string, authProxyConfigId: string) {
+  const emailAccount = await createNewAccount()
+  const stamper = createTestStamper()
+  const publicKey = (await stamper.getPublicKey())!
+
+  const client = createTestClient(stamper)
+
+  const registerResult = await client.registerWithOTP({
+    email: emailAccount.address,
+    contact: { type: 'email', contact: emailAccount.address },
+    projectId,
+    otpCodeCustomization: {
+      length: OTP_CODE_LENGTH as 6 | 7 | 8 | 9,
+      alphanumeric: false,
+    },
+  })
+
+  const emailContent = await searchForNewEmail(
+    emailAccount.authToken,
+    EMAIL_POLL_INTERVAL_MS,
+    EMAIL_POLL_TIMEOUT_MS,
+  )
+  const otpCode = extractOtpCode(emailContent, OTP_CODE_LENGTH)!
+
+  const authProxyClient = createAuthProxyClient({ authProxyConfigId })
+  const verifyResult = await authProxyClient.verifyOtp({
+    otpId: registerResult.otpId,
+    otpCode,
+    public_key: publicKey,
+  })
+
+  const clientSignature = await buildClientSignature({
+    verificationToken: verifyResult.verificationToken,
+    publicKey,
+    stamper,
+  })
+
+  const loginResult = await client.loginWithOTP({
+    verificationToken: verifyResult.verificationToken,
+    clientSignature,
+    projectId,
+  })
+
+  const session = parseSession(loginResult.session)
+  return { client, stamper, session, sessionToken: loginResult.session }
+}
+
+describe('Session Management', () => {
+  let projectId: string
+  let authProxyConfigId: string
+  let skipReason = ''
+
+  beforeAll(async () => {
+    try {
+      await waitForBackend(BACKEND_URL)
+    } catch {
+      skipReason = `Backend not reachable at ${BACKEND_URL}`
+      return
+    }
+
+    try {
+      await ping()
+    } catch {
+      skipReason = 'Email service unavailable'
+      return
+    }
+
+    authProxyConfigId = await getAuthProxyConfigId(BACKEND_URL)
+
+    projectId = process.env.ZD_PROJECT_ID || ''
+    if (!projectId) {
+      skipReason = 'ZD_PROJECT_ID not set'
+      return
+    }
+  })
+
+  it('should refresh session via loginWithStamp with a new key pair', async (context) => {
+    context.skip(!!skipReason, skipReason)
+
+    // Step 1: Complete initial OTP login
+    const { client, session, sessionToken } = await completeOtpLogin(
+      projectId,
+      authProxyConfigId,
+    )
+    console.log(`Initial login: orgId=${session.organizationId}`)
+
+    // Step 2: Verify initial session works
+    const whoami1 = await client.getWhoami({
+      organizationId: session.organizationId,
+      projectId,
+      token: sessionToken,
+    })
+    expect(whoami1.userId).toBeTruthy()
+
+    // Step 3: Create a new stamper (new key pair) for session refresh
+    const newStamper = createTestStamper()
+    const newPublicKey = (await newStamper.getPublicKey())!
+
+    // Step 4: Login with stamp using the OLD stamper (active session key)
+    // targeting the NEW public key
+    const stampLoginResult = await client.loginWithStamp({
+      projectId,
+      organizationId: session.organizationId,
+      targetPublicKey: newPublicKey,
+    })
+    expect(stampLoginResult.session).toBeTruthy()
+    console.log('Stamp login successful')
+
+    // Step 5: Parse the new session and verify it
+    const newSession = parseSession(stampLoginResult.session)
+    expect(newSession.userId).toBeTruthy()
+    expect(newSession.organizationId).toBe(session.organizationId)
+    expect(newSession.sessionType).toBe('SESSION_TYPE_READ_WRITE')
+    console.log(`Refreshed session: userId=${newSession.userId}`)
+
+    // Step 6: Create a new client with the new stamper and verify it works
+    const newClient = createTestClient(newStamper)
+
+    const whoami2 = await newClient.getWhoami({
+      organizationId: newSession.organizationId,
+      projectId,
+      token: stampLoginResult.session,
+    })
+    expect(whoami2.userId).toBe(whoami1.userId)
+    expect(whoami2.organizationId).toBe(session.organizationId)
+    console.log('New session verified with whoami')
+  })
+})

--- a/e2e/integration/wallet-operations.test.ts
+++ b/e2e/integration/wallet-operations.test.ts
@@ -1,0 +1,169 @@
+/**
+ * E2E integration test for wallet operations after authentication.
+ *
+ * After OTP login:
+ * 1. Get user wallet addresses
+ * 2. Sign a raw payload
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest'
+import { createAuthProxyClient } from '../../packages/core/src/client/authProxy.js'
+import { buildClientSignature } from '../../packages/core/src/utils/buildClientSignature.js'
+import { parseSession } from '../../packages/core/src/utils/utils.js'
+import {
+  getAuthProxyConfigId,
+  waitForBackend,
+} from '../helpers/backend-health.js'
+import {
+  BACKEND_URL,
+  EMAIL_POLL_INTERVAL_MS,
+  EMAIL_POLL_TIMEOUT_MS,
+  OTP_CODE_LENGTH,
+} from '../helpers/constants.js'
+import { extractOtpCode } from '../helpers/otp-utils.js'
+import {
+  createNewAccount,
+  ping,
+  searchForNewEmail,
+} from '../helpers/temp-email.js'
+import { createTestClient } from '../helpers/test-client.js'
+import { createTestStamper } from '../helpers/test-stamper.js'
+
+/** Helper to complete an OTP login flow */
+async function completeOtpLogin(projectId: string, authProxyConfigId: string) {
+  const emailAccount = await createNewAccount()
+  const stamper = createTestStamper()
+  const publicKey = (await stamper.getPublicKey())!
+
+  const client = createTestClient(stamper)
+
+  const registerResult = await client.registerWithOTP({
+    email: emailAccount.address,
+    contact: { type: 'email', contact: emailAccount.address },
+    projectId,
+    otpCodeCustomization: {
+      length: OTP_CODE_LENGTH as 6 | 7 | 8 | 9,
+      alphanumeric: false,
+    },
+  })
+
+  const emailContent = await searchForNewEmail(
+    emailAccount.authToken,
+    EMAIL_POLL_INTERVAL_MS,
+    EMAIL_POLL_TIMEOUT_MS,
+  )
+  const otpCode = extractOtpCode(emailContent, OTP_CODE_LENGTH)!
+
+  const authProxyClient = createAuthProxyClient({ authProxyConfigId })
+  const verifyResult = await authProxyClient.verifyOtp({
+    otpId: registerResult.otpId,
+    otpCode,
+    public_key: publicKey,
+  })
+
+  const clientSignature = await buildClientSignature({
+    verificationToken: verifyResult.verificationToken,
+    publicKey,
+    stamper,
+  })
+
+  const loginResult = await client.loginWithOTP({
+    verificationToken: verifyResult.verificationToken,
+    clientSignature,
+    projectId,
+  })
+
+  const session = parseSession(loginResult.session)
+  return { client, stamper, session, sessionToken: loginResult.session }
+}
+
+describe('Wallet Operations', () => {
+  let projectId: string
+  let authProxyConfigId: string
+  let skipReason = ''
+
+  beforeAll(async () => {
+    try {
+      await waitForBackend(BACKEND_URL)
+    } catch {
+      skipReason = `Backend not reachable at ${BACKEND_URL}`
+      return
+    }
+
+    try {
+      await ping()
+    } catch {
+      skipReason = 'Email service unavailable'
+      return
+    }
+
+    authProxyConfigId = await getAuthProxyConfigId(BACKEND_URL)
+
+    projectId = process.env.ZD_PROJECT_ID || ''
+    if (!projectId) {
+      skipReason = 'ZD_PROJECT_ID not set'
+      return
+    }
+  })
+
+  it('should get user wallet addresses after login', async (context) => {
+    context.skip(!!skipReason, skipReason)
+
+    const { client, session, sessionToken } = await completeOtpLogin(
+      projectId,
+      authProxyConfigId,
+    )
+
+    const wallet = await client.getUserWallet({
+      organizationId: session.organizationId,
+      projectId,
+      token: sessionToken,
+    })
+
+    expect(wallet.walletAddresses).toBeDefined()
+    expect(Array.isArray(wallet.walletAddresses)).toBe(true)
+    expect(wallet.walletAddresses.length).toBeGreaterThan(0)
+
+    for (const addr of wallet.walletAddresses) {
+      expect(addr).toMatch(/^0x[a-fA-F0-9]{40}$/)
+    }
+
+    console.log(`Wallet addresses: ${wallet.walletAddresses.join(', ')}`)
+  })
+
+  it('should sign a raw payload after login', async (context) => {
+    context.skip(!!skipReason, skipReason)
+
+    const { client, session, sessionToken } = await completeOtpLogin(
+      projectId,
+      authProxyConfigId,
+    )
+
+    // First get wallet address
+    const wallet = await client.getUserWallet({
+      organizationId: session.organizationId,
+      projectId,
+      token: sessionToken,
+    })
+    expect(wallet.walletAddresses.length).toBeGreaterThan(0)
+    const walletAddress = wallet.walletAddresses[0]!
+
+    // Sign a test payload (32 bytes of zeros as hex)
+    const testPayload = '0'.repeat(64)
+    const signature = await client.signRawPayload({
+      organizationId: session.organizationId,
+      projectId,
+      token: sessionToken,
+      address: walletAddress,
+      payload: testPayload,
+      encoding: 'PAYLOAD_ENCODING_HEXADECIMAL',
+      hashFunction: 'HASH_FUNCTION_NO_OP',
+    })
+
+    expect(signature).toBeTruthy()
+    expect(typeof signature).toBe('string')
+    console.log(
+      `Signed payload, signature: ${String(signature).substring(0, 20)}...`,
+    )
+  })
+})

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,38 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig, devices } from '@playwright/test'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const demoAppDir = path.resolve(__dirname, '../../zerodev-signer-demo')
+
+export default defineConfig({
+  testDir: './browser',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [['html'], ['github']] : [['html']],
+  timeout: 120_000,
+  expect: {
+    timeout: 30_000,
+  },
+  use: {
+    baseURL: process.env.DEMO_APP_URL || 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: process.env.CI
+    ? undefined
+    : {
+        command: `cd ${demoAppDir} && pnpm dev`,
+        url: 'http://localhost:3000',
+        reuseExistingServer: true,
+        timeout: 30_000,
+      },
+})

--- a/e2e/vitest.integration.config.ts
+++ b/e2e/vitest.integration.config.ts
@@ -1,0 +1,21 @@
+import path from 'node:path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@zerodev/wallet-core': path.resolve(
+        __dirname,
+        '../packages/core/src/index.ts',
+      ),
+    },
+  },
+  test: {
+    include: ['e2e/integration/**/*.test.ts'],
+    environment: 'node',
+    testTimeout: 120_000,
+    hookTimeout: 60_000,
+    pool: 'forks',
+    fileParallelism: false,
+  },
+})

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:integration": "vitest run --config e2e/vitest.integration.config.ts",
+    "test:e2e": "playwright test --config e2e/playwright.config.ts",
+    "test:e2e:headed": "playwright test --config e2e/playwright.config.ts --headed",
     "prepare": "husky",
     "changeset": "changeset",
     "changeset:version": "changeset version && pnpm install --lockfile-only",
@@ -38,6 +41,7 @@
   "license": "MIT",
   "devDependencies": {
     "@biomejs/biome": "^2.2.4",
+    "@playwright/test": "^1.52.0",
     "@changesets/cli": "^2.29.7",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/core/src/actions/auth/auth.test.ts
+++ b/packages/core/src/actions/auth/auth.test.ts
@@ -421,7 +421,7 @@ describe('getUserEmail', () => {
 })
 
 describe('getWhoami', () => {
-  it('sends whoami request with correct parameters', async () => {
+  it('sends whoami request with dual stamps', async () => {
     const mockClient = createMockClient(async () => ({
       userId: 'user-789',
       organizationId: 'org-123',
@@ -432,18 +432,50 @@ describe('getWhoami', () => {
       projectId: 'proj-456',
     })
 
+    // Should call stamper twice (inner stamp + outer stamp)
+    expect(mockClient.indexedDbStamper.stamp).toHaveBeenCalledTimes(2)
+
+    // Request should include stamp in body and X-Stamp header
     expect(mockClient.request).toHaveBeenCalledWith({
       path: 'proj-456/whoami',
       method: 'POST',
       body: {
         organizationId: 'org-123',
+        stamp: {
+          stampHeaderName: 'X-Stamp',
+          stampHeaderValue: 'mock-stamp-value',
+        },
       },
-      stamp: true,
+      headers: {
+        'X-Stamp': 'mock-stamp-value',
+      },
     })
     expect(result).toEqual({
       userId: 'user-789',
       organizationId: 'org-123',
     })
+  })
+
+  it('includes bearer token when provided', async () => {
+    const mockClient = createMockClient(async () => ({
+      userId: 'user-789',
+      organizationId: 'org-123',
+    }))
+
+    await getWhoami(mockClient, {
+      organizationId: 'org-123',
+      projectId: 'proj-456',
+      token: 'session-jwt',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer session-jwt',
+          'X-Stamp': 'mock-stamp-value',
+        }),
+      }),
+    )
   })
 
   it('returns all user info fields when available', async () => {
@@ -465,24 +497,6 @@ describe('getWhoami', () => {
       organizationName: 'My Organization',
       username: 'john_doe',
     })
-  })
-
-  it('requests stamping', async () => {
-    const mockClient = createMockClient(async () => ({
-      userId: 'user-789',
-      organizationId: 'org-123',
-    }))
-
-    await getWhoami(mockClient, {
-      organizationId: 'org-123',
-      projectId: 'proj-456',
-    })
-
-    expect(mockClient.request).toHaveBeenCalledWith(
-      expect.objectContaining({
-        stamp: true,
-      }),
-    )
   })
 
   it('propagates errors', async () => {

--- a/packages/core/src/actions/auth/getWhoami.ts
+++ b/packages/core/src/actions/auth/getWhoami.ts
@@ -1,3 +1,4 @@
+import { canonicalizeEx } from 'json-canonicalize'
 import type { Client } from '../../client/types.js'
 
 export type GetWhoamiParameters = {
@@ -5,6 +6,8 @@ export type GetWhoamiParameters = {
   organizationId: string
   /** The project ID for the request */
   projectId: string
+  /** The session token for authorization (required for session-based auth) */
+  token?: string
 }
 
 export type GetWhoamiReturnType = {
@@ -19,7 +22,11 @@ export type GetWhoamiReturnType = {
 }
 
 /**
- * Gets the current user information
+ * Gets the current user information.
+ *
+ * The whoami endpoint requires two stamps:
+ * 1. An inner stamp over the payload (for Turnkey verification) embedded in the body
+ * 2. An outer stamp over the full body (for KMS middleware) in the X-Stamp header
  *
  * @param client - The ZeroDev Wallet client
  * @param params - The parameters for the whoami request
@@ -29,7 +36,8 @@ export type GetWhoamiReturnType = {
  * ```ts
  * const userInfo = await getWhoami(client, {
  *   organizationId: 'org_123',
- *   projectId: 'proj_456'
+ *   projectId: 'proj_456',
+ *   token: 'session_token',
  * });
  * console.log(userInfo.userId); // 'user_789'
  * ```
@@ -38,14 +46,33 @@ export async function getWhoami(
   client: Client,
   params: GetWhoamiParameters,
 ): Promise<GetWhoamiReturnType> {
-  const { organizationId, projectId } = params
+  const { organizationId, projectId, token } = params
+
+  // Step 1: Inner stamp over the payload (for Turnkey verification)
+  const innerBody = { organizationId }
+  const innerBodyString = canonicalizeEx(innerBody)
+  const innerStamp = await client.indexedDbStamper.stamp(innerBodyString)
+
+  // Step 2: Build full body with inner stamp embedded
+  const fullBody = {
+    ...innerBody,
+    stamp: {
+      stampHeaderName: innerStamp.stampHeaderName,
+      stampHeaderValue: innerStamp.stampHeaderValue,
+    },
+  }
+
+  // Step 3: Outer stamp over full body (for KMS middleware)
+  const fullBodyString = canonicalizeEx(fullBody)
+  const outerStamp = await client.indexedDbStamper.stamp(fullBodyString)
 
   return await client.request({
     path: `${projectId}/whoami`,
     method: 'POST',
-    body: {
-      organizationId,
+    body: fullBody,
+    headers: {
+      [outerStamp.stampHeaderName]: outerStamp.stampHeaderValue,
+      ...(token && { Authorization: `Bearer ${token}` }),
     },
-    stamp: true,
   })
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.7
         version: 2.29.7(@types/node@20.19.11)
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.57.0
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -599,6 +602,11 @@ packages:
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
     deprecated: 'The package is now available as "qr": npm install qr'
+
+  '@playwright/test@1.57.0':
+    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@reown/appkit-common@1.7.8':
     resolution: {integrity: sha512-ridIhc/x6JOp7KbDdwGKY4zwf8/iK8EYBl+HtWrruutSLwZyVi5P8WaZa+8iajL6LcDcDF7LoyLwMTym7SRuwQ==}
@@ -1873,6 +1881,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2372,6 +2385,16 @@ packages:
 
   pino@7.11.0:
     resolution: {integrity: sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==}
+    hasBin: true
+
+  playwright-core@1.57.0:
+    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.57.0:
+    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
+    engines: {node: '>=18'}
     hasBin: true
 
   pngjs@5.0.0:
@@ -3783,6 +3806,10 @@ snapshots:
 
   '@paulmillr/qr@0.2.1':
     optional: true
+
+  '@playwright/test@1.57.0':
+    dependencies:
+      playwright: 1.57.0
 
   '@reown/appkit-common@1.7.8(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
     dependencies:
@@ -6025,6 +6052,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6638,6 +6668,14 @@ snapshots:
       sonic-boom: 2.8.0
       thread-stream: 0.15.2
     optional: true
+
+  playwright-core@1.57.0: {}
+
+  playwright@1.57.0:
+    dependencies:
+      playwright-core: 1.57.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@5.0.0:
     optional: true


### PR DESCRIPTION
## Summary
- Add SDK integration tests (Vitest) covering OTP, magic link, session management, and wallet operations against the staging KMS backend
- Add browser E2E tests (Playwright) covering OTP, magic link, passkey, and post-auth operations through the zerodev-signer-demo UI
- CI jobs talk directly to staging — no local backend, postgres, or docker needed
- Tests use `context.skip()` so skipped tests are properly flagged (not falsely passed)

## CI Secrets Required
- `ZD_PROJECT_ID` — ZeroDev project ID