### PR TITLE
feat(react-kit): support pending request queue for concurrent signing

### DIFF
--- a/apps/react-example/src/App.tsx
+++ b/apps/react-example/src/App.tsx
@@ -95,42 +95,47 @@ function WalletPanel() {
   const { pendingRequests } = usePendingRequest()
 
   return (
-    <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-      <div className="flex justify-between items-center mb-3">
-        <h2 className="text-lg font-semibold text-gray-900">Wallet</h2>
-        <button
-          type="button"
-          onClick={() => disconnect()}
-          className="rounded-lg bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700 cursor-pointer"
-        >
-          Disconnect
-        </button>
+    <>
+      <div className="rounded-xl border border-gray-200 bg-white p-6 gap shadow-sm">
+        <div className="flex justify-between items-center mb-3">
+          <h2 className="text-lg font-semibold text-gray-900">Wallet</h2>
+          <button
+            type="button"
+            onClick={() => disconnect()}
+            className="rounded-lg bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700 cursor-pointer"
+          >
+            Disconnect
+          </button>
+        </div>
+
+        <p className="text-xs text-gray-400 break-all mb-4">{address}</p>
+
+        <Button
+          text={
+            pendingRequests.length > 0
+              ? 'Queue another transaction'
+              : 'Send Transaction'
+          }
+          onClick={() =>
+            sendTransaction({
+              to: address!,
+              value: parseEther('0'),
+              data: '0x',
+            })
+          }
+        />
+
+        {isSuccess && <p className="text-green-600 text-sm mt-2">tx: {data}</p>}
+        {isError && (
+          <p className="text-red-500 text-sm mt-2">
+            {error?.message?.includes('User rejected')
+              ? 'Rejected by user'
+              : error?.message}
+          </p>
+        )}
       </div>
-
-      <p className="text-xs text-gray-400 break-all mb-4">{address}</p>
-
-      <Button
-        text={
-          pendingRequests.length > 0
-            ? 'Queue another transaction'
-            : 'Send Transaction'
-        }
-        onClick={() =>
-          sendTransaction({ to: address!, value: parseEther('0'), data: '0x' })
-        }
-      />
-
-      {isSuccess && <p className="text-green-600 text-sm mt-2">tx: {data}</p>}
-      {isError && (
-        <p className="text-red-500 text-sm mt-2">
-          {error?.message?.includes('User rejected')
-            ? 'Rejected by user'
-            : error?.message}
-        </p>
-      )}
-
       <SignatureRequest />
-    </div>
+    </>
   )
 }
 

--- a/apps/react-example/src/App.tsx
+++ b/apps/react-example/src/App.tsx
@@ -1,5 +1,9 @@
 import { useSendOTP, useVerifyOTP } from '@zerodev/wallet-react'
