### PR TITLE
feat: replace cookie-based OAuth with server-side session ID

### DIFF
--- a/packages/core/src/actions/auth/auth.test.ts
+++ b/packages/core/src/actions/auth/auth.test.ts
@@ -55,7 +55,7 @@ function createMockClient(
 }
 
 describe('authenticateWithOAuth', () => {
-  it('sends OAuth auth request with correct path and credentials', async () => {
+  it('sends OAuth auth request with sessionId in body', async () => {
     const mockClient = createMockClient(async () => ({
       userId: 'user-123',
       session: 'session-jwt',
@@ -64,13 +64,13 @@ describe('authenticateWithOAuth', () => {
     const result = await authenticateWithOAuth(mockClient, {
       provider: 'google',
       projectId: 'proj-456',
+      sessionId: 'test-session-id',
     })
 
     expect(mockClient.request).toHaveBeenCalledWith({
       path: 'proj-456/auth/oauth',
       method: 'POST',
-      body: null,
-      credentials: 'include',
+      body: { sessionId: 'test-session-id' },
     })
     expect(result).toEqual({
       userId: 'user-123',
@@ -90,6 +90,7 @@ describe('authenticateWithOAuth', () => {
     const result = await authenticateWithOAuth(mockClient, {
       provider: 'google',
       projectId: 'proj-456',
+      sessionId: 'test-session-id',
     })
 
     expect(result).toEqual(fullResponse)
@@ -104,6 +105,7 @@ describe('authenticateWithOAuth', () => {
       authenticateWithOAuth(mockClient, {
         provider: 'google',
         projectId: 'proj-456',
+        sessionId: 'expired-session',
       }),
     ).rejects.toThrow('OAuth session expired')
   })

--- a/packages/core/src/actions/auth/authenticateWithOAuth.ts
+++ b/packages/core/src/actions/auth/authenticateWithOAuth.ts
@@ -5,6 +5,8 @@ export type AuthenticateWithOAuthParameters = {
   provider: string
   /** The project ID for the request */
   projectId: string
+  /** The session ID from the OAuth callback URL */
+  sessionId: string
 }
 
 export type AuthenticateWithOAuthReturnType = {
@@ -19,11 +21,11 @@ export type AuthenticateWithOAuthReturnType = {
 }
 
 /**
- * Authenticates a user with OAuth using cookie-based backend flow
+ * Authenticates a user with OAuth using a server-side session ID
  *
- * The backend reads the OAuth session from a cookie set during the OAuth flow.
- * This requires the OAuth popup flow to complete first via the backend's
- * /oauth/google/login endpoint.
+ * The backend stores the OAuth session server-side and returns a session ID
+ * via the callback URL. The SDK extracts this session ID and sends it in
+ * the request body.
  *
  * @param client - The ZeroDev Wallet client
  * @param params - The parameters for OAuth authentication
@@ -34,6 +36,7 @@ export type AuthenticateWithOAuthReturnType = {
  * const result = await authenticateWithOAuth(client, {
  *   provider: 'google',
  *   projectId: 'proj_456',
+ *   sessionId: 'abc123',
  * });
  * ```
  */
@@ -41,12 +44,11 @@ export async function authenticateWithOAuth(
   client: Client,
   params: AuthenticateWithOAuthParameters,
 ): Promise<AuthenticateWithOAuthReturnType> {
-  const { projectId } = params
+  const { projectId, sessionId } = params
 
   return await client.request({
     path: `${projectId}/auth/oauth`,
     method: 'POST',
-    body: null,
-    credentials: 'include',
+    body: { sessionId },
   })
 }

--- a/packages/core/src/core/createZeroDevWallet.ts
+++ b/packages/core/src/core/createZeroDevWallet.ts
@@ -50,6 +50,7 @@ export type AuthParams =
   | {
       type: 'oauth'
       provider: string
+      sessionId: string
     }
   | {
       type: 'passkey'
@@ -219,11 +220,10 @@ export async function createZeroDevWallet(
     async auth(params: AuthParams) {
       switch (params.type) {
         case 'oauth': {
-          // Backend OAuth flow - the backend reads the OAuth session from a cookie
-          // set during the OAuth popup flow via /oauth/google/login
           const data = await client.authenticateWithOAuth({
             provider: params.provider,
             projectId,
+            sessionId: params.sessionId,
           })
 
           if (data.session) {

--- a/packages/react/src/actions.test.ts
+++ b/packages/react/src/actions.test.ts
@@ -569,7 +569,7 @@ describe('React Actions', () => {
       })
     })
 
-    it('completes full OAuth success flow', async () => {
+    it('completes full OAuth success flow with sessionId', async () => {
       const wallet = createMockWallet()
       wallet.getSession.mockResolvedValue({ id: 'oauth-session' })
       wallet.toAccount.mockResolvedValue({ address: '0xoauth' })
@@ -578,11 +578,14 @@ describe('React Actions', () => {
       const config = createMockConfig(connector)
 
       mockOpenOAuthPopup.mockReturnValue({ closed: false } as Window)
-      // Simulate the success callback being called immediately
+      // Simulate the success callback being called with sessionId
       mockListenForOAuthMessage.mockImplementation(
-        (_win: Window, _origin: string, onSuccess: () => void) => {
-          // Call onSuccess asynchronously to simulate real behavior
-          setTimeout(() => onSuccess(), 0)
+        (
+          _win: Window,
+          _origin: string,
+          onSuccess: (sessionId: string) => void,
+        ) => {
+          setTimeout(() => onSuccess('test-session-id'), 0)
           return () => {}
         },
       )
@@ -592,6 +595,7 @@ describe('React Actions', () => {
       expect(wallet.auth).toHaveBeenCalledWith({
         type: 'oauth',
         provider: 'google',
+        sessionId: 'test-session-id',
       })
       expect(store.getState().setEoaAccount).toHaveBeenCalledWith({
         address: '0xoauth',
@@ -611,8 +615,12 @@ describe('React Actions', () => {
 
       mockOpenOAuthPopup.mockReturnValue({ closed: false } as Window)
       mockListenForOAuthMessage.mockImplementation(
-        (_win: Window, _origin: string, onSuccess: () => void) => {
-          setTimeout(() => onSuccess(), 0)
+        (
+          _win: Window,
+          _origin: string,
+          onSuccess: (sessionId: string) => void,
+        ) => {
+          setTimeout(() => onSuccess('session-id'), 0)
           return () => {}
         },
       )
@@ -633,7 +641,7 @@ describe('React Actions', () => {
         (
           _win: Window,
           _origin: string,
-          _onSuccess: () => void,
+          _onSuccess: (sessionId: string) => void,
           onError: (error: Error) => void,
         ) => {
           setTimeout(() => onError(new Error('Window closed')), 0)

--- a/packages/react/src/actions.ts
+++ b/packages/react/src/actions.ts
@@ -158,13 +158,13 @@ export async function authenticateOAuth(
     const cleanup = listenForOAuthMessage(
       authWindow,
       window.location.origin,
-      async () => {
+      async (sessionId) => {
         try {
           // Complete OAuth authentication with wallet-core
-          // The backend has stored the OAuth session in a cookie
           await wallet.auth({
             type: 'oauth',
             provider: parameters.provider,
+            sessionId,
           })
 
           const [session, eoaAccount] = await Promise.all([

--- a/packages/react/src/connector.ts
+++ b/packages/react/src/connector.ts
@@ -16,6 +16,7 @@ import { getAAUrl } from './utils/aaUtils.js'
 // OAuth URL parameter used to detect callback
 const OAUTH_SUCCESS_PARAM = 'oauth_success'
 const OAUTH_PROVIDER_PARAM = 'oauth_provider'
+const OAUTH_SESSION_ID_PARAM = 'session_id'
 
 /**
  * Detect OAuth callback from URL params and handle it.
@@ -43,9 +44,10 @@ async function detectAndHandleOAuthCallback(
   console.log('OAuth callback detected, completing authentication...')
   const provider = (params.get(OAUTH_PROVIDER_PARAM) ||
     'google') as OAuthProvider
+  const sessionId = params.get(OAUTH_SESSION_ID_PARAM) || ''
 
   try {
-    await wallet.auth({ type: 'oauth', provider })
+    await wallet.auth({ type: 'oauth', provider, sessionId })
 
     const [session, eoaAccount] = await Promise.all([
       wallet.getSession(),
@@ -58,6 +60,7 @@ async function detectAndHandleOAuthCallback(
     // Clean up URL params
     params.delete(OAUTH_SUCCESS_PARAM)
     params.delete(OAUTH_PROVIDER_PARAM)
+    params.delete(OAUTH_SESSION_ID_PARAM)
     const newUrl = params.toString()
       ? `${window.location.pathname}?${params.toString()}`
       : window.location.pathname

--- a/packages/react/src/oauth.test.ts
+++ b/packages/react/src/oauth.test.ts
@@ -188,15 +188,35 @@ describe('OAuth utilities', () => {
       vi.useRealTimers()
     })
 
-    it('calls onSuccess when oauth_success message received', () => {
+    it('calls onSuccess with sessionId when oauth_success message received', () => {
       const cleanup = listenForOAuthMessage(
         mockWindow as Window,
         'https://app.example.com',
-        onSuccessMock as () => void,
+        onSuccessMock as (sessionId: string) => void,
         onErrorMock as (error: Error) => void,
       )
 
-      // Simulate receiving a message
+      // Simulate receiving a message with sessionId
+      const event = new MessageEvent('message', {
+        data: { type: 'oauth_success', sessionId: 'test-session-123' },
+        origin: 'https://app.example.com',
+      })
+      window.dispatchEvent(event)
+
+      expect(onSuccessMock).toHaveBeenCalledOnce()
+      expect(onSuccessMock).toHaveBeenCalledWith('test-session-123')
+      expect(onErrorMock).not.toHaveBeenCalled()
+      cleanup()
+    })
+
+    it('calls onSuccess with empty string when sessionId is missing', () => {
+      const cleanup = listenForOAuthMessage(
+        mockWindow as Window,
+        'https://app.example.com',
+        onSuccessMock as (sessionId: string) => void,
+        onErrorMock as (error: Error) => void,
+      )
+
       const event = new MessageEvent('message', {
         data: { type: 'oauth_success' },
         origin: 'https://app.example.com',
@@ -204,6 +224,7 @@ describe('OAuth utilities', () => {
       window.dispatchEvent(event)
 
       expect(onSuccessMock).toHaveBeenCalledOnce()
+      expect(onSuccessMock).toHaveBeenCalledWith('')
       expect(onErrorMock).not.toHaveBeenCalled()
       cleanup()
     })
@@ -212,7 +233,7 @@ describe('OAuth utilities', () => {
       const cleanup = listenForOAuthMessage(
         mockWindow as Window,
         'https://app.example.com',
-        onSuccessMock as () => void,
+        onSuccessMock as (sessionId: string) => void,
         onErrorMock as (error: Error) => void,
       )
 
@@ -232,7 +253,7 @@ describe('OAuth utilities', () => {
       const cleanup = listenForOAuthMessage(
         mockWindow as Window,
         'https://app.example.com',
-        onSuccessMock as () => void,
+        onSuccessMock as (sessionId: string) => void,
         onErrorMock as (error: Error) => void,
       )
 
@@ -251,7 +272,7 @@ describe('OAuth utilities', () => {
       const cleanup = listenForOAuthMessage(
         mockWindow as Window,
         'https://app.example.com',
-        onSuccessMock as () => void,
+        onSuccessMock as (sessionId: string) => void,
         onErrorMock as (error: Error) => void,
       )
 
@@ -268,7 +289,7 @@ describe('OAuth utilities', () => {
       const cleanup = listenForOAuthMessage(
         mockWindow as Window,
         'https://app.example.com',
-        onSuccessMock as () => void,
+        onSuccessMock as (sessionId: string) => void,
         onErrorMock as (error: Error) => void,
       )
 
@@ -288,7 +309,7 @@ describe('OAuth utilities', () => {
       const cleanup = listenForOAuthMessage(
         mockWindow as Window,
         'https://app.example.com',
-        onSuccessMock as () => void,
+        onSuccessMock as (sessionId: string) => void,
         onErrorMock as (error: Error) => void,
       )
 
@@ -323,7 +344,7 @@ describe('OAuth utilities', () => {
       const cleanup = listenForOAuthMessage(
         mockWindow as Window,
         'https://app.example.com',
-        onSuccessMock as () => void,
+        onSuccessMock as (sessionId: string) => void,
         onErrorMock as (error: Error) => void,
       )
 
@@ -345,7 +366,7 @@ describe('OAuth utilities', () => {
       const cleanup = listenForOAuthMessage(
         mockWindow as Window,
         'https://app.example.com',
-        onSuccessMock as () => void,
+        onSuccessMock as (sessionId: string) => void,
         onErrorMock as (error: Error) => void,
       )
 
@@ -391,7 +412,20 @@ describe('OAuth utilities', () => {
       window.close = originalClose
     })
 
-    it('returns true and posts success message on oauth_success=true', () => {
+    it('returns true and posts success message with sessionId on oauth_success=true', () => {
+      window.location.search = '?oauth_success=true&session_id=abc123'
+
+      const result = handleOAuthCallback()
+
+      expect(result).toBe(true)
+      expect(window.opener?.postMessage).toHaveBeenCalledWith(
+        { type: 'oauth_success', sessionId: 'abc123' },
+        'https://app.example.com',
+      )
+      expect(window.close).toHaveBeenCalled()
+    })
+
+    it('posts success message without sessionId when session_id param is missing', () => {
       window.location.search = '?oauth_success=true'
 
       const result = handleOAuthCallback()

--- a/packages/react/src/oauth.ts
+++ b/packages/react/src/oauth.ts
@@ -62,6 +62,7 @@ export function buildBackendOAuthUrl(params: BackendOAuthFlowParams): string {
 
 export type OAuthMessageData = {
   type: 'oauth_success' | 'oauth_error'
+  sessionId?: string
   error?: string
 }
 
@@ -72,7 +73,7 @@ export type OAuthMessageData = {
 export function listenForOAuthMessage(
   authWindow: Window,
   expectedOrigin: string,
-  onSuccess: () => void,
+  onSuccess: (sessionId: string) => void,
   onError: (error: Error) => void,
 ): () => void {
   let cleaned = false
@@ -84,7 +85,7 @@ export function listenForOAuthMessage(
 
     if (event.data.type === 'oauth_success') {
       cleanup()
-      onSuccess()
+      onSuccess(event.data.sessionId || '')
     } else if (event.data.type === 'oauth_error') {
       cleanup()
       onError(new Error(event.data.error || 'OAuth authentication failed'))
@@ -119,13 +120,13 @@ export function handleOAuthCallback(successParam = 'oauth_success'): boolean {
   const urlParams = new URLSearchParams(window.location.search)
   const isSuccess = urlParams.get(successParam) === 'true'
   const error = urlParams.get('error')
+  const sessionId = urlParams.get('session_id') ?? undefined
 
   if (window.opener) {
     if (isSuccess) {
-      window.opener.postMessage(
-        { type: 'oauth_success' } satisfies OAuthMessageData,
-        window.location.origin,
-      )
+      const message: OAuthMessageData = { type: 'oauth_success' }
+      if (sessionId) message.sessionId = sessionId
+      window.opener.postMessage(message, window.location.origin)
       window.close()
       return true
     }


### PR DESCRIPTION
## Summary

- Replaces the cookie-based OAuth flow with a server-side session ID approach to fix authentication in Brave and other privacy-focused browsers that block third-party cookies
- The backend now redirects the OAuth popup with `?session_id=...` instead of setting a cookie; the SDK extracts this and sends it in the `POST /auth/oauth` request body
- Removes `credentials: 'include'` from the OAuth request since cookies are no longer used

## Changes

| File | Change |
|------|--------|
| `packages/core/src/actions/auth/authenticateWithOAuth.ts` | Send `sessionId` in body, remove `credentials: 'include'` |
| `packages/core/src/core/createZeroDevWallet.ts` | Add `sessionId` to oauth `AuthParams`, pass to client |
| `packages/react/src/oauth.ts` | Extract `session_id` from URL, include in postMessage |
| `packages/react/src/actions.ts` | Pass `sessionId` from postMessage through to `wallet.auth()` |
| `packages/react/src/connector.ts` | Extract `session_id` in redirect flow, clean up from URL |

Corresponds to backend branch: `afilios/dpl-245-replace-cross-site-oauth-cookie-with-server-side-token`