### PR TITLE
refactor(react-kit): icon names

### DIFF
--- a/packages/react-kit/src/shared/components/Button/Button.stories.tsx
+++ b/packages/react-kit/src/shared/components/Button/Button.stories.tsx
@@ -72,7 +72,7 @@ export const WithLeadingIcon: Story = {
   args: {
     text: 'Send',
     action: 'primary',
-    iconName: 'RocketIcon',
+    iconName: 'rocket',
   },
 }
 
@@ -80,7 +80,7 @@ export const WithTrailingIcon: Story = {
   args: {
     text: 'Next',
     action: 'primary',
-    iconName: 'ArrowRightFillIcon',
+    iconName: 'arrowRightFill',
     trailIcon: true,
   },
 }
@@ -88,7 +88,7 @@ export const WithTrailingIcon: Story = {
 export const IconOnly: Story = {
   args: {
     action: 'primary',
-    iconName: 'CheckIcon',
+    iconName: 'check',
   },
 }
 
@@ -96,7 +96,7 @@ export const SecondaryWithIcon: Story = {
   args: {
     text: 'Copy',
     action: 'secondary',
-    iconName: 'CopyIcon',
+    iconName: 'copy',
   },
 }
 
@@ -107,14 +107,14 @@ export const AllVariants: Story = {
       <Button text="Secondary" action="secondary" />
       <Button text="Secondary Neutral" action="secondaryNeutral" />
       <Button text="Disabled" action="primary" disabled />
-      <Button text="With Icon" action="primary" iconName="RocketIcon" />
+      <Button text="With Icon" action="primary" iconName="rocket" />
       <Button
         text="Trail Icon"
         action="primary"
-        iconName="ArrowRightFillIcon"
+        iconName="arrowRightFill"
         trailIcon
       />
-      <Button action="secondary" iconName="CheckIcon" />
+      <Button action="secondary" iconName="check" />
     </div>
   ),
 }