-import { Button, SignatureRequest } from '@zerodev/wallet-react-kit'
+import {
+  Button,
+  SignatureRequest,
+  usePendingRequest,
+} from '@zerodev/wallet-react-kit'
 import { useState } from 'react'
 import { parseEther } from 'viem'
 import {
@@ -86,8 +90,9 @@ function AuthForm() {
 function WalletPanel() {
   const { address } = useAccount()
   const { disconnect } = useDisconnect()
-  const { sendTransaction, isPending, isSuccess, isError, error, data } =
+  const { sendTransaction, isSuccess, isError, error, data } =
     useSendTransaction()
+  const { pendingRequests } = usePendingRequest()
 
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
@@ -105,11 +110,14 @@ function WalletPanel() {
       <p className="text-xs text-gray-400 break-all mb-4">{address}</p>
 
       <Button
-        text={isPending ? 'Awaiting confirmation...' : 'Send Transaction'}
+        text={
+          pendingRequests.length > 0
+            ? 'Queue another transaction'
+            : 'Send Transaction'
+        }
         onClick={() =>
           sendTransaction({ to: address!, value: parseEther('0'), data: '0x' })
         }
-        disabled={isPending}
       />
 
       {isSuccess && <p className="text-green-600 text-sm mt-2">tx: {data}</p>}

--- a/packages/react-kit/src/connector.test.ts
+++ b/packages/react-kit/src/connector.test.ts
@@ -84,7 +84,7 @@ describe('connector', () => {
       await new Promise((r) => setTimeout(r, 10))
       expect(resolved).toBe(false)
 
-      store.getState().pendingRequest?.resolve()
+      store.getState().pendingRequests[0]?.resolve()
       await requestPromise
       expect(resolved).toBe(true)
     })
@@ -158,13 +158,13 @@ describe('connector', () => {
       // Request should be pending
       await new Promise((r) => setTimeout(r, 10))
       expect(resolved).toBe(false)
-      expect(store.getState().pendingRequest).not.toBeNull()
-      expect(store.getState().pendingRequest?.method).toBe(
+      expect(store.getState().pendingRequests[0]).not.toBeNull()
+      expect(store.getState().pendingRequests[0]?.method).toBe(
         'eth_sendTransaction',
       )
 
       // Confirm — resolve the gate
-      store.getState().pendingRequest?.resolve()
+      store.getState().pendingRequests[0]?.resolve()
       const result = await requestPromise
       expect(resolved).toBe(true)
       expect(result).toBe('0xhash')
@@ -187,7 +187,7 @@ describe('connector', () => {
       })
 
       await new Promise((r) => setTimeout(r, 10))
-      store.getState().pendingRequest?.reject(new Error('User rejected'))
+      store.getState().pendingRequests[0]?.reject(new Error('User rejected'))
 
       await expect(requestPromise).rejects.toThrow('User rejected')
     })
@@ -214,7 +214,7 @@ describe('connector', () => {
         params: ['0xdata', '0xaddress'],
       })
       expect(result).toBe('0xhash')
-      expect(store.getState().pendingRequest).toBeNull()
+      expect(store.getState().pendingRequests).toEqual([])
     })
   })
 
@@ -223,7 +223,7 @@ describe('connector', () => {
       const connector = createKitConnector()
       const store = connector.getKitStore()
       expect(store).toBeDefined()
-      expect(store.getState().pendingRequest).toBeNull()
+      expect(store.getState().pendingRequests).toEqual([])
     })
   })
 })

