### PR TITLE
fix(react): race condition between initialize and isAuthorized in RN

### DIFF
--- a/packages/react/src/connector.ts
+++ b/packages/react/src/connector.ts
@@ -286,6 +286,9 @@ export function zeroDevWallet(
         ...(params.persistStorage && { storage: params.persistStorage }),
       })
 
+      // Wait for the store to rehydrate - if an async storage is used we need to ensure the persisted state is loaded
+      await store.persist.rehydrate()
+
       store.getState().setWallet(wallet)
 
       // Store OAuth config - uses proxyBaseUrl and projectId from params
@@ -430,9 +433,7 @@ export function zeroDevWallet(
       },
 
       async getProvider() {
-        if (!provider) {
-          await initialize()
-        }
+        await initialize()
         return provider
       },
 

--- a/packages/react/src/store.ts
+++ b/packages/react/src/store.ts
@@ -136,6 +136,8 @@ export const createZeroDevWalletStore = (options?: CreateStoreOptions) =>
           ...(options?.storage && {
             storage: createJSONStorage(() => options.storage!),
           }),
+          // We'll handle hydration manually to ensure it completes before we use the store
+          skipHydration: true,
         },
       ),
     ),


### PR DESCRIPTION
<!-- av pr stack begin -->
<table><tr><td><details><summary>This PR is part of a stack created with <a href="https://github.com/aviator-co/av">Aviator</a>.</summary>

* **#168**
* **#142**
* **#141**
* **#131**
* **#80**
* **#124**
* **#76**
* ➡️ **#75**
* `main`
</details></td></tr></table>
<!-- av pr stack end -->


Closes FS-1930

On mobile when passing in a `SecureStoreStamper` to the SDK I noticed that the session refresh wasn't working properly. The session refresh itself succeeded (so `initialize()` ran and completed) but the `connect()` wasn't being called inside wagmi. 
Here's the lifecycle of the connector methods in `wagmi`:

1. In Wagmi: `setup()` is called in createConfig, it's not awaited, you can see it [here](https://github.com/wevm/wagmi/blob/a5c4381563374018dca0074017b21181ac027e9a/packages/core/src/createConfig.ts#L107) - so this just kicks off our session refresh and `initialize()`
2. In `reconnect()` (when the user refreshes the app): ([here](https://github.com/wevm/wagmi/blob/d11f227c76b10b84fb412c9806f0fb149c558f32/packages/core/src/actions/reconnect.ts#L67))

     1. `getProvider()` is called first, awaited, `if !provider`  then skips - on mobile we have the provider here already so this is truthy and the execution continues to
     2. `isAuthorized()` : this gets called and awaited, here the `eoaAccount` that we return is still `null` when this method is called, because `initalize()` takes too long likely because of the `secureStoreStamper` operations. So when this happens the `reconnect()` doesn't continue. It just skips our connector.

The fix I opted for was awaiting `initialize()` in `getProvider()` so even at that point we for sure have the `Provider` and initialized the session.
An additional fix I opted for was awaiting the hydration of the Zustand store as well. This is best done because on React Native the store can be `AsyncStorage` with async operations. In order to do this, I passed `skipHydration` to the store and then in `initialize()` started and await the `store.persist.rehydrate()`.

This way at the point wagmi calls `getProvider()` we know we have the store hydrated and the ZDWallet + the Session initialized and set in store. So `connect()` will definitely be called with the correct state.

On Web: awaiting the hydration should be quick because the store is Sync. Also, `IndexedDB` is much faster so the `initialize()` should already be resolved by the time `getProvider()` (and `await initialize()`) is called.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
