### PR TITLE
refactor(react-kit): auto-register confirmation listener

### DIFF
--- a/packages/react-kit/src/components/SignatureRequest/SignatureRequest.test.tsx
+++ b/packages/react-kit/src/components/SignatureRequest/SignatureRequest.test.tsx
@@ -3,17 +3,19 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createStore } from '../../store'
 import type { PendingRequest } from '../../types'
 
+// Must be a stable reference (like real wagmi) so the effect doesn't re-run on every render.
 const mockStore = createStore()
+const mockConfig = {
+  connectors: [
+    {
+      id: 'zerodev-wallet',
+      getKitStore: () => mockStore,
+    },
+  ],
+}
 
 vi.mock('wagmi', () => ({
-  useConfig: () => ({
-    connectors: [
-      {
-        id: 'zerodev-wallet',
-        getKitStore: () => mockStore,
-      },
-    ],
-  }),
+  useConfig: () => mockConfig,
 }))
 
 import { SignatureRequest } from './index'

--- a/packages/react-kit/src/components/SignatureRequest/index.tsx
+++ b/packages/react-kit/src/components/SignatureRequest/index.tsx
@@ -1,18 +1,11 @@
 'use client'
 
-import { useEffect } from 'react'
 import { usePendingRequest } from '../../hooks/usePendingRequest.js'
 import { cn } from '../../shared/utils/common.js'
 
 // todo: proper UI
 export function SignatureRequest() {
-  const { pendingRequest, confirm, reject, register, deregister } =
-    usePendingRequest()
-
-  useEffect(() => {
-    register()
-    return deregister
-  }, [register, deregister])
+  const { pendingRequest, confirm, reject } = usePendingRequest()
 
   if (!pendingRequest) return null
 

--- a/packages/react-kit/src/hooks/usePendingRequest.test.ts
+++ b/packages/react-kit/src/hooks/usePendingRequest.test.ts
@@ -3,18 +3,20 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createStore } from '../store'
 import type { PendingRequest } from '../types'
 
-// Mock wagmi's useConfig to return a connector with getKitStore
+// Mock wagmi's useConfig to return a connector with getKitStore.
+// Must be a stable reference (like real wagmi) so the effect doesn't re-run on every render.
 const mockStore = createStore()
+const mockConfig = {
+  connectors: [
+    {
+      id: 'zerodev-wallet',
+      getKitStore: () => mockStore,
+    },
+  ],
+}
 
 vi.mock('wagmi', () => ({
-  useConfig: () => ({
-    connectors: [
-      {
-        id: 'zerodev-wallet',
-        getKitStore: () => mockStore,
-      },
-    ],
-  }),
+  useConfig: () => mockConfig,
 }))
 
 import { usePendingRequest } from './usePendingRequest'
@@ -40,30 +42,27 @@ afterEach(() => {
 })
 
 describe('usePendingRequest', () => {
-  describe('register / deregister', () => {
-    it('register sets userConfirmationListenerActive to true', () => {
-      const { result } = renderHook(() => usePendingRequest())
-
-      act(() => result.current.register())
+  describe('lifecycle', () => {
+    it('sets userConfirmationListenerActive to true on mount', () => {
+      renderHook(() => usePendingRequest())
 
       expect(mockStore.getState().userConfirmationListenerActive).toBe(true)
     })
 
-    it('deregister sets userConfirmationListenerActive to false', () => {
-      mockStore.getState().setUserConfirmationListenerActive(true)
-      const { result } = renderHook(() => usePendingRequest())
+    it('sets userConfirmationListenerActive to false on unmount', () => {
+      const { unmount } = renderHook(() => usePendingRequest())
 
-      act(() => result.current.deregister())
+      unmount()
 
       expect(mockStore.getState().userConfirmationListenerActive).toBe(false)
     })
 
-    it('deregister rejects pending request if one exists', () => {
+    it('rejects pending request on unmount', () => {
       const request = createMockPendingRequest()
       mockStore.getState().setPendingRequest(request)
-      const { result } = renderHook(() => usePendingRequest())
+      const { unmount } = renderHook(() => usePendingRequest())
 
-      act(() => result.current.deregister())
+      unmount()
 
       expect(request.reject).toHaveBeenCalledWith(
         expect.objectContaining({ message: 'Confirmation listener unmounted' }),

--- a/packages/react-kit/src/hooks/usePendingRequest.ts
+++ b/packages/react-kit/src/hooks/usePendingRequest.ts
@@ -19,36 +19,33 @@ export function usePendingRequest() {
   const [pendingRequest, setPendingRequestState] =
     useState<PendingRequest | null>(null)
   const storeRef = useRef<Store | null>(null)
-  const registered = useRef(false)
 
   useEffect(() => {
-    let cancelled = false
-    let unsubscribe: (() => void) | undefined
-
     const store = getStore(config)
     if (!store) return
 
     storeRef.current = store
-
-    // Apply deferred registration
-    if (registered.current) {
-      store.getState().setUserConfirmationListenerActive(true)
-    }
+    store.getState().setUserConfirmationListenerActive(true)
 
     // Sync initial state
     setPendingRequestState(store.getState().pendingRequest)
 
     // Subscribe to changes
-    unsubscribe = store.subscribe(
+    const unsubscribe = store.subscribe(
       (state: State) => state.pendingRequest,
-      (req: PendingRequest | null) => {
-        if (!cancelled) setPendingRequestState(req)
-      },
+      (req: PendingRequest | null) => setPendingRequestState(req),
     )
 
     return () => {
-      cancelled = true
-      unsubscribe?.()
+      unsubscribe()
+      const state = store.getState()
+      if (state.pendingRequest) {
+        state.pendingRequest.reject(
+          new Error('Confirmation listener unmounted'),
+        )
+        state.setPendingRequest(null)
+      }
+      state.setUserConfirmationListenerActive(false)
     }
   }, [config])
 
@@ -74,26 +71,5 @@ export function usePendingRequest() {
     }
   }, [])
 
-  const register = useCallback(() => {
-    registered.current = true
-    if (storeRef.current) {
-      storeRef.current.getState().setUserConfirmationListenerActive(true)
-    }
-  }, [])
-
-  const deregister = useCallback(() => {
-    registered.current = false
-    if (storeRef.current) {
-      const state = storeRef.current.getState()
-      if (state.pendingRequest) {
-        state.pendingRequest.reject(
-          new Error('Confirmation listener unmounted'),
-        )
-        state.setPendingRequest(null)
-      }
-      state.setUserConfirmationListenerActive(false)
-    }
-  }, [])
-
-  return { pendingRequest, confirm, reject, register, deregister }
+  return { pendingRequest, confirm, reject }
 }


### PR DESCRIPTION
Removes the need for doing this in `usePendingRequest.ts`:

```typescript
  useEffect(() => {
    register()
    return deregister
  }, [register, deregister])
```

 - usePendingRequest.ts: registration/deregistration now happens automatically in the `useEffect` — sets `userConfirmationListenerActive(true)` on mount and handles cleanup (reject pending request + set inactive) on unmount.
  - SignatureRequest/index.tsx: removed the `useEffect` with register/deregister and the `useEffect` import. Just destructures `{ pendingRequest, confirm, reject }`
  - Tests: updated to test lifecycle via mount/unmount instead of manual `register()`/`deregister()` calls, and fixed the wagmi mock to return a stable config reference.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
