### PR TITLE
feat: add fetchOptions to core and react so Origin header can be sent on RN

### DIFF
--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -10,7 +10,10 @@ export {
   createClient,
   type ZeroDevWalletClient,
 } from './createClient.js'
-export { zeroDevWalletTransport } from './transports/createTransport.js'
+export {
+  type CreateTransportOptions,
+  zeroDevWalletTransport,
+} from './transports/createTransport.js'
 export type {
   Client,
   ClientConfig,

--- a/packages/core/src/client/transports/createTransport.ts
+++ b/packages/core/src/client/transports/createTransport.ts
@@ -10,6 +10,8 @@ export type CreateTransportOptions = {
   key?: string
   /** Transport name */
   name?: string
+  /** Extra options merged into every fetch() call */
+  fetchOptions?: Omit<RequestInit, 'body' | 'method' | 'signal'>
 }
 
 /**
@@ -34,6 +36,7 @@ export function zeroDevWalletTransport(
       name,
       apiKeyStamper,
       passkeyStamper,
+      ...(options.fetchOptions && { fetchOptions: options.fetchOptions }),
     })
 
     return {

--- a/packages/core/src/client/transports/rest.ts
+++ b/packages/core/src/client/transports/rest.ts
@@ -50,9 +50,9 @@ export function rest(url: string, cfg: RestTransportConfig): RestTransport {
     try {
       let requestBody = args.body
       let requestHeaders = {
-        'content-type': 'application/json',
-        ...(args.headers ?? {}),
         ...(cfg.fetchOptions?.headers ?? {}),
+        ...(args.headers ?? {}),
+        'content-type': 'application/json',
       }
 
       // Handle stamping if requested

--- a/packages/core/src/core/createZeroDevWallet.ts
+++ b/packages/core/src/core/createZeroDevWallet.ts
@@ -5,6 +5,7 @@ import type {
 } from '../actions/auth/index.js'
 import { toViemAccount } from '../adapters/viem.js'
 import {
+  type CreateTransportOptions,
   createAuthProxyClient,
   createClient,
   type ZeroDevWalletClient,
@@ -35,6 +36,7 @@ export interface ZeroDevWalletConfig {
   rpId?: string
   apiKeyStamper?: ApiKeyStamper
   passkeyStamper?: PasskeyStamper
+  fetchOptions?: CreateTransportOptions['fetchOptions']
 }
 
 // Re-export EmailCustomization for convenience
@@ -140,6 +142,7 @@ export async function createZeroDevWallet(
     passkeyStamper,
     transport: zeroDevWalletTransport({
       baseUrl: config.proxyBaseUrl || `${KMS_SERVER_URL}/api/v1`,
+      ...(config.fetchOptions && { fetchOptions: config.fetchOptions }),
     }),
   })
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,7 +56,12 @@ export { toViemAccount } from './adapters/viem.js'
 export type { ZeroDevWalletActions } from './client/decorators/client.js'
 // Client decorators
 export { zeroDevWalletActions } from './client/decorators/client.js'
-export type { Client, ClientConfig, Transport } from './client/index.js'
+export type {
+  Client,
+  ClientConfig,
+  CreateTransportOptions,
+  Transport,
+} from './client/index.js'
 // Client
 export {
   createBaseClient,

--- a/packages/react/src/connector.ts
+++ b/packages/react/src/connector.ts
@@ -8,6 +8,7 @@ import {
 import { getEntryPoint, KERNEL_V3_3 } from '@zerodev/sdk/constants'
 import type {
   ApiKeyStamper,
+  CreateTransportOptions,
   PasskeyStamper,
   StorageAdapter,
 } from '@zerodev/wallet-core'
@@ -104,6 +105,7 @@ export type ZeroDevWalletConnectorParams = {
   persistStorage?: CreateStoreOptions['storage']
   apiKeyStamper?: ApiKeyStamper | Promise<ApiKeyStamper>
   passkeyStamper?: PasskeyStamper | Promise<PasskeyStamper>
+  fetchOptions?: CreateTransportOptions['fetchOptions']
   autoRefreshSession?: boolean
   sessionWarningThreshold?: number
   /**
@@ -160,7 +162,10 @@ export function zeroDevWallet(
      *
      * No-ops if the chain is already set up.
      */
-    const setupChain = async (chainId: number) => {
+    const setupChain = async (
+      chainId: number,
+      httpOpts?: { fetchOptions?: CreateTransportOptions['fetchOptions'] },
+    ) => {
       const state = store.getState()
       const eoaAccount = state.eoaAccount
       if (!eoaAccount) throw new Error('Not authenticated')
@@ -210,12 +215,16 @@ export function zeroDevWallet(
         account: kernelAccount,
         bundlerTransport: http(
           getAAUrl(params.projectId, chainId, params.aaUrl),
+          httpOpts,
         ),
         chain,
         client: publicClient,
         paymaster: createZeroDevPaymasterClient({
           chain,
-          transport: http(getAAUrl(params.projectId, chainId, params.aaUrl)),
+          transport: http(
+            getAAUrl(params.projectId, chainId, params.aaUrl),
+            httpOpts,
+          ),
         }),
       })
       store.getState().setKernelClient(chainId, kernelClient)
@@ -233,6 +242,9 @@ export function zeroDevWallet(
       }
       return state.eoaAccount?.address ?? null
     }
+    const httpOpts = params.fetchOptions
+      ? { fetchOptions: params.fetchOptions }
+      : undefined
 
     // Lazy initialization - only runs on client side (idempotent)
     const initialize = async () => {
@@ -266,6 +278,7 @@ export function zeroDevWallet(
         ...(params.rpId && { rpId: params.rpId }),
         ...(apiKeyStamper && { apiKeyStamper }),
         ...(passkeyStamper && { passkeyStamper }),
+        ...(params.fetchOptions && { fetchOptions: params.fetchOptions }),
       })
 
       // Create store
@@ -361,7 +374,7 @@ export function zeroDevWallet(
           )
         }
 
-        await setupChain(activeChainId)
+        await setupChain(activeChainId, httpOpts)
 
         store.getState().setActiveChainId(activeChainId)
 
@@ -432,7 +445,7 @@ export function zeroDevWallet(
         }
 
         store.getState().setActiveChainId(chainId)
-        await setupChain(chainId)
+        await setupChain(chainId, httpOpts)
 
         wagmiConfig.emitter.emit('change', { chainId })
         return params.chains.find((c) => c.id === chainId)!


### PR DESCRIPTION
<!-- av pr stack begin -->
<table><tr><td><details><summary>This PR is part of a stack created with <a href="https://github.com/aviator-co/av">Aviator</a>.</summary>

* **#168**
* **#142**
* **#141**
* **#131**
* **#80**
* **#124**
* **#76**
* **#75**
* ➡️ **#74**
* `main`
</details></td></tr></table>
<!-- av pr stack end -->


Part of FS-1971

`fetch` doesn't automatically send `Origin` headers on React Native as there's no concept of a domain there. (It sends an IP instead.) So I solved this by passing through the `Origin` headers instead configurable via the `wallet-react` and `wallet-core` entrypoints.
We definitely have to come up with a better solution to this, but for the purpose of testing this works. I'm totally fine not merging this.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
