### PR TITLE
feat(core): rename stampers and expose them on createZeroDevWallet

### DIFF
--- a/e2e/helpers/test-client.ts
+++ b/e2e/helpers/test-client.ts
@@ -8,13 +8,24 @@
 import { createClient } from '../../packages/core/src/client/createClient.js'
 import { rest } from '../../packages/core/src/client/transports/rest.js'
 import type { Transport } from '../../packages/core/src/client/types.js'
-import type { IndexedDbStamper } from '../../packages/core/src/stampers/types.js'
+import type {
+  ApiKeyStamper,
+  PasskeyStamper,
+} from '../../packages/core/src/stampers/types.js'
 import { BACKEND_URL } from './constants.js'
 
-const noopStamper = {
+const noopStamper: PasskeyStamper = {
   getPublicKey: async () => null,
   stamp: async () => ({ stampHeaderName: '', stampHeaderValue: '' }),
   clear: async () => {},
+  register: async () => ({
+    attestation: {
+      attestationObject: '',
+      clientDataJson: '',
+      credentialId: '',
+    },
+    encodedChallenge: '',
+  }),
 }
 
 /**
@@ -22,13 +33,13 @@ const noopStamper = {
  * The staging backend requires a valid Origin header matching the project's ACL.
  */
 function testTransport(baseUrl: string): Transport {
-  return ({ indexedDbStamper, webauthnStamper }) => {
+  return ({ apiKeyStamper, passkeyStamper }) => {
     const transport = rest(baseUrl, {
       timeoutMs: 30_000,
       key: 'zeroDevWallet',
       name: 'ZeroDev Wallet Transport',
-      indexedDbStamper,
-      webauthnStamper,
+      apiKeyStamper,
+      passkeyStamper,
       fetchOptions: {
         headers: {
           Origin: 'http://localhost:3000',
@@ -55,12 +66,12 @@ function testTransport(baseUrl: string): Transport {
  * Includes Origin header for ACL checks and uses the provided stamper.
  */
 export function createTestClient(
-  stamper: IndexedDbStamper,
+  stamper: ApiKeyStamper,
   baseUrl = BACKEND_URL,
 ) {
   return createClient({
     transport: testTransport(baseUrl),
-    indexedDbStamper: stamper,
-    webauthnStamper: noopStamper,
+    apiKeyStamper: stamper,
+    passkeyStamper: noopStamper,
   })
 }

--- a/e2e/helpers/test-stamper.ts
+++ b/e2e/helpers/test-stamper.ts
@@ -8,7 +8,7 @@
 
 import { createSign, generateKeyPairSync, type KeyObject } from 'node:crypto'
 import type {
-  IndexedDbStamper,
+  ApiKeyStamper,
   Stamp,
 } from '../../packages/core/src/stampers/types.js'
 
@@ -21,11 +21,12 @@ export type TestStamperKeyPair = {
  * Creates a test stamper that implements the IndexedDbStamper interface
  * using Node.js crypto instead of browser IndexedDB.
  */
-export function createTestStamper(): IndexedDbStamper & {
+export function createTestStamper(): ApiKeyStamper & {
   /** Expose the key pair for tests that need direct access */
   getKeyPair(): TestStamperKeyPair | null
 } {
   let keyPair: TestStamperKeyPair | null = null
+  let pendingKeyPair: TestStamperKeyPair | null = null
 
   function ensureKeyPair(): TestStamperKeyPair {
     if (!keyPair) {
@@ -81,6 +82,19 @@ export function createTestStamper(): IndexedDbStamper & {
 
     getKeyPair(): TestStamperKeyPair | null {
       return keyPair
+    },
+
+    async prepareKeyRotation() {
+      const keyPair = generateP256KeyPair()
+      pendingKeyPair = keyPair
+      return getCompressedPublicKeyHex(pendingKeyPair.publicKey)
+    },
+    async commitKeyRotation() {
+      if (!pendingKeyPair) {
+        throw new Error('No pending key rotation to commit')
+      }
+      keyPair = pendingKeyPair
+      pendingKeyPair = null
     },
   }
 }

--- a/packages/core/src/actions/auth/auth.test.ts
+++ b/packages/core/src/actions/auth/auth.test.ts
@@ -40,7 +40,6 @@ function createMockClient(
       init: vi.fn().mockResolvedValue(undefined),
       publicKey: vi.fn().mockReturnValue('mock-public-key'),
       injectCredentialBundle: vi.fn().mockResolvedValue(undefined),
-      getStamperType: vi.fn().mockReturnValue('indexedDb'),
       clear: vi.fn().mockResolvedValue(undefined),
     } as unknown as Client['apiKeyStamper'],
     passkeyStamper: {

--- a/packages/core/src/actions/auth/auth.test.ts
+++ b/packages/core/src/actions/auth/auth.test.ts
@@ -35,17 +35,17 @@ function createMockClient(
     request: vi.fn(
       requestImpl || (async () => ({})),
     ) as unknown as Client['request'],
-    indexedDbStamper: {
+    apiKeyStamper: {
       stamp: vi.fn().mockResolvedValue(mockStamp),
       init: vi.fn().mockResolvedValue(undefined),
       publicKey: vi.fn().mockReturnValue('mock-public-key'),
       injectCredentialBundle: vi.fn().mockResolvedValue(undefined),
       getStamperType: vi.fn().mockReturnValue('indexedDb'),
       clear: vi.fn().mockResolvedValue(undefined),
-    } as unknown as Client['indexedDbStamper'],
-    webauthnStamper: {
+    } as unknown as Client['apiKeyStamper'],
+    passkeyStamper: {
       stamp: vi.fn().mockResolvedValue(mockStamp),
-    } as unknown as Client['webauthnStamper'],
+    } as unknown as Client['passkeyStamper'],
     key: 'test-client',
     name: 'Test Client',
     type: 'zeroDevWalletClient',
@@ -194,11 +194,11 @@ describe('loginWithStamp', () => {
     })
 
     // Verify indexedDb stamper was used
-    expect(mockClient.indexedDbStamper.stamp).toHaveBeenCalled()
-    expect(mockClient.webauthnStamper.stamp).not.toHaveBeenCalled()
+    expect(mockClient.apiKeyStamper.stamp).toHaveBeenCalled()
+    expect(mockClient.passkeyStamper.stamp).not.toHaveBeenCalled()
 
     // Verify the stamp payload structure
-    const stampCall = vi.mocked(mockClient.indexedDbStamper.stamp).mock.calls[0]
+    const stampCall = vi.mocked(mockClient.apiKeyStamper.stamp).mock.calls[0]
     const stampPayload = JSON.parse(stampCall[0] as string)
     expect(stampPayload).toMatchObject({
       organizationId: 'org-123',
@@ -228,7 +228,7 @@ describe('loginWithStamp', () => {
     expect(result).toEqual({ session: 'session-jwt' })
   })
 
-  it('uses webauthn stamper when specified', async () => {
+  it('uses passkey stamper when specified', async () => {
     const mockClient = createMockClient(async () => ({
       session: 'session-jwt',
     }))
@@ -237,14 +237,14 @@ describe('loginWithStamp', () => {
       projectId: 'proj-456',
       organizationId: 'org-123',
       targetPublicKey: '03abcdef',
-      stampWith: 'webauthn',
+      stampWith: 'passkey',
     })
 
-    expect(mockClient.webauthnStamper.stamp).toHaveBeenCalled()
-    expect(mockClient.indexedDbStamper.stamp).not.toHaveBeenCalled()
+    expect(mockClient.passkeyStamper.stamp).toHaveBeenCalled()
+    expect(mockClient.apiKeyStamper.stamp).not.toHaveBeenCalled()
   })
 
-  it('uses indexedDb stamper when explicitly specified', async () => {
+  it('uses apiKey stamper when explicitly specified', async () => {
     const mockClient = createMockClient(async () => ({
       session: 'session-jwt',
     }))
@@ -253,11 +253,11 @@ describe('loginWithStamp', () => {
       projectId: 'proj-456',
       organizationId: 'org-123',
       targetPublicKey: '03abcdef',
-      stampWith: 'indexedDb',
+      stampWith: 'apiKey',
     })
 
-    expect(mockClient.indexedDbStamper.stamp).toHaveBeenCalled()
-    expect(mockClient.webauthnStamper.stamp).not.toHaveBeenCalled()
+    expect(mockClient.apiKeyStamper.stamp).toHaveBeenCalled()
+    expect(mockClient.passkeyStamper.stamp).not.toHaveBeenCalled()
   })
 
   it('includes timestamp in request body', async () => {
@@ -282,7 +282,7 @@ describe('loginWithStamp', () => {
 
   it('propagates stamper errors', async () => {
     const mockClient = createMockClient()
-    vi.mocked(mockClient.indexedDbStamper.stamp).mockRejectedValue(
+    vi.mocked(mockClient.apiKeyStamper.stamp).mockRejectedValue(
       new Error('Stamper unavailable'),
     )
 
@@ -445,7 +445,7 @@ describe('getWhoami', () => {
     })
 
     // Should call stamper twice (inner stamp + outer stamp)
-    expect(mockClient.indexedDbStamper.stamp).toHaveBeenCalledTimes(2)
+    expect(mockClient.apiKeyStamper.stamp).toHaveBeenCalledTimes(2)
 
     // Request should include stamp in body and X-Stamp header
     expect(mockClient.request).toHaveBeenCalledWith({

--- a/packages/core/src/actions/auth/getWhoami.ts
+++ b/packages/core/src/actions/auth/getWhoami.ts
@@ -51,7 +51,7 @@ export async function getWhoami(
   // Step 1: Inner stamp over the payload (for Turnkey verification)
   const innerBody = { organizationId }
   const innerBodyString = canonicalizeEx(innerBody)
-  const innerStamp = await client.indexedDbStamper.stamp(innerBodyString)
+  const innerStamp = await client.apiKeyStamper.stamp(innerBodyString)
 
   // Step 2: Build full body with inner stamp embedded
   const fullBody = {
@@ -64,7 +64,7 @@ export async function getWhoami(
 
   // Step 3: Outer stamp over full body (for KMS middleware)
   const fullBodyString = canonicalizeEx(fullBody)
-  const outerStamp = await client.indexedDbStamper.stamp(fullBodyString)
+  const outerStamp = await client.apiKeyStamper.stamp(fullBodyString)
 
   return await client.request({
     path: `${projectId}/whoami`,

--- a/packages/core/src/actions/auth/loginWithStamp.ts
+++ b/packages/core/src/actions/auth/loginWithStamp.ts
@@ -1,6 +1,7 @@
 import { canonicalizeEx } from 'json-canonicalize'
 import type { Client } from '../../client/types.js'
 import type { Stamp } from '../../stampers/types.js'
+import type { StamperType } from '../../types/session.js'
 
 export type EmailCustomization = {
   /** A template for the URL to be used in a magic link button, e.g. `https://dapp.xyz/%s`. The auth bundle will be interpolated into the `%s`. */
@@ -15,8 +16,7 @@ export type LoginWithStampParameters = {
   /** The encoded public key for the request */
   targetPublicKey: string
   /** The stamper type for the request */
-  // TODO: @stamper-type - Derive type from `StamperType`
-  stampWith?: 'apiKey' | 'passkey'
+  stampWith?: StamperType
 }
 
 export type LoginWithStampReturnType = {

--- a/packages/core/src/actions/auth/loginWithStamp.ts
+++ b/packages/core/src/actions/auth/loginWithStamp.ts
@@ -15,7 +15,8 @@ export type LoginWithStampParameters = {
   /** The encoded public key for the request */
   targetPublicKey: string
   /** The stamper type for the request */
-  stampWith?: 'indexedDb' | 'webauthn'
+  // TODO: @stamper-type - Derive type from `StamperType`
+  stampWith?: 'apiKey' | 'passkey'
 }
 
 export type LoginWithStampReturnType = {
@@ -58,12 +59,12 @@ export async function loginWithStamp(
     type: 'ACTIVITY_TYPE_STAMP_LOGIN',
   })
   let stamp: Stamp
-  if (stampWith === 'indexedDb') {
-    stamp = await client.indexedDbStamper.stamp(stampPayload)
-  } else if (stampWith === 'webauthn') {
-    stamp = await client.webauthnStamper.stamp(stampPayload)
+  if (stampWith === 'apiKey') {
+    stamp = await client.apiKeyStamper.stamp(stampPayload)
+  } else if (stampWith === 'passkey') {
+    stamp = await client.passkeyStamper.stamp(stampPayload)
   } else {
-    stamp = await client.indexedDbStamper.stamp(stampPayload)
+    stamp = await client.apiKeyStamper.stamp(stampPayload)
   }
 
   return client.request({

--- a/packages/core/src/actions/auth/otp.test.ts
+++ b/packages/core/src/actions/auth/otp.test.ts
@@ -22,8 +22,8 @@ function createMockClient(
     request: vi.fn(
       requestImpl || (async () => ({})),
     ) as unknown as Client['request'],
-    indexedDbStamper: {} as Client['indexedDbStamper'],
-    webauthnStamper: {} as Client['webauthnStamper'],
+    apiKeyStamper: {} as Client['apiKeyStamper'],
+    passkeyStamper: {} as Client['passkeyStamper'],
     key: 'test-client',
     name: 'Test Client',
     type: 'zeroDevWalletClient',

--- a/packages/core/src/actions/wallet/signingUtils.ts
+++ b/packages/core/src/actions/wallet/signingUtils.ts
@@ -47,7 +47,7 @@ export async function sendSigningRequest(
 
   // Inner stamp over the Turnkey payload (for Turnkey verification)
   const innerBodyString = canonicalizeEx(turnkeyPayload)
-  const innerStamp = await client.indexedDbStamper.stamp(innerBodyString)
+  const innerStamp = await client.apiKeyStamper.stamp(innerBodyString)
 
   // Build full body with inner stamp embedded
   const fullBody = {
@@ -61,7 +61,7 @@ export async function sendSigningRequest(
 
   // Outer stamp over full body (for KMS middleware)
   const fullBodyString = canonicalizeEx(fullBody)
-  const outerStamp = await client.indexedDbStamper.stamp(fullBodyString)
+  const outerStamp = await client.apiKeyStamper.stamp(fullBodyString)
 
   const { signature } = await client.request({
     path: `${projectId}/${path}`,

--- a/packages/core/src/actions/wallet/wallet.test.ts
+++ b/packages/core/src/actions/wallet/wallet.test.ts
@@ -32,15 +32,15 @@ function createMockClient(
     request: vi.fn(
       requestImpl || (async () => ({})),
     ) as unknown as Client['request'],
-    indexedDbStamper: {
+    apiKeyStamper: {
       stamp: vi.fn(async () => ({
         stampHeaderName: 'X-Stamp-Webauthn',
         stampHeaderValue: 'mock-stamp-value',
       })),
       getPublicKey: vi.fn(async () => 'mock-public-key'),
       init: vi.fn(async () => {}),
-    } as unknown as Client['indexedDbStamper'],
-    webauthnStamper: {} as Client['webauthnStamper'],
+    } as unknown as Client['apiKeyStamper'],
+    passkeyStamper: {} as Client['passkeyStamper'],
     key: 'test-client',
     name: 'Test Client',
     type: 'zeroDevWalletClient',
@@ -175,7 +175,7 @@ describe('signMessage', () => {
     })
 
     // Inner stamp + outer stamp = 2 calls
-    expect(mockClient.indexedDbStamper.stamp).toHaveBeenCalledTimes(2)
+    expect(mockClient.apiKeyStamper.stamp).toHaveBeenCalledTimes(2)
 
     expect(mockClient.request).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -207,7 +207,7 @@ describe('signMessage', () => {
     })
 
     // First stamp call is the inner stamp over turnkeyPayload
-    const innerStampInput = vi.mocked(mockClient.indexedDbStamper.stamp).mock
+    const innerStampInput = vi.mocked(mockClient.apiKeyStamper.stamp).mock
       .calls[0][0]
     const parsed = JSON.parse(innerStampInput)
     expect(parsed.type).toBe('ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2')
@@ -233,7 +233,7 @@ describe('signMessage', () => {
     })
 
     // Second stamp call is the outer stamp over the full body
-    const outerStampInput = vi.mocked(mockClient.indexedDbStamper.stamp).mock
+    const outerStampInput = vi.mocked(mockClient.apiKeyStamper.stamp).mock
       .calls[1][0]
     const parsed = JSON.parse(outerStampInput)
     expect(parsed.message).toBe('Hello')
@@ -330,7 +330,7 @@ describe('signTransaction', () => {
       unsignedTransaction: 'f86c808504a817c80082520894',
     })
 
-    expect(mockClient.indexedDbStamper.stamp).toHaveBeenCalledTimes(2)
+    expect(mockClient.apiKeyStamper.stamp).toHaveBeenCalledTimes(2)
 
     expect(mockClient.request).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -450,7 +450,7 @@ describe('signTypedDataV4', () => {
       typedDataHash: 'deadbeef'.repeat(8),
     })
 
-    expect(mockClient.indexedDbStamper.stamp).toHaveBeenCalledTimes(2)
+    expect(mockClient.apiKeyStamper.stamp).toHaveBeenCalledTimes(2)
     expect(mockClient.request).toHaveBeenCalledWith(
       expect.objectContaining({
         path: 'proj-456/sign/typed-data-v4',
@@ -522,7 +522,7 @@ describe('signUserOperation', () => {
       encoding: 'hex',
     })
 
-    expect(mockClient.indexedDbStamper.stamp).toHaveBeenCalledTimes(2)
+    expect(mockClient.apiKeyStamper.stamp).toHaveBeenCalledTimes(2)
     expect(mockClient.request).toHaveBeenCalledWith(
       expect.objectContaining({
         path: 'proj-456/sign/user-operation',
@@ -593,7 +593,7 @@ describe('sign7702Authorization', () => {
       hashedAuthorization: 'deadbeef'.repeat(8),
     })
 
-    expect(mockClient.indexedDbStamper.stamp).toHaveBeenCalledTimes(2)
+    expect(mockClient.apiKeyStamper.stamp).toHaveBeenCalledTimes(2)
     expect(mockClient.request).toHaveBeenCalledWith(
       expect.objectContaining({
         path: 'proj-456/sign/7702-authorization',

--- a/packages/core/src/client/createClient.ts
+++ b/packages/core/src/client/createClient.ts
@@ -16,8 +16,8 @@ export function createBaseClient<
 >(config: ClientConfig): Client<extended> {
   const {
     transport,
-    indexedDbStamper,
-    webauthnStamper,
+    apiKeyStamper,
+    passkeyStamper,
     organizationId,
     key = 'zeroDevWallet',
     name = 'ZeroDev Wallet Client',
@@ -29,8 +29,8 @@ export function createBaseClient<
     request,
     value,
   } = transport({
-    indexedDbStamper,
-    webauthnStamper,
+    apiKeyStamper,
+    passkeyStamper,
   })
   const transportInstance = { ...transportConfig, ...value }
 
@@ -39,8 +39,8 @@ export function createBaseClient<
   const client = {
     transport: transportInstance,
     request,
-    indexedDbStamper,
-    webauthnStamper,
+    apiKeyStamper,
+    passkeyStamper,
     organizationId,
     key,
     name,

--- a/packages/core/src/client/transports/createTransport.ts
+++ b/packages/core/src/client/transports/createTransport.ts
@@ -26,14 +26,14 @@ export function zeroDevWalletTransport(
     name = 'ZeroDev Wallet Transport',
   } = options
 
-  return ({ indexedDbStamper, webauthnStamper }) => {
+  return ({ apiKeyStamper, passkeyStamper }) => {
     // Create REST transport with stamper
     const transport = rest(baseUrl, {
       timeoutMs,
       key,
       name,
-      indexedDbStamper,
-      webauthnStamper,
+      apiKeyStamper,
+      passkeyStamper,
     })
 
     return {
@@ -46,8 +46,8 @@ export function zeroDevWalletTransport(
       },
       request: transport.request,
       value: {
-        indexedDbStamper,
-        webauthnStamper,
+        apiKeyStamper,
+        passkeyStamper,
       },
     }
   }

--- a/packages/core/src/client/transports/rest.ts
+++ b/packages/core/src/client/transports/rest.ts
@@ -1,6 +1,6 @@
 import { canonicalizeEx } from 'json-canonicalize'
 import { RestRequestError, RestTimeoutError } from '../../errors/request.js'
-import type { IndexedDbStamper, WebauthnStamper } from '../../stampers/types.js'
+import type { ApiKeyStamper, PasskeyStamper } from '../../stampers/types.js'
 
 export type RestRequestArgs = {
   path: string
@@ -8,7 +8,8 @@ export type RestRequestArgs = {
   body?: any
   headers?: Record<string, string>
   stamp?: boolean
-  stampWith?: 'indexedDb' | 'webAuthn'
+  // TODO: @stamper-type - Derive type from `StamperType`
+  stampWith?: 'apiKey' | 'passkey'
   stampPostion?: 'body' | 'headers'
   /** Include credentials (cookies) in the request */
   credentials?: RequestCredentials
@@ -32,8 +33,8 @@ export type RestTransportConfig = {
   timeoutMs?: number
   key?: string
   name?: string
-  indexedDbStamper: IndexedDbStamper
-  webauthnStamper: WebauthnStamper
+  apiKeyStamper: ApiKeyStamper
+  passkeyStamper: PasskeyStamper
 }
 
 export function rest(url: string, cfg: RestTransportConfig): RestTransport {
@@ -56,13 +57,13 @@ export function rest(url: string, cfg: RestTransportConfig): RestTransport {
 
       // Handle stamping if requested
       if (args.stamp) {
-        let stamper: IndexedDbStamper | WebauthnStamper
-        if (args.stampWith === 'indexedDb') {
-          stamper = cfg.indexedDbStamper
-        } else if (args.stampWith === 'webAuthn') {
-          stamper = cfg.webauthnStamper
+        let stamper: ApiKeyStamper | PasskeyStamper
+        if (args.stampWith === 'apiKey') {
+          stamper = cfg.apiKeyStamper
+        } else if (args.stampWith === 'passkey') {
+          stamper = cfg.passkeyStamper
         } else {
-          stamper = cfg.indexedDbStamper
+          stamper = cfg.apiKeyStamper
         }
         const { body, apiUrl } = args.body
         const bodyString = canonicalizeEx(body ?? args.body)

--- a/packages/core/src/client/transports/rest.ts
+++ b/packages/core/src/client/transports/rest.ts
@@ -1,6 +1,7 @@
 import { canonicalizeEx } from 'json-canonicalize'
 import { RestRequestError, RestTimeoutError } from '../../errors/request.js'
 import type { ApiKeyStamper, PasskeyStamper } from '../../stampers/types.js'
+import type { StamperType } from '../../types/session.js'
 
 export type RestRequestArgs = {
   path: string
@@ -8,8 +9,7 @@ export type RestRequestArgs = {
   body?: any
   headers?: Record<string, string>
   stamp?: boolean
-  // TODO: @stamper-type - Derive type from `StamperType`
-  stampWith?: 'apiKey' | 'passkey'
+  stampWith?: StamperType
   stampPostion?: 'body' | 'headers'
   /** Include credentials (cookies) in the request */
   credentials?: RequestCredentials

--- a/packages/core/src/client/types.ts
+++ b/packages/core/src/client/types.ts
@@ -1,4 +1,4 @@
-import type { IndexedDbStamper, WebauthnStamper } from '../stampers/types.js'
+import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'
 import type { RestRequestFn } from './transports/rest.js'
 
 export type TransportConfig = {
@@ -17,8 +17,8 @@ export type TransportConfig = {
 }
 
 export type Transport = (options: {
-  indexedDbStamper: IndexedDbStamper
-  webauthnStamper: WebauthnStamper
+  apiKeyStamper: ApiKeyStamper
+  passkeyStamper: PasskeyStamper
 }) => {
   config: TransportConfig
   request: RestRequestFn
@@ -27,8 +27,8 @@ export type Transport = (options: {
 
 export type ClientConfig = {
   transport: Transport
-  indexedDbStamper: IndexedDbStamper
-  webauthnStamper: WebauthnStamper
+  apiKeyStamper: ApiKeyStamper
+  passkeyStamper: PasskeyStamper
   organizationId?: string
   key?: string
   name?: string
@@ -39,10 +39,10 @@ export type Client<extended extends Extended | undefined = undefined> = {
   transport: TransportConfig & Record<string, unknown>
   /** Request function from transport */
   request: RestRequestFn
-  /** IndexedDB Stamper for authenticated requests */
-  indexedDbStamper: IndexedDbStamper
-  /** WebAuthn Stamper for authenticated requests */
-  webauthnStamper: WebauthnStamper
+  /** API Key Stamper for authenticated requests */
+  apiKeyStamper: ApiKeyStamper
+  /** Passkey Stamper for authenticated requests */
+  passkeyStamper: PasskeyStamper
   /** Organization ID */
   organizationId?: string
   /** A key for the client */

--- a/packages/core/src/core/createZeroDevWallet.ts
+++ b/packages/core/src/core/createZeroDevWallet.ts
@@ -205,7 +205,6 @@ export async function createZeroDevWallet(
           organizationId: parsedSession.organizationId,
           stamperType: 'indexedDb',
           sessionType: SessionType.READ_WRITE,
-          publicKey: compressedPublicKeyHex,
           token: data.session,
           expiry: parsedSession.expiry,
           createdAt: Date.now(),
@@ -230,7 +229,6 @@ export async function createZeroDevWallet(
           if (data.session) {
             // Parse the JWT to get session data
             const parsedSession = parseSession(data.session)
-            const publicKey = await client.apiKeyStamper.getPublicKey()
             const session: ZeroDevWalletSession = {
               id: `session_oauth_${Date.now()}`,
               userId: parsedSession.userId,
@@ -240,7 +238,6 @@ export async function createZeroDevWallet(
               token: data.session,
               expiry: parsedSession.expiry,
               createdAt: Date.now(),
-              publicKey: publicKey || '',
             }
             await sessionStorageManager.storeSession(session, session.id)
           }
@@ -289,7 +286,6 @@ export async function createZeroDevWallet(
               expiry:
                 Date.now() +
                 Number(DEFAULT_SESSION_EXPIRATION_IN_SECONDS) * 1000,
-              publicKey: compressedPublicKeyHex,
               token: loginData.session,
             }
             await sessionStorageManager.storeSession(session, session.id)
@@ -322,7 +318,6 @@ export async function createZeroDevWallet(
               expiry:
                 Date.now() +
                 Number(DEFAULT_SESSION_EXPIRATION_IN_SECONDS) * 1000,
-              publicKey: generatedPublicKey,
               token: loginData.session,
             }
             await sessionStorageManager.storeSession(session, session.id)
@@ -436,7 +431,6 @@ export async function createZeroDevWallet(
                 token: data.session,
                 expiry: parsedSession.expiry,
                 createdAt: Date.now(),
-                publicKey: parsedSession.publicKey,
               }
               await sessionStorageManager.storeSession(session, session.id)
             }

--- a/packages/core/src/core/createZeroDevWallet.ts
+++ b/packages/core/src/core/createZeroDevWallet.ts
@@ -188,7 +188,7 @@ export async function createZeroDevWallet(
       if (!activeSession) {
         throw new Error('No active session')
       }
-      if (activeSession.stamperType === 'indexedDb') {
+      if (activeSession.stamperType === 'apiKey') {
         const compressedPublicKeyHex =
           await client.apiKeyStamper.prepareKeyRotation()
         const data = await client.loginWithStamp({
@@ -203,7 +203,7 @@ export async function createZeroDevWallet(
           id: `session_indexedDb_${Date.now()}`,
           userId: parsedSession.userId,
           organizationId: parsedSession.organizationId,
-          stamperType: 'indexedDb',
+          stamperType: 'apiKey',
           sessionType: SessionType.READ_WRITE,
           token: data.session,
           expiry: parsedSession.expiry,
@@ -233,7 +233,7 @@ export async function createZeroDevWallet(
               id: `session_oauth_${Date.now()}`,
               userId: parsedSession.userId,
               organizationId: parsedSession.organizationId,
-              stamperType: 'indexedDb',
+              stamperType: 'apiKey',
               sessionType: parsedSession.sessionType || SessionType.READ_WRITE,
               token: data.session,
               expiry: parsedSession.expiry,
@@ -278,7 +278,7 @@ export async function createZeroDevWallet(
             const parsedSession = parseSession(loginData.session)
             const session: ZeroDevWalletSession = {
               id: `session_indexedDb_${Date.now()}`,
-              stamperType: 'indexedDb',
+              stamperType: 'apiKey',
               createdAt: Date.now(),
               sessionType: SessionType.READ_WRITE,
               userId: parsedSession.userId,
@@ -310,7 +310,7 @@ export async function createZeroDevWallet(
             const parsedSession = parseSession(loginData.session)
             const session: ZeroDevWalletSession = {
               id: `session_indexedDb_${Date.now()}`,
-              stamperType: 'indexedDb',
+              stamperType: 'apiKey',
               createdAt: Date.now(),
               sessionType: SessionType.READ_WRITE,
               userId: parsedSession.userId,
@@ -425,7 +425,7 @@ export async function createZeroDevWallet(
                 id: `session_otp_${Date.now()}`,
                 userId: parsedSession.userId,
                 organizationId: parsedSession.organizationId,
-                stamperType: 'indexedDb',
+                stamperType: 'apiKey',
                 sessionType:
                   parsedSession.sessionType || SessionType.READ_WRITE,
                 token: data.session,

--- a/packages/core/src/core/createZeroDevWallet.ts
+++ b/packages/core/src/core/createZeroDevWallet.ts
@@ -1,4 +1,3 @@
-import { getWebAuthnAttestation } from '@turnkey/http'
 import type { LocalAccount } from 'viem/accounts'
 import type {
   EmailCustomization,
@@ -17,6 +16,7 @@ import {
   KMS_SERVER_URL,
 } from '../constants.js'
 import { createIndexedDbStamper } from '../stampers/indexedDbStamper.js'
+import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'
 import { createWebauthnStamper } from '../stampers/webauthnStamper.js'
 import { createWebStorageAdapter } from '../storage/adapters.js'
 import {
@@ -26,19 +26,15 @@ import {
 import { SessionType, type ZeroDevWalletSession } from '../types/session.js'
 import { buildClientSignature } from '../utils/buildClientSignature.js'
 import { encryptOtpAttempt } from '../utils/encryptOtpAttempt.js'
-import {
-  base64UrlEncode,
-  generateCompressedPublicKeyFromKeyPair,
-  generateRandomBuffer,
-  humanReadableDateTime,
-  parseSession,
-} from '../utils/utils.js'
+import { humanReadableDateTime, parseSession } from '../utils/utils.js'
 export interface ZeroDevWalletConfig {
   organizationId?: string
   proxyBaseUrl?: string
   projectId: string
   sessionStorage?: StorageAdapter
   rpId?: string
+  apiKeyStamper?: ApiKeyStamper
+  passkeyStamper?: PasskeyStamper
 }
 
 // Re-export EmailCustomization for convenience
@@ -134,13 +130,14 @@ export async function createZeroDevWallet(
     sessionStorage || createWebStorageAdapter(),
   )
 
-  const indexedDbStamper = await createIndexedDbStamper()
+  const apiKeyStamper = config.apiKeyStamper ?? (await createIndexedDbStamper())
 
-  const webauthnStamper = await createWebauthnStamper({ rpId })
+  const passkeyStamper =
+    config.passkeyStamper ?? (await createWebauthnStamper({ rpId }))
 
   const client = createClient({
-    indexedDbStamper,
-    webauthnStamper,
+    apiKeyStamper,
+    passkeyStamper,
     transport: zeroDevWalletTransport({
       baseUrl: config.proxyBaseUrl || `${KMS_SERVER_URL}/api/v1`,
     }),
@@ -151,8 +148,8 @@ export async function createZeroDevWallet(
   return {
     client,
     async getPublicKey() {
-      await client.indexedDbStamper.resetKeyPair()
-      const compressedPublicKey = await client.indexedDbStamper.getPublicKey()
+      await client.apiKeyStamper.resetKeyPair()
+      const compressedPublicKey = await client.apiKeyStamper.getPublicKey()
       return compressedPublicKey
     },
 
@@ -192,23 +189,15 @@ export async function createZeroDevWallet(
         throw new Error('No active session')
       }
       if (activeSession.stamperType === 'indexedDb') {
-        const newKeyPair = await crypto.subtle.generateKey(
-          {
-            name: 'ECDSA',
-            namedCurve: 'P-256',
-          },
-          false,
-          ['sign', 'verify'],
-        )
         const compressedPublicKeyHex =
-          await generateCompressedPublicKeyFromKeyPair(newKeyPair)
+          await client.apiKeyStamper.prepareKeyRotation()
         const data = await client.loginWithStamp({
           targetPublicKey: compressedPublicKeyHex,
           projectId,
           organizationId: activeSession.organizationId,
-          stampWith: 'indexedDb',
+          stampWith: 'apiKey',
         })
-        await client.indexedDbStamper.resetKeyPair(newKeyPair)
+        await client.apiKeyStamper.commitKeyRotation()
         const parsedSession = parseSession(data.session)
         const session: ZeroDevWalletSession = {
           id: `session_indexedDb_${Date.now()}`,
@@ -216,6 +205,7 @@ export async function createZeroDevWallet(
           organizationId: parsedSession.organizationId,
           stamperType: 'indexedDb',
           sessionType: SessionType.READ_WRITE,
+          publicKey: compressedPublicKeyHex,
           token: data.session,
           expiry: parsedSession.expiry,
           createdAt: Date.now(),
@@ -240,7 +230,7 @@ export async function createZeroDevWallet(
           if (data.session) {
             // Parse the JWT to get session data
             const parsedSession = parseSession(data.session)
-            const publicKey = await client.indexedDbStamper.getPublicKey()
+            const publicKey = await client.apiKeyStamper.getPublicKey()
             const session: ZeroDevWalletSession = {
               id: `session_oauth_${Date.now()}`,
               userId: parsedSession.userId,
@@ -263,58 +253,31 @@ export async function createZeroDevWallet(
             'mode' in params &&
             params.mode === 'register'
           ) {
-            await client.indexedDbStamper.resetKeyPair()
-            const tempPublicKey = await client.indexedDbStamper.getPublicKey()
+            await client.apiKeyStamper.resetKeyPair()
+            const tempPublicKey = await client.apiKeyStamper.getPublicKey()
             if (!tempPublicKey) {
               throw new Error('Failed to get public key')
             }
-            const challenge = generateRandomBuffer()
-            const encodedChallenge = base64UrlEncode(challenge)
-            const authenticatorUserId = generateRandomBuffer()
             const name = `ZeroDevWallet-${humanReadableDateTime()}`
-            const attestation = await getWebAuthnAttestation({
-              publicKey: {
+            const { attestation, encodedChallenge } =
+              await passkeyStamper.register({
                 rp: { id: rpId, name: '' },
-                challenge,
-                pubKeyCredParams: [
-                  {
-                    type: 'public-key',
-                    alg: -7,
-                  },
-                  {
-                    type: 'public-key',
-                    alg: -257,
-                  },
-                ],
-                user: {
-                  id: authenticatorUserId,
-                  name,
-                  displayName: name,
-                },
-              },
-            })
+                userName: name,
+              })
             const data = await client.registerWithPasskey({
               attestation,
               challenge: encodedChallenge,
               projectId,
               encodedPublicKey: tempPublicKey,
             })
-            const newKeyPair = await crypto.subtle.generateKey(
-              {
-                name: 'ECDSA',
-                namedCurve: 'P-256',
-              },
-              false,
-              ['sign', 'verify'],
-            )
             const compressedPublicKeyHex =
-              await generateCompressedPublicKeyFromKeyPair(newKeyPair)
+              await client.apiKeyStamper.prepareKeyRotation()
             const loginData = await client.loginWithStamp({
               projectId,
               targetPublicKey: compressedPublicKeyHex,
               organizationId: data.subOrganizationId,
             })
-            await client.indexedDbStamper.resetKeyPair(newKeyPair)
+            await client.apiKeyStamper.commitKeyRotation()
             const parsedSession = parseSession(loginData.session)
             const session: ZeroDevWalletSession = {
               id: `session_indexedDb_${Date.now()}`,
@@ -326,6 +289,7 @@ export async function createZeroDevWallet(
               expiry:
                 Date.now() +
                 Number(DEFAULT_SESSION_EXPIRATION_IN_SECONDS) * 1000,
+              publicKey: compressedPublicKeyHex,
               token: loginData.session,
             }
             await sessionStorageManager.storeSession(session, session.id)
@@ -336,9 +300,8 @@ export async function createZeroDevWallet(
             'mode' in params &&
             params.mode === 'login'
           ) {
-            await client.indexedDbStamper.resetKeyPair()
-            const generatedPublicKey =
-              await client.indexedDbStamper.getPublicKey()
+            await client.apiKeyStamper.resetKeyPair()
+            const generatedPublicKey = await client.apiKeyStamper.getPublicKey()
             if (!generatedPublicKey) {
               throw new Error('Failed to get public key')
             }
@@ -346,7 +309,7 @@ export async function createZeroDevWallet(
               targetPublicKey: generatedPublicKey,
               projectId,
               organizationId,
-              stampWith: 'webauthn',
+              stampWith: 'passkey',
             })
             const parsedSession = parseSession(loginData.session)
             const session: ZeroDevWalletSession = {
@@ -359,6 +322,7 @@ export async function createZeroDevWallet(
               expiry:
                 Date.now() +
                 Number(DEFAULT_SESSION_EXPIRATION_IN_SECONDS) * 1000,
+              publicKey: generatedPublicKey,
               token: loginData.session,
             }
             await sessionStorageManager.storeSession(session, session.id)
@@ -416,8 +380,8 @@ export async function createZeroDevWallet(
             const { otpId, otpCode, otpEncryptionTargetBundle } = otpParams
 
             // Step 1: Generate new key pair
-            await client.indexedDbStamper.resetKeyPair()
-            const targetPublicKey = await client.indexedDbStamper.getPublicKey()
+            await client.apiKeyStamper.resetKeyPair()
+            const targetPublicKey = await client.apiKeyStamper.getPublicKey()
 
             if (!targetPublicKey) {
               throw new Error('Failed to get public key')
@@ -449,7 +413,7 @@ export async function createZeroDevWallet(
             const clientSignature = await buildClientSignature({
               verificationToken,
               publicKey: targetPublicKey,
-              stamper: client.indexedDbStamper,
+              stamper: client.apiKeyStamper,
             })
 
             // Step 4: Login via backend (not Auth Proxy!)
@@ -472,7 +436,7 @@ export async function createZeroDevWallet(
                 token: data.session,
                 expiry: parsedSession.expiry,
                 createdAt: Date.now(),
-                publicKey: targetPublicKey,
+                publicKey: parsedSession.publicKey,
               }
               await sessionStorageManager.storeSession(session, session.id)
             }
@@ -488,7 +452,7 @@ export async function createZeroDevWallet(
 
     async logout() {
       await sessionStorageManager.clearAllSessions()
-      await client.indexedDbStamper.resetKeyPair()
+      await client.apiKeyStamper.resetKeyPair()
       return true
     },
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,9 +80,12 @@ export {
   createWebauthnStamper,
 } from './stampers/index.js'
 export type {
+  ApiKeyStamper,
+  Attestation,
   IframeStamper,
-  IndexedDbStamper,
-  WebauthnStamper,
+  PasskeyRegistrationOptions,
+  PasskeyRegistrationResult,
+  PasskeyStamper,
 } from './stampers/types.js'
 // Storage
 export type { StorageAdapter, StorageManager } from './storage/manager.js'

--- a/packages/core/src/stampers/index.ts
+++ b/packages/core/src/stampers/index.ts
@@ -1,8 +1,8 @@
 export { createIframeStamper } from './iframeStamper.js'
 export { createIndexedDbStamper } from './indexedDbStamper.js'
 export type {
+  ApiKeyStamper,
   IframeStamper,
-  IndexedDbStamper,
-  WebauthnStamper,
+  PasskeyStamper,
 } from './types.js'
 export { createWebauthnStamper } from './webauthnStamper.js'

--- a/packages/core/src/stampers/indexedDbStamper.ts
+++ b/packages/core/src/stampers/indexedDbStamper.ts
@@ -1,9 +1,12 @@
 import { IndexedDbStamper as TurnkeyIndexedDbStamper } from '@turnkey/indexed-db-stamper'
-import type { IndexedDbStamper } from './types.js'
+import { generateCompressedPublicKeyFromKeyPair } from '../utils/utils.js'
+import type { ApiKeyStamper } from './types.js'
 
-export async function createIndexedDbStamper(): Promise<IndexedDbStamper> {
+export async function createIndexedDbStamper(): Promise<ApiKeyStamper> {
   const inner = new TurnkeyIndexedDbStamper()
   await inner.init()
+
+  let pendingKeyPair: CryptoKeyPair | null = null
 
   return {
     async getPublicKey() {
@@ -15,8 +18,25 @@ export async function createIndexedDbStamper(): Promise<IndexedDbStamper> {
     async clear() {
       await inner.clear()
     },
-    async resetKeyPair(externalKeyPair?: CryptoKeyPair) {
-      await inner.resetKeyPair(externalKeyPair)
+    async resetKeyPair() {
+      pendingKeyPair = null
+      await inner.resetKeyPair()
+    },
+    async prepareKeyRotation() {
+      const keyPair = await crypto.subtle.generateKey(
+        { name: 'ECDSA', namedCurve: 'P-256' },
+        false,
+        ['sign', 'verify'],
+      )
+      pendingKeyPair = keyPair
+      return await generateCompressedPublicKeyFromKeyPair(keyPair)
+    },
+    async commitKeyRotation() {
+      if (!pendingKeyPair) {
+        throw new Error('No pending key rotation to commit')
+      }
+      await inner.resetKeyPair(pendingKeyPair)
+      pendingKeyPair = null
     },
   }
 }

--- a/packages/core/src/stampers/types.ts
+++ b/packages/core/src/stampers/types.ts
@@ -30,7 +30,33 @@ export type IframeStamper = Stamper & {
   applySettings(settings: { styles?: Record<string, string> }): Promise<boolean>
 }
 
-export type IndexedDbStamper = Stamper & {
-  resetKeyPair: (externalKeyPair?: CryptoKeyPair) => Promise<void>
+export type ApiKeyStamper = Stamper & {
+  /** Generate + activate a new key pair immediately (simple cases: login init, logout). */
+  resetKeyPair: () => Promise<void>
+  /** Generate a new key pair internally, return its public key, but keep the OLD key active for stamp(). */
+  prepareKeyRotation: () => Promise<string>
+  /** Promote the pending key to active. Call after the server accepts the new key. */
+  commitKeyRotation: () => Promise<void>
 }
-export type WebauthnStamper = Stamper
+export type Attestation = {
+  attestationObject: string
+  clientDataJson: string
+  credentialId: string
+}
+
+export type PasskeyRegistrationOptions = {
+  rp: { id: string; name: string }
+  userName: string
+}
+
+export type PasskeyRegistrationResult = {
+  attestation: Attestation
+  encodedChallenge: string
+}
+
+export type PasskeyStamper = Stamper & {
+  /** Create a new passkey credential. Owns challenge and user ID generation internally. */
+  register: (
+    options: PasskeyRegistrationOptions,
+  ) => Promise<PasskeyRegistrationResult>
+}

--- a/packages/core/src/stampers/types.ts
+++ b/packages/core/src/stampers/types.ts
@@ -5,8 +5,6 @@ export type Stamp = {
 }
 
 export type Stamper = {
-  /** retrieve public key compressed or otherwise as per the stamper */
-  getPublicKey: () => Promise<string | null>
   /** produce Turnkey header value for a given request body */
   stamp: (payload: string) => Promise<Stamp>
   /** clear local state (embedded key, IDB keypair, etc.) */
@@ -16,6 +14,8 @@ export type Stamper = {
 export type KeyFormat = 'Hexadecimal' | 'Solana'
 
 export type IframeStamper = Stamper & {
+  /** retrieve public key compressed or otherwise as per the stamper */
+  getPublicKey: () => Promise<string | null>
   init(): Promise<string>
   injectCredentialBundle(bundle: string): Promise<boolean>
   injectWalletExportBundle(
@@ -31,6 +31,8 @@ export type IframeStamper = Stamper & {
 }
 
 export type ApiKeyStamper = Stamper & {
+  /** retrieve public key compressed or otherwise as per the stamper */
+  getPublicKey: () => Promise<string | null>
   /** Generate + activate a new key pair immediately (simple cases: login init, logout). */
   resetKeyPair: () => Promise<void>
   /** Generate a new key pair internally, return its compressed public key, but keep the OLD key active for stamp(). */

--- a/packages/core/src/stampers/types.ts
+++ b/packages/core/src/stampers/types.ts
@@ -33,7 +33,7 @@ export type IframeStamper = Stamper & {
 export type ApiKeyStamper = Stamper & {
   /** Generate + activate a new key pair immediately (simple cases: login init, logout). */
   resetKeyPair: () => Promise<void>
-  /** Generate a new key pair internally, return its public key, but keep the OLD key active for stamp(). */
+  /** Generate a new key pair internally, return its compressed public key, but keep the OLD key active for stamp(). */
   prepareKeyRotation: () => Promise<string>
   /** Promote the pending key to active. Call after the server accepts the new key. */
   commitKeyRotation: () => Promise<void>

--- a/packages/core/src/stampers/webauthnStamper.ts
+++ b/packages/core/src/stampers/webauthnStamper.ts
@@ -1,11 +1,13 @@
+import { getWebAuthnAttestation } from '@turnkey/http'
 import { WebauthnStamper as TurnkeyWebauthnStamper } from '@turnkey/webauthn-stamper'
-import type { WebauthnStamper } from './types.js'
+import { base64UrlEncode, generateRandomBuffer } from '../utils/utils.js'
+import type { PasskeyRegistrationOptions, PasskeyStamper } from './types.js'
 
 export async function createWebauthnStamper({
   rpId,
 }: {
   rpId: string
-}): Promise<WebauthnStamper> {
+}): Promise<PasskeyStamper> {
   const inner = new TurnkeyWebauthnStamper({ rpId })
 
   return {
@@ -17,5 +19,28 @@ export async function createWebauthnStamper({
       return await inner.stamp(payload)
     },
     async clear() {},
+    async register(options: PasskeyRegistrationOptions) {
+      const challenge = generateRandomBuffer()
+      const encodedChallenge = base64UrlEncode(challenge)
+      const authenticatorUserId = generateRandomBuffer()
+
+      const attestation = await getWebAuthnAttestation({
+        publicKey: {
+          rp: options.rp,
+          challenge,
+          pubKeyCredParams: [
+            { type: 'public-key', alg: -7 },
+            { type: 'public-key', alg: -257 },
+          ],
+          user: {
+            id: authenticatorUserId,
+            name: options.userName,
+            displayName: options.userName,
+          },
+        },
+      })
+
+      return { attestation, encodedChallenge }
+    },
   }
 }

--- a/packages/core/src/stampers/webauthnStamper.ts
+++ b/packages/core/src/stampers/webauthnStamper.ts
@@ -11,10 +11,6 @@ export async function createWebauthnStamper({
   const inner = new TurnkeyWebauthnStamper({ rpId })
 
   return {
-    async getPublicKey() {
-      //   return await inner.();
-      return null
-    },
     async stamp(payload: string) {
       return await inner.stamp(payload)
     },

--- a/packages/core/src/storage/manager.test.ts
+++ b/packages/core/src/storage/manager.test.ts
@@ -26,6 +26,7 @@ function createSession(
     userId: 'user-123',
     organizationId: 'org-456',
     stamperType: 'iframe',
+    publicKey: 'mock-public-key',
     expiry: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now (in seconds)
     createdAt: Date.now(),
     ...overrides,

--- a/packages/core/src/storage/manager.test.ts
+++ b/packages/core/src/storage/manager.test.ts
@@ -25,8 +25,8 @@ function createSession(
     id: `session-${Math.random().toString(36).slice(2)}`,
     userId: 'user-123',
     organizationId: 'org-456',
-    stamperType: 'iframe',
-    publicKey: 'mock-public-key',
+    stamperType: 'apiKey',
+    token: 'mock-token',
     expiry: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now (in seconds)
     createdAt: Date.now(),
     ...overrides,

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -3,8 +3,7 @@ export enum SessionType {
   READ_WRITE = 'SESSION_TYPE_READ_WRITE',
 }
 
-// TODO: Change `stamperType` to `"apiKey" | "passkey"`
-export type StamperType = 'iframe' | 'indexedDb' | 'passkey'
+export type StamperType = 'apiKey' | 'passkey'
 
 export type ZeroDevWalletSession = {
   id: string

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -12,8 +12,7 @@ export type ZeroDevWalletSession = {
   organizationId: string
   stamperType: StamperType
   sessionType?: SessionType
-  token?: string
-  publicKey: string
+  token: string
   expiry: number
   createdAt: number
 }

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -3,6 +3,7 @@ export enum SessionType {
   READ_WRITE = 'SESSION_TYPE_READ_WRITE',
 }
 
+// TODO: Change `stamperType` to `"apiKey" | "passkey"`
 export type StamperType = 'iframe' | 'indexedDb' | 'passkey'
 
 export type ZeroDevWalletSession = {
@@ -12,7 +13,7 @@ export type ZeroDevWalletSession = {
   stamperType: StamperType
   sessionType?: SessionType
   token?: string
-  publicKey?: string
+  publicKey: string
   expiry: number
   createdAt: number
 }

--- a/packages/core/src/utils/buildClientSignature.test.ts
+++ b/packages/core/src/utils/buildClientSignature.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { IndexedDbStamper } from '../stampers/types.js'
+import type { ApiKeyStamper } from '../stampers/types.js'
 import { buildClientSignature } from './buildClientSignature.js'
 
 // Helper to create base64url encoded string
@@ -26,7 +26,7 @@ function createValidDerSignature(): string {
 // Create a mock stamper
 function createMockStamper(
   signatureHex: string = createValidDerSignature(),
-): IndexedDbStamper {
+): ApiKeyStamper {
   return {
     stamp: vi.fn().mockResolvedValue({
       stampHeaderName: 'X-Stamp',
@@ -37,6 +37,8 @@ function createMockStamper(
     getPublicKey: vi.fn().mockResolvedValue('mock-public-key'),
     clear: vi.fn().mockResolvedValue(undefined),
     resetKeyPair: vi.fn().mockResolvedValue(undefined),
+    prepareKeyRotation: vi.fn().mockResolvedValue('mock-public-key'),
+    commitKeyRotation: vi.fn().mockResolvedValue(undefined),
   }
 }
 

--- a/packages/core/src/utils/buildClientSignature.ts
+++ b/packages/core/src/utils/buildClientSignature.ts
@@ -1,4 +1,4 @@
-import type { IndexedDbStamper } from '../stampers/types.js'
+import type { ApiKeyStamper } from '../stampers/types.js'
 import { derToRawSignature } from './derToRawSignature.js'
 
 export type BuildClientSignatureParams = {
@@ -6,8 +6,8 @@ export type BuildClientSignatureParams = {
   verificationToken: string
   /** The compressed public key hex */
   publicKey: string
-  /** The IndexedDB stamper for signing */
-  stamper: IndexedDbStamper
+  /** The API key stamper for signing */
+  stamper: ApiKeyStamper
 }
 
 /**

--- a/packages/core/src/utils/exportPrivateKey.ts
+++ b/packages/core/src/utils/exportPrivateKey.ts
@@ -71,8 +71,9 @@ export async function exportPrivateKey(
     },
   })
 
+  // TODO: Change `stamperType` to `"apiKey" | "passkey"`
   const stamperKey =
-    session.stamperType === 'indexedDb' ? 'indexedDbStamper' : 'webauthnStamper'
+    session.stamperType === 'indexedDb' ? 'apiKeyStamper' : 'passkeyStamper'
   const stamper = wallet.client[stamperKey]
   if (!stamper) {
     throw new Error(`Stamper '${stamperKey}' not found on wallet.client`)

--- a/packages/core/src/utils/exportPrivateKey.ts
+++ b/packages/core/src/utils/exportPrivateKey.ts
@@ -71,9 +71,8 @@ export async function exportPrivateKey(
     },
   })
 
-  // TODO: Change `stamperType` to `"apiKey" | "passkey"`
   const stamperKey =
-    session.stamperType === 'indexedDb' ? 'apiKeyStamper' : 'passkeyStamper'
+    session.stamperType === 'apiKey' ? 'apiKeyStamper' : 'passkeyStamper'
   const stamper = wallet.client[stamperKey]
   if (!stamper) {
     throw new Error(`Stamper '${stamperKey}' not found on wallet.client`)

--- a/packages/core/src/utils/exportWallet.ts
+++ b/packages/core/src/utils/exportWallet.ts
@@ -56,9 +56,8 @@ export async function exportWallet(
 
     const listWalletsStamp =
       await wallet.client[
-        session.stamperType === 'indexedDb'
-          ? 'indexedDbStamper'
-          : 'webauthnStamper'
+        // TODO: Change `stamperType` to `"apiKey" | "passkey"`
+        session.stamperType === 'indexedDb' ? 'apiKeyStamper' : 'passkeyStamper'
       ].stamp(listWalletsBody)
     if (!listWalletsStamp) {
       throw new Error('Failed to stamp list wallets body')
@@ -93,9 +92,8 @@ export async function exportWallet(
     })
     const exportWalletStamp =
       await wallet.client[
-        session.stamperType === 'indexedDb'
-          ? 'indexedDbStamper'
-          : 'webauthnStamper'
+        // TODO: Change `stamperType` to `"apiKey" | "passkey"`
+        session.stamperType === 'indexedDb' ? 'apiKeyStamper' : 'passkeyStamper'
       ].stamp(exportWalletBody)
     if (!exportWalletStamp) {
       throw new Error('Failed to stamp export wallet body')

--- a/packages/core/src/utils/exportWallet.ts
+++ b/packages/core/src/utils/exportWallet.ts
@@ -56,8 +56,7 @@ export async function exportWallet(
 
     const listWalletsStamp =
       await wallet.client[
-        // TODO: Change `stamperType` to `"apiKey" | "passkey"`
-        session.stamperType === 'indexedDb' ? 'apiKeyStamper' : 'passkeyStamper'
+        session.stamperType === 'apiKey' ? 'apiKeyStamper' : 'passkeyStamper'
       ].stamp(listWalletsBody)
     if (!listWalletsStamp) {
       throw new Error('Failed to stamp list wallets body')
@@ -92,8 +91,7 @@ export async function exportWallet(
     })
     const exportWalletStamp =
       await wallet.client[
-        // TODO: Change `stamperType` to `"apiKey" | "passkey"`
-        session.stamperType === 'indexedDb' ? 'apiKeyStamper' : 'passkeyStamper'
+        session.stamperType === 'apiKey' ? 'apiKeyStamper' : 'passkeyStamper'
       ].stamp(exportWalletBody)
     if (!exportWalletStamp) {
       throw new Error('Failed to stamp export wallet body')

--- a/packages/core/src/utils/utils.test.ts
+++ b/packages/core/src/utils/utils.test.ts
@@ -43,7 +43,7 @@ describe('parseSession', () => {
       id: 'session-id',
       userId: 'user-123',
       organizationId: 'org-456',
-      stamperType: 'iframe' as const,
+      stamperType: 'apiKey' as const,
       expiry: 1700000000,
       createdAt: 1699900000,
       token: 'test-public-key',

--- a/packages/core/src/utils/utils.test.ts
+++ b/packages/core/src/utils/utils.test.ts
@@ -35,7 +35,6 @@ describe('parseSession', () => {
       organizationId: 'org-456',
       expiry: 1700000000,
       token: 'test-public-key',
-      publicKey: 'test-public-key',
     })
   })
 
@@ -47,7 +46,7 @@ describe('parseSession', () => {
       stamperType: 'iframe' as const,
       expiry: 1700000000,
       createdAt: 1699900000,
-      publicKey: 'test-public-key',
+      token: 'test-public-key',
     }
 
     const result = parseSession(session)

--- a/packages/core/src/utils/utils.test.ts
+++ b/packages/core/src/utils/utils.test.ts
@@ -35,6 +35,7 @@ describe('parseSession', () => {
       organizationId: 'org-456',
       expiry: 1700000000,
       token: 'test-public-key',
+      publicKey: 'test-public-key',
     })
   })
 
@@ -46,6 +47,7 @@ describe('parseSession', () => {
       stamperType: 'iframe' as const,
       expiry: 1700000000,
       createdAt: 1699900000,
+      publicKey: 'test-public-key',
     }
 
     const result = parseSession(session)

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -37,7 +37,6 @@ export function parseSession(
     organizationId,
     expiry: exp,
     token: publicKey,
-    publicKey,
   }
 }
 

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -37,6 +37,7 @@ export function parseSession(
     organizationId,
     expiry: exp,
     token: publicKey,
+    publicKey,
   }
 }
 


### PR DESCRIPTION
<!-- av pr stack begin -->
<table><tr><td><details><summary>This PR is part of a stack created with <a href="https://github.com/aviator-co/av">Aviator</a>.</summary>

* **#142**
* **#141**
* **#131**
* **#80**
* **#124**
* **#76**
* **#75**
* **#74**
* **#73**
* **#72**
* ➡️ **#71**
* `main`
</details></td></tr></table>
<!-- av pr stack end -->


Closes FS-1925, FS-1946

Renamed the stampers to a more generic name `apiKeyStamper` and `passkeyStampers`. Exposed them so they can be passed in through `createZeroDevWallet()`. But I haven't removed the default `indexedDbStamper` and `webauthnStamper` so this is not a breaking change.

(will add more documentation later)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