--- a/packages/react-kit/src/connector.ts
+++ b/packages/react-kit/src/connector.ts
@@ -31,7 +31,7 @@ function requireUserConfirmation(
   request: Request,
 ): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    store.getState().setPendingRequest({
+    store.getState().addPendingRequest({
       id: crypto.randomUUID(),
       ...request,
       resolve,

--- a/packages/react-kit/src/signing/components/SignatureRequest/SignatureRequest.test.tsx
+++ b/packages/react-kit/src/signing/components/SignatureRequest/SignatureRequest.test.tsx
@@ -24,7 +24,7 @@ function createMockPendingRequest(
   overrides?: Partial<PendingRequest>,
 ): PendingRequest {
   return {
-    id: 'test-id',
+    id: crypto.randomUUID(),
     method: 'eth_sendTransaction',
     params: [{ to: '0x1234', value: '0x0' }],
     resolve: vi.fn(),
@@ -35,7 +35,7 @@ function createMockPendingRequest(
 
 afterEach(() => {
   cleanup()
-  mockStore.getState().setPendingRequest(null)
+  mockStore.getState().clearPendingRequests()
   mockStore.getState().setUserConfirmationListenerActive(false)
 })
 
@@ -60,7 +60,7 @@ describe('SignatureRequest', () => {
 
   it('renders when pending request exists', () => {
     const request = createMockPendingRequest()
-    mockStore.getState().setPendingRequest(request)
+    mockStore.getState().addPendingRequest(request)
 
     render(<SignatureRequest />)
 
@@ -72,7 +72,7 @@ describe('SignatureRequest', () => {
 
   it('displays request params', () => {
     const request = createMockPendingRequest()
-    mockStore.getState().setPendingRequest(request)
+    mockStore.getState().addPendingRequest(request)
 
     render(<SignatureRequest />)
 
@@ -82,18 +82,18 @@ describe('SignatureRequest', () => {
 
   it('calls resolve and clears on confirm click', () => {
     const request = createMockPendingRequest()
-    mockStore.getState().setPendingRequest(request)
+    mockStore.getState().addPendingRequest(request)
 
     render(<SignatureRequest />)
     fireEvent.click(screen.getByText('Confirm'))
 
     expect(request.resolve).toHaveBeenCalled()
-    expect(mockStore.getState().pendingRequest).toBeNull()
+    expect(mockStore.getState().pendingRequests).toEqual([])
   })
 
   it('calls reject and clears on reject click', () => {
     const request = createMockPendingRequest()
-    mockStore.getState().setPendingRequest(request)
+    mockStore.getState().addPendingRequest(request)
 
     render(<SignatureRequest />)
     fireEvent.click(screen.getByText('Reject'))
@@ -101,12 +101,40 @@ describe('SignatureRequest', () => {
     expect(request.reject).toHaveBeenCalledWith(
       expect.objectContaining({ message: 'User rejected the request' }),
     )
-    expect(mockStore.getState().pendingRequest).toBeNull()
+    expect(mockStore.getState().pendingRequests).toEqual([])
   })
 
-  it('rejects dangling request on unmount', () => {
+  it('does not show pending count with a single request', () => {
     const request = createMockPendingRequest()
-    mockStore.getState().setPendingRequest(request)
+    mockStore.getState().addPendingRequest(request)
+
+    render(<SignatureRequest />)
+
+    expect(screen.queryByText(/more pending/)).toBeNull()
+  })
+
+  it('shows singular pending text for one extra request', () => {
+    mockStore.getState().addPendingRequest(createMockPendingRequest())
+    mockStore.getState().addPendingRequest(createMockPendingRequest())
+
+    render(<SignatureRequest />)
+
+    expect(screen.getByText('+1 more pending request')).toBeDefined()
+  })
+
+  it('shows pending count when multiple requests are queued', () => {
+    mockStore.getState().addPendingRequest(createMockPendingRequest())
+    mockStore.getState().addPendingRequest(createMockPendingRequest())
+    mockStore.getState().addPendingRequest(createMockPendingRequest())
+
+    render(<SignatureRequest />)
+
+    expect(screen.getByText('+2 more pending requests')).toBeDefined()
+  })
+
+  it('rejects dangling requests on unmount', () => {
+    const request = createMockPendingRequest()
+    mockStore.getState().addPendingRequest(request)
 
     const { unmount } = render(<SignatureRequest />)
     unmount()
@@ -114,6 +142,6 @@ describe('SignatureRequest', () => {
     expect(request.reject).toHaveBeenCalledWith(
       expect.objectContaining({ message: 'Confirmation listener unmounted' }),
     )
-    expect(mockStore.getState().pendingRequest).toBeNull()
+    expect(mockStore.getState().pendingRequests).toEqual([])
   })
 })

--- a/packages/react-kit/src/signing/components/SignatureRequest/index.tsx
+++ b/packages/react-kit/src/signing/components/SignatureRequest/index.tsx
@@ -5,7 +5,8 @@ import { usePendingRequest } from '../../hooks/usePendingRequest.js'
 
 // todo: proper UI
 export function SignatureRequest() {
-  const { pendingRequest, confirm, reject } = usePendingRequest()
+  const { pendingRequest, pendingRequests, confirm, reject } =
+    usePendingRequest()
 
   if (!pendingRequest) return null
 
@@ -23,6 +24,13 @@ export function SignatureRequest() {
       <pre className="mt-3 rounded-lg bg-gray-50 p-3 text-xs text-gray-700 overflow-auto max-h-48 border border-gray-100">
         {JSON.stringify(pendingRequest.params, null, 2)}
       </pre>
+
+      {pendingRequests.length > 1 && (
+        <p className="text-xs text-gray-500 mt-3">
+          +{pendingRequests.length - 1} more pending{' '}
+          {pendingRequests.length - 1 === 1 ? 'request' : 'requests'}
+        </p>
+      )}
 
       <div className="flex gap-3 mt-4">
         <button

--- a/packages/react-kit/src/signing/hooks/usePendingRequest.test.ts
+++ b/packages/react-kit/src/signing/hooks/usePendingRequest.test.ts
@@ -25,7 +25,7 @@ function createMockPendingRequest(
   overrides?: Partial<PendingRequest>,
 ): PendingRequest {
   return {
-    id: 'test-id',
+    id: crypto.randomUUID(),
     method: 'eth_sendTransaction',
     params: [{ to: '0x1234', value: '0x0' }],
     resolve: vi.fn(),
@@ -36,8 +36,7 @@ function createMockPendingRequest(
 
 afterEach(() => {
   cleanup()
-  // Reset store between tests
-  mockStore.getState().setPendingRequest(null)
+  mockStore.getState().clearPendingRequests()
   mockStore.getState().setUserConfirmationListenerActive(false)
 })
 
@@ -57,46 +56,66 @@ describe('usePendingRequest', () => {
       expect(mockStore.getState().userConfirmationListenerActive).toBe(false)
     })
 
-    it('rejects pending request on unmount', () => {
-      const request = createMockPendingRequest()
-      mockStore.getState().setPendingRequest(request)
+    it('rejects all pending requests on unmount', () => {
+      const request1 = createMockPendingRequest()
+      const request2 = createMockPendingRequest()
+      mockStore.getState().addPendingRequest(request1)
+      mockStore.getState().addPendingRequest(request2)
       const { unmount } = renderHook(() => usePendingRequest())
 
       unmount()
 
-      expect(request.reject).toHaveBeenCalledWith(
+      expect(request1.reject).toHaveBeenCalledWith(
         expect.objectContaining({ message: 'Confirmation listener unmounted' }),
       )
-      expect(mockStore.getState().pendingRequest).toBeNull()
+      expect(request2.reject).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Confirmation listener unmounted' }),
+      )
+      expect(mockStore.getState().pendingRequests).toEqual([])
     })
   })
 
   describe('confirm', () => {
-    it('resolves pending request and clears it', () => {
+    it('resolves head request and removes it', () => {
       const request = createMockPendingRequest()
-      mockStore.getState().setPendingRequest(request)
+      mockStore.getState().addPendingRequest(request)
       const { result } = renderHook(() => usePendingRequest())
 
       act(() => result.current.confirm())
 
       expect(request.resolve).toHaveBeenCalled()
-      expect(mockStore.getState().pendingRequest).toBeNull()
+      expect(mockStore.getState().pendingRequests).toEqual([])
       expect(result.current.pendingRequest).toBeNull()
     })
 
-    it('is a no-op when no pending request', () => {
+    it('confirms first and second becomes head', () => {
+      const request1 = createMockPendingRequest()
+      const request2 = createMockPendingRequest()
+      mockStore.getState().addPendingRequest(request1)
+      mockStore.getState().addPendingRequest(request2)
       const { result } = renderHook(() => usePendingRequest())
 
       act(() => result.current.confirm())
 
-      expect(mockStore.getState().pendingRequest).toBeNull()
+      expect(request1.resolve).toHaveBeenCalled()
+      expect(request2.resolve).not.toHaveBeenCalled()
+      expect(result.current.pendingRequest).toBe(request2)
+      expect(result.current.pendingRequests).toEqual([request2])
+    })
+
+    it('is a no-op when no pending requests', () => {
+      const { result } = renderHook(() => usePendingRequest())
+
+      act(() => result.current.confirm())
+
+      expect(mockStore.getState().pendingRequests).toEqual([])
     })
   })
 
   describe('reject', () => {
-    it('rejects pending request and clears it', () => {
+    it('rejects head request and removes it', () => {
       const request = createMockPendingRequest()
-      mockStore.getState().setPendingRequest(request)
+      mockStore.getState().addPendingRequest(request)
       const { result } = renderHook(() => usePendingRequest())
 
       act(() => result.current.reject())
@@ -104,47 +123,92 @@ describe('usePendingRequest', () => {
       expect(request.reject).toHaveBeenCalledWith(
         expect.objectContaining({ message: 'User rejected the request' }),
       )
-      expect(mockStore.getState().pendingRequest).toBeNull()
+      expect(mockStore.getState().pendingRequests).toEqual([])
       expect(result.current.pendingRequest).toBeNull()
     })
 
-    it('is a no-op when no pending request', () => {
+    it('rejects first and second becomes head', () => {
+      const request1 = createMockPendingRequest()
+      const request2 = createMockPendingRequest()
+      mockStore.getState().addPendingRequest(request1)
+      mockStore.getState().addPendingRequest(request2)
       const { result } = renderHook(() => usePendingRequest())
 
       act(() => result.current.reject())
 
-      expect(mockStore.getState().pendingRequest).toBeNull()
+      expect(request1.reject).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'User rejected the request' }),
+      )
+      expect(request2.reject).not.toHaveBeenCalled()
+      expect(result.current.pendingRequest).toBe(request2)
+      expect(result.current.pendingRequests).toEqual([request2])
+    })
+
+    it('is a no-op when no pending requests', () => {
+      const { result } = renderHook(() => usePendingRequest())
+
+      act(() => result.current.reject())
+
+      expect(mockStore.getState().pendingRequests).toEqual([])
     })
   })
 
-  describe('pendingRequest state', () => {
-    it('syncs initial pending request from store', () => {
+  describe('pendingRequests state', () => {
+    it('syncs initial pending requests from store', () => {
       const request = createMockPendingRequest()
-      mockStore.getState().setPendingRequest(request)
+      mockStore.getState().addPendingRequest(request)
 
       const { result } = renderHook(() => usePendingRequest())
 
       expect(result.current.pendingRequest).toBe(request)
+      expect(result.current.pendingRequests).toEqual([request])
     })
 
-    it('updates when store pendingRequest changes', () => {
+    it('updates when a new request is added to an empty queue', () => {
       const { result } = renderHook(() => usePendingRequest())
       expect(result.current.pendingRequest).toBeNull()
 
       const request = createMockPendingRequest()
-      act(() => mockStore.getState().setPendingRequest(request))
+      act(() => mockStore.getState().addPendingRequest(request))
 
       expect(result.current.pendingRequest).toBe(request)
+      expect(result.current.pendingRequests).toEqual([request])
     })
 
-    it('clears when store pendingRequest is set to null', () => {
-      const request = createMockPendingRequest()
-      mockStore.getState().setPendingRequest(request)
+    it('updates when a new request is added while one is pending', () => {
+      const request1 = createMockPendingRequest()
+      mockStore.getState().addPendingRequest(request1)
       const { result } = renderHook(() => usePendingRequest())
 
-      act(() => mockStore.getState().setPendingRequest(null))
+      const request2 = createMockPendingRequest()
+      act(() => mockStore.getState().addPendingRequest(request2))
+
+      expect(result.current.pendingRequest).toBe(request1)
+      expect(result.current.pendingRequests).toEqual([request1, request2])
+    })
+
+    it('updates when a request is removed while others are pending', () => {
+      const request1 = createMockPendingRequest()
+      const request2 = createMockPendingRequest()
+      mockStore.getState().addPendingRequest(request1)
+      mockStore.getState().addPendingRequest(request2)
+      const { result } = renderHook(() => usePendingRequest())
+
+      act(() => mockStore.getState().removePendingRequest(request1.id))
+
+      expect(result.current.pendingRequest).toBe(request2)
+      expect(result.current.pendingRequests).toEqual([request2])
+    })
+
+    it('clears when last request is removed', () => {
+      const request = createMockPendingRequest()
+      mockStore.getState().addPendingRequest(request)
+      const { result } = renderHook(() => usePendingRequest())
+
+      act(() => mockStore.getState().removePendingRequest(request.id))
 
       expect(result.current.pendingRequest).toBeNull()
+      expect(result.current.pendingRequests).toEqual([])
     })
   })
 })

--- a/packages/react-kit/src/signing/hooks/usePendingRequest.ts
+++ b/packages/react-kit/src/signing/hooks/usePendingRequest.ts
@@ -16,8 +16,7 @@ function getStore(config: ReturnType<typeof useConfig>): Store | null {
 
 export function usePendingRequest() {
   const config = useConfig()
-  const [pendingRequest, setPendingRequestState] =
-    useState<PendingRequest | null>(null)
+  const [pendingRequests, setPendingRequests] = useState<PendingRequest[]>([])
   const storeRef = useRef<Store | null>(null)
 
   useEffect(() => {
@@ -28,23 +27,21 @@ export function usePendingRequest() {
     store.getState().setUserConfirmationListenerActive(true)
 
     // Sync initial state
-    setPendingRequestState(store.getState().pendingRequest)
+    setPendingRequests(store.getState().pendingRequests)
 
     // Subscribe to changes
     const unsubscribe = store.subscribe(
-      (state: State) => state.pendingRequest,
-      (req: PendingRequest | null) => setPendingRequestState(req),
+      (state: State) => state.pendingRequests,
+      (reqs: PendingRequest[]) => setPendingRequests(reqs),
     )
 
     return () => {
       unsubscribe()
       const state = store.getState()
-      if (state.pendingRequest) {
-        state.pendingRequest.reject(
-          new Error('Confirmation listener unmounted'),
-        )
-        state.setPendingRequest(null)
+      for (const req of state.pendingRequests) {
+        req.reject(new Error('Confirmation listener unmounted'))
       }
+      state.clearPendingRequests()
       state.setUserConfirmationListenerActive(false)
     }
   }, [config])
@@ -53,10 +50,10 @@ export function usePendingRequest() {
     const store = storeRef.current
     if (!store) return
     const state = store.getState()
-    if (state.pendingRequest) {
-      state.pendingRequest.resolve()
-      // todo: handle multiple requests (queue)
-      state.setPendingRequest(null)
+    const head = state.pendingRequests[0]
+    if (head) {
+      head.resolve()
+      state.removePendingRequest(head.id)
     }
   }, [])
 
@@ -64,12 +61,14 @@ export function usePendingRequest() {
     const store = storeRef.current
     if (!store) return
     const state = store.getState()
-    if (state.pendingRequest) {
-      state.pendingRequest.reject(new Error('User rejected the request'))
-      // todo: handle multiple requests (queue)
-      state.setPendingRequest(null)
+    const head = state.pendingRequests[0]
+    if (head) {
+      head.reject(new Error('User rejected the request'))
+      state.removePendingRequest(head.id)
     }
   }, [])
 
-  return { pendingRequest, confirm, reject }
+  const pendingRequest = pendingRequests[0] ?? null
+
+  return { pendingRequest, pendingRequests, confirm, reject }
 }

--- a/packages/react-kit/src/store.test.ts
+++ b/packages/react-kit/src/store.test.ts
@@ -6,7 +6,7 @@ function createMockPendingRequest(
   overrides?: Partial<PendingRequest>,
 ): PendingRequest {
   return {
-    id: 'test-id',
+    id: crypto.randomUUID(),
     method: 'eth_sendTransaction',
     params: [{ to: '0x1234', value: '0x0' }],
     resolve: vi.fn(),
@@ -20,19 +20,54 @@ describe('store', () => {
     const store = createStore()
     const state = store.getState()
 
-    expect(state.pendingRequest).toBeNull()
+    expect(state.pendingRequests).toEqual([])
     expect(state.userConfirmationListenerActive).toBe(false)
   })
 
-  it('sets and clears pending request', () => {
+  it('adds pending requests to the queue', () => {
+    const store = createStore()
+    const request1 = createMockPendingRequest()
+    const request2 = createMockPendingRequest()
+
+    store.getState().addPendingRequest(request1)
+    expect(store.getState().pendingRequests).toEqual([request1])
+
+    store.getState().addPendingRequest(request2)
+    expect(store.getState().pendingRequests).toEqual([request1, request2])
+  })
+
+  it('removes a pending request by id', () => {
+    const store = createStore()
+    const request1 = createMockPendingRequest()
+    const request2 = createMockPendingRequest()
+
+    store.getState().addPendingRequest(request1)
+    store.getState().addPendingRequest(request2)
+
+    store.getState().removePendingRequest(request1.id)
+    expect(store.getState().pendingRequests).toEqual([request2])
+  })
+
+  it('removing a non-existent id is a no-op', () => {
     const store = createStore()
     const request = createMockPendingRequest()
 
-    store.getState().setPendingRequest(request)
-    expect(store.getState().pendingRequest).toBe(request)
+    store.getState().addPendingRequest(request)
+    store.getState().removePendingRequest('non-existent')
 
-    store.getState().setPendingRequest(null)
-    expect(store.getState().pendingRequest).toBeNull()
+    expect(store.getState().pendingRequests).toEqual([request])
+  })
+
+  it('clears all pending requests', () => {
+    const store = createStore()
+    const request1 = createMockPendingRequest()
+    const request2 = createMockPendingRequest()
+
+    store.getState().addPendingRequest(request1)
+    store.getState().addPendingRequest(request2)
+
+    store.getState().clearPendingRequests()
+    expect(store.getState().pendingRequests).toEqual([])
   })
 
   it('toggles userConfirmationListenerActive', () => {
@@ -45,18 +80,18 @@ describe('store', () => {
     expect(store.getState().userConfirmationListenerActive).toBe(false)
   })
 
-  it('fires subscription on pendingRequest change', () => {
+  it('fires subscription on pendingRequests change', () => {
     const store = createStore()
     const listener = vi.fn()
     const request = createMockPendingRequest()
 
-    store.subscribe((state) => state.pendingRequest, listener)
+    store.subscribe((state) => state.pendingRequests, listener)
 
-    store.getState().setPendingRequest(request)
-    expect(listener).toHaveBeenCalledWith(request, null)
+    store.getState().addPendingRequest(request)
+    expect(listener).toHaveBeenCalledWith([request], [])
 
-    store.getState().setPendingRequest(null)
-    expect(listener).toHaveBeenCalledWith(null, request)
+    store.getState().removePendingRequest(request.id)
+    expect(listener).toHaveBeenCalledWith([], [request])
     expect(listener).toHaveBeenCalledTimes(2)
   })
 
@@ -64,7 +99,7 @@ describe('store', () => {
     const store = createStore()
     const listener = vi.fn()
 
-    store.subscribe((state) => state.pendingRequest, listener)
+    store.subscribe((state) => state.pendingRequests, listener)
 
     store.getState().setUserConfirmationListenerActive(true)
     expect(listener).not.toHaveBeenCalled()
@@ -75,9 +110,9 @@ describe('store', () => {
     const store2 = createStore()
     const request = createMockPendingRequest()
 
-    store1.getState().setPendingRequest(request)
+    store1.getState().addPendingRequest(request)
 
-    expect(store1.getState().pendingRequest).toBe(request)
-    expect(store2.getState().pendingRequest).toBeNull()
+    expect(store1.getState().pendingRequests).toEqual([request])
+    expect(store2.getState().pendingRequests).toEqual([])
   })
 })

--- a/packages/react-kit/src/store.ts
+++ b/packages/react-kit/src/store.ts
@@ -3,18 +3,28 @@ import { subscribeWithSelector } from 'zustand/middleware'
 import type { PendingRequest } from './types.js'
 
 export type State = {
-  pendingRequest: PendingRequest | null
+  pendingRequests: PendingRequest[]
   userConfirmationListenerActive: boolean
-  setPendingRequest: (request: PendingRequest | null) => void
+  addPendingRequest: (request: PendingRequest) => void
+  removePendingRequest: (id: string) => void
+  clearPendingRequests: () => void
   setUserConfirmationListenerActive: (active: boolean) => void
 }
 
 export const createStore = () =>
   create<State>()(
     subscribeWithSelector((set) => ({
-      pendingRequest: null,
+      pendingRequests: [],
       userConfirmationListenerActive: false,
-      setPendingRequest: (request) => set({ pendingRequest: request }),
+      addPendingRequest: (request) =>
+        set((state) => ({
+          pendingRequests: [...state.pendingRequests, request],
+        })),
+      removePendingRequest: (id) =>
+        set((state) => ({
+          pendingRequests: state.pendingRequests.filter((r) => r.id !== id),
+        })),
+      clearPendingRequests: () => set({ pendingRequests: [] }),
       setUserConfirmationListenerActive: (active) =>
         set({ userConfirmationListenerActive: active }),
     })),


### PR DESCRIPTION
Requests are now queued up and confirmed/rejected one by one. You can test by running `/apps/react-example`.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
