### PR TITLE
refactor(core): use atob and btoa instead of Buffer

### DIFF
--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -18,7 +18,8 @@ export function parseSession(
     throw new Error('Invalid JWT: Missing payload')
   }
 
-  const decoded = JSON.parse(Buffer.from(payload, 'base64').toString())
+  const base64 = payload.replace(/-/g, '+').replace(/_/g, '/')
+  const decoded = JSON.parse(atob(base64))
   const {
     exp,
     public_key: publicKey,
@@ -68,11 +69,9 @@ export const generateRandomBuffer = (): ArrayBuffer => {
  * @returns {string} - The encoded challenge.
  */
 export const base64UrlEncode = (challenge: ArrayBuffer): string => {
-  return Buffer.from(challenge)
-    .toString('base64')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=/g, '')
+  const bytes = new Uint8Array(challenge)
+  const binary = String.fromCharCode(...bytes)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
 }
 
 /**


### PR DESCRIPTION
<!-- av pr stack begin -->
<table><tr><td><details><summary>This PR is part of a stack created with <a href="https://github.com/aviator-co/av">Aviator</a>.</summary>

* **#142**
* **#141**
* **#131**
* **#80**
* **#124**
* **#76**
* **#75**
* **#74**
* **#73**
* ➡️ **#72**
* `main`
</details></td></tr></table>
<!-- av pr stack end -->


Closes FS-1926

Removing the usage of Buffer and switching to `atob` and `btoa` + using custom code. It works but this is probably best to replace with something more robust.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