--- a/packages/react-kit/src/shared/components/Button/Button.test.tsx
+++ b/packages/react-kit/src/shared/components/Button/Button.test.tsx
@@ -155,14 +155,14 @@ describe('Button', () => {
 
   describe('icon rendering', () => {
     it('renders a leading icon when iconName is provided', () => {
-      render(<Button text="Send" iconName="RocketIcon" />)
-      expect(screen.getByTestId('icon-RocketIcon')).toBeDefined()
+      render(<Button text="Send" iconName="rocket" />)
+      expect(screen.getByTestId('icon-rocket')).toBeDefined()
       expect(screen.getByText('Send')).toBeDefined()
     })
 
     it('renders a trailing icon when trailIcon is true', () => {
-      render(<Button text="Next" iconName="ArrowRightFillIcon" trailIcon />)
-      const icon = screen.getByTestId('icon-ArrowRightFillIcon')
+      render(<Button text="Next" iconName="arrowRightFill" trailIcon />)
+      const icon = screen.getByTestId('icon-arrowRightFill')
       const text = screen.getByText('Next')
       // Icon should come after text in the DOM
       expect(
@@ -171,8 +171,8 @@ describe('Button', () => {
     })
 
     it('renders a leading icon before text when trailIcon is false', () => {
-      render(<Button text="Back" iconName="ArrowLeftIcon" />)
-      const icon = screen.getByTestId('icon-ArrowLeftIcon')
+      render(<Button text="Back" iconName="arrowLeft" />)
+      const icon = screen.getByTestId('icon-arrowLeft')
       const text = screen.getByText('Back')
       // Icon should come before text in the DOM
       expect(
@@ -181,8 +181,8 @@ describe('Button', () => {
     })
 
     it('renders icon without text', () => {
-      render(<Button iconName="CheckIcon" />)
-      expect(screen.getByTestId('icon-CheckIcon')).toBeDefined()
+      render(<Button iconName="check" />)
+      expect(screen.getByTestId('icon-check')).toBeDefined()
     })
 
     it('does not render icon when iconName is not provided', () => {
@@ -191,14 +191,14 @@ describe('Button', () => {
     })
 
     it('applies text color classes to the icon', () => {
-      render(<Button text="Send" iconName="RocketIcon" action="primary" />)
-      const icon = screen.getByTestId('icon-RocketIcon')
+      render(<Button text="Send" iconName="rocket" action="primary" />)
+      const icon = screen.getByTestId('icon-rocket')
       expect(icon.getAttribute('class')).toContain('text-white')
     })
 
     it('applies secondary text color classes to the icon', () => {
-      render(<Button text="Send" iconName="RocketIcon" action="secondary" />)
-      const icon = screen.getByTestId('icon-RocketIcon')
+      render(<Button text="Send" iconName="rocket" action="secondary" />)
+      const icon = screen.getByTestId('icon-rocket')
       expect(icon.getAttribute('class')).toContain('text-gray-900')
     })
   })

--- a/packages/react-kit/src/shared/components/Icon/Icon.stories.tsx
+++ b/packages/react-kit/src/shared/components/Icon/Icon.stories.tsx
@@ -32,7 +32,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
-    name: 'CheckIcon',
+    name: 'check',
     className: 'w-6 h-6 text-white',
   },
 }

--- a/packages/react-kit/src/shared/components/Icon/Icon.test.tsx
+++ b/packages/react-kit/src/shared/components/Icon/Icon.test.tsx
@@ -13,8 +13,8 @@ vi.mock('./index', async () => {
     })
 
   const iconsMap: Record<string, React.FC<React.SVGProps<SVGSVGElement>>> = {
-    CheckIcon: MockCheckIcon,
-    ArrowLeftIcon: MockArrowLeftIcon,
+    check: MockCheckIcon,
+    arrowLeft: MockArrowLeftIcon,
   }
 
   return {
@@ -39,43 +39,43 @@ afterEach(() => {
 describe('Icon', () => {
   describe('rendering', () => {
     it('renders the correct icon by name', () => {
-      render(<Icon name="CheckIcon" />)
+      render(<Icon name="check" />)
       expect(screen.getByTestId('mock-check-icon')).toBeDefined()
     })
 
     it('renders a different icon by name', () => {
-      render(<Icon name="ArrowLeftIcon" />)
+      render(<Icon name="arrowLeft" />)
       expect(screen.getByTestId('mock-arrow-left-icon')).toBeDefined()
     })
 
     it('returns null for an unknown icon name', () => {
-      const { container } = render(<Icon name="NonExistentIcon" />)
+      const { container } = render(<Icon name="nonExistent" />)
       expect(container.innerHTML).toBe('')
     })
   })
 
   describe('prop passthrough', () => {
     it('passes className to the SVG element', () => {
-      render(<Icon name="CheckIcon" className="w-6 h-6 text-white" />)
+      render(<Icon name="check" className="w-6 h-6 text-white" />)
       const svg = screen.getByTestId('mock-check-icon')
       expect(svg.getAttribute('class')).toBe('w-6 h-6 text-white')
     })
 
     it('passes aria-label to the SVG element', () => {
-      render(<Icon name="CheckIcon" aria-label="Checkmark" />)
+      render(<Icon name="check" aria-label="Checkmark" />)
       const svg = screen.getByTestId('mock-check-icon')
       expect(svg.getAttribute('aria-label')).toBe('Checkmark')
     })
 
     it('passes width and height props', () => {
-      render(<Icon name="CheckIcon" width={32} height={32} />)
+      render(<Icon name="check" width={32} height={32} />)
       const svg = screen.getByTestId('mock-check-icon')
       expect(svg.getAttribute('width')).toBe('32')
       expect(svg.getAttribute('height')).toBe('32')
     })
 
     it('passes data attributes', () => {
-      render(<Icon name="CheckIcon" data-tooltip="check" />)
+      render(<Icon name="check" data-tooltip="check" />)
       const svg = screen.getByTestId('mock-check-icon')
       expect(svg.getAttribute('data-tooltip')).toBe('check')
     })
@@ -88,13 +88,13 @@ describe('Icon', () => {
     })
 
     it('contains expected icon entries', () => {
-      expect(icons.CheckIcon).toBeDefined()
-      expect(icons.ArrowLeftIcon).toBeDefined()
+      expect(icons.check).toBeDefined()
+      expect(icons.arrowLeft).toBeDefined()
     })
 
     it('icon entries are functions (components)', () => {
-      expect(typeof icons.CheckIcon).toBe('function')
-      expect(typeof icons.ArrowLeftIcon).toBe('function')
+      expect(typeof icons.check).toBe('function')
+      expect(typeof icons.arrowLeft).toBe('function')
     })
   })
 })

--- a/packages/react-kit/src/shared/components/Icon/index.tsx
+++ b/packages/react-kit/src/shared/components/Icon/index.tsx
@@ -8,18 +8,22 @@ const svgModules = import.meta.glob('../../../../../../assets/icons/*.svg', {
   query: '?react',
 }) as Record<string, SvgModule>
 
-// Build a name → component map:  "check" → CheckIcon, "arrow-left" → ArrowLeftIcon, etc.
-function toPascalCase(str: string) {
-  return str
-    .split('-')
-    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
-    .join('')
+// Build a name → component map:  "check" → check component, "arrow-left" → arrowLeft component
+function toCamelCase(str: string) {
+  const parts = str.split('-')
+  return (
+    parts[0] +
+    parts
+      .slice(1)
+      .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+      .join('')
+  )
 }
 
 const icons: Record<string, FC<SVGProps<SVGSVGElement>>> = {}
 for (const [path, mod] of Object.entries(svgModules) as [string, SvgModule][]) {
   const filename = path.split('/').pop()?.replace('.svg', '') ?? ''
-  const name = `${toPascalCase(filename)}Icon`
+  const name = toCamelCase(filename)
   icons[name] = mod.default
 }
 

--- a/packages/react-kit/src/shared/components/ListItem/ListItem.stories.tsx
+++ b/packages/react-kit/src/shared/components/ListItem/ListItem.stories.tsx
@@ -49,7 +49,7 @@ type Story = StoryObj<typeof meta>
 
 export const WithIcon: Story = {
   args: {
-    iconName: 'WalletIcon',
+    iconName: 'wallet',
     title: 'Wallet',
     subtitle: 'Connected',
     chevron: true,
@@ -58,7 +58,7 @@ export const WithIcon: Story = {
 
 export const WithDetails: Story = {
   args: {
-    iconName: 'WalletIcon',
+    iconName: 'wallet',
     title: 'Transaction',
     subtitle: 'Pending',
     details: {
@@ -70,7 +70,7 @@ export const WithDetails: Story = {
 
 export const AlertState: Story = {
   args: {
-    iconName: 'WalletIcon',
+    iconName: 'warning',
     title: 'Action Required',
     subtitle: 'Review transaction',
     alert: true,

--- a/packages/react-kit/src/shared/components/ListItem/ListItem.test.tsx
+++ b/packages/react-kit/src/shared/components/ListItem/ListItem.test.tsx
@@ -34,13 +34,13 @@ describe('ListItem', () => {
   })
 
   it('renders icon when iconName is provided', () => {
-    render(<ListItem title="Test Title" iconName="WalletIcon" />)
-    expect(screen.getByTestId('icon-WalletIcon')).toBeDefined()
+    render(<ListItem title="Test Title" iconName="wallet" />)
+    expect(screen.getByTestId('icon-wallet')).toBeDefined()
   })
 
   it('renders chevron when chevron prop is true', () => {
     render(<ListItem title="Test Title" chevron />)
-    expect(screen.getByTestId('icon-ChevronRightIcon')).toBeDefined()
+    expect(screen.getByTestId('icon-chevronRight')).toBeDefined()
   })
 
   it('renders details when provided', () => {

--- a/packages/react-kit/src/shared/components/ListItem/index.tsx
+++ b/packages/react-kit/src/shared/components/ListItem/index.tsx
@@ -107,7 +107,7 @@ export function ListItem({
             )}
           </div>
         ) : chevron ? (
-          <Icon name="ChevronRightIcon" className="h-6 w-6" />
+          <Icon name="chevronRight" className="h-6 w-6" />
         ) : null}
       </button>
     </Wrapper>


### PR DESCRIPTION
### Summary

This PR does a small refactor to icon names usage to be used as "check" instead of "CheckIcon"

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
