### PR TITLE
feat(react-kit): Badge component

### DIFF
--- a/packages/react-kit/src/shared/components/Badge/Badge.stories.tsx
+++ b/packages/react-kit/src/shared/components/Badge/Badge.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { icons } from '../Icon'
+import { Badge } from './index'
+
+const iconNames = Object.keys(icons)
+
+const meta = {
+  title: 'Shared/Badge',
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    text: {
+      control: 'text',
+      description: 'Badge text',
+    },
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary'],
+      description: 'Visual variant',
+    },
+    leadingIcon: {
+      control: 'select',
+      options: [undefined, ...iconNames],
+      description: 'Leading icon name',
+    },
+    trailingIcon: {
+      control: 'select',
+      options: [undefined, ...iconNames],
+      description: 'Trailing icon name',
+    },
+  },
+} satisfies Meta<typeof Badge>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {
+  args: {
+    text: 'New',
+    variant: 'primary',
+  },
+}
+
+export const Secondary: Story = {
+  args: {
+    text: 'Updated',
+    variant: 'secondary',
+  },
+}
+
+export const WithLeadingIcon: Story = {
+  args: {
+    text: 'Verified',
+    variant: 'secondary',
+    leadingIcon: 'check',
+  },
+}
+
+export const WithTrailingIcon: Story = {
+  args: {
+    text: 'Next',
+    variant: 'primary',
+    trailingIcon: 'chevronRight',
+  },
+}
+
+export const WithBothIcons: Story = {
+  args: {
+    text: 'Complete',
+    variant: 'secondary',
+    leadingIcon: 'check',
+    trailingIcon: 'chevronRight',
+  },
+}
+
+export const AllVariants = {
+  args: {
+    text: 'Example',
+  },
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <div className="flex gap-2 flex-wrap">
+        <Badge text="Primary" variant="primary" />
+        <Badge text="Secondary" variant="secondary" />
+      </div>
+      <div className="flex gap-2 flex-wrap">
+        <Badge text="With Icon" variant="secondary" leadingIcon="check" />
+        <Badge text="Trailing" variant="primary" trailingIcon="chevronRight" />
+      </div>
+      <div className="flex gap-2 flex-wrap">
+        <Badge
+          text="Both Icons"
+          variant="secondary"
+          leadingIcon="check"
+          trailingIcon="chevronRight"
+        />
+      </div>
+    </div>
+  ),
+} satisfies Story

--- a/packages/react-kit/src/shared/components/Badge/Badge.test.tsx
+++ b/packages/react-kit/src/shared/components/Badge/Badge.test.tsx
@@ -1,0 +1,116 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../Icon', async () => {
+  const React = await import('react')
+
+  const MockIcon = ({
+    name,
+    ...props
+  }: { name: string } & React.SVGProps<SVGSVGElement>) =>
+    React.createElement('svg', { 'data-testid': `icon-${name}`, ...props })
+
+  return {
+    Icon: MockIcon,
+    icons: {},
+  }
+})
+
+import { Badge } from './index'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Badge', () => {
+  describe('rendering', () => {
+    it('renders with text', () => {
+      render(<Badge text="New" />)
+      expect(screen.getByText('New')).toBeDefined()
+    })
+
+    it('renders with primary variant by default', () => {
+      const { container } = render(<Badge text="Default" />)
+      const badge = container.firstChild as HTMLElement
+      expect(badge.className).toContain('bg-white/40')
+    })
+
+    it('renders with secondary variant', () => {
+      const { container } = render(
+        <Badge text="Secondary" variant="secondary" />,
+      )
+      const badge = container.firstChild as HTMLElement
+      expect(badge.className).toContain('bg-orange/10')
+    })
+  })
+
+  describe('icons', () => {
+    it('renders leading icon when provided', () => {
+      render(<Badge text="Badge" leadingIcon="check" />)
+      expect(screen.getByTestId('icon-check')).toBeDefined()
+      expect(screen.getByText('Badge')).toBeDefined()
+    })
+
+    it('renders trailing icon when provided', () => {
+      render(<Badge text="Badge" trailingIcon="chevronRight" />)
+      expect(screen.getByTestId('icon-chevronRight')).toBeDefined()
+      expect(screen.getByText('Badge')).toBeDefined()
+    })
+
+    it('renders both leading and trailing icons', () => {
+      render(
+        <Badge text="Badge" leadingIcon="check" trailingIcon="chevronRight" />,
+      )
+      expect(screen.getByTestId('icon-check')).toBeDefined()
+      expect(screen.getByTestId('icon-chevronRight')).toBeDefined()
+      expect(screen.getByText('Badge')).toBeDefined()
+    })
+
+    it('renders without icons when not provided', () => {
+      render(<Badge text="Badge" />)
+      expect(screen.queryByTestId(/^icon-/)).toBeNull()
+    })
+
+    it('applies correct classes to leading icon', () => {
+      render(<Badge text="Badge" leadingIcon="check" />)
+      const icon = screen.getByTestId('icon-check')
+      expect(icon.className).toContain('w-3')
+      expect(icon.className).toContain('h-3')
+      expect(icon.className).toContain('text-solarOrange')
+    })
+
+    it('applies correct classes to trailing icon', () => {
+      render(<Badge text="Badge" trailingIcon="chevronRight" />)
+      const icon = screen.getByTestId('icon-chevronRight')
+      expect(icon.className).toContain('w-2.5')
+      expect(icon.className).toContain('h-2.5')
+    })
+  })
+
+  describe('className merging', () => {
+    it('merges custom className with base classes', () => {
+      const { container } = render(
+        <Badge text="Custom" className="my-custom-class" />,
+      )
+      const badge = container.firstChild as HTMLElement
+      expect(badge.className).toContain('my-custom-class')
+      expect(badge.className).toContain('rounded-lg')
+    })
+  })
+
+  describe('variants', () => {
+    it('applies primary variant styles', () => {
+      const { container } = render(<Badge text="Primary" variant="primary" />)
+      const badge = container.firstChild as HTMLElement
+      expect(badge.className).toContain('bg-white/40')
+    })
+
+    it('applies secondary variant styles', () => {
+      const { container } = render(
+        <Badge text="Secondary" variant="secondary" />,
+      )
+      const badge = container.firstChild as HTMLElement
+      expect(badge.className).toContain('bg-orange/10')
+    })
+  })
+})

--- a/packages/react-kit/src/shared/components/Badge/index.tsx
+++ b/packages/react-kit/src/shared/components/Badge/index.tsx
@@ -1,0 +1,40 @@
+import { cn } from '../../utils/common'
+import { Icon, type IconName } from '../Icon'
+import { Text } from '../Text'
+
+export interface BadgeProps {
+  text: string
+  variant?: 'primary' | 'secondary'
+  leadingIcon?: IconName
+  trailingIcon?: IconName
+  className?: string
+}
+
+const variantStyles = {
+  primary: 'bg-white/40',
+  secondary: 'bg-orange/10',
+}
+
+export function Badge({
+  text,
+  variant = 'primary',
+  leadingIcon,
+  trailingIcon,
+  className,
+}: BadgeProps) {
+  return (
+    <div
+      className={cn(
+        'py-1 px-2 gap-1 flex flex-row items-center rounded-lg self-start',
+        variantStyles[variant],
+        className,
+      )}
+    >
+      {leadingIcon && (
+        <Icon name={leadingIcon} className="w-3 h-3 text-solarOrange" />
+      )}
+      <Text className="text-body3">{text}</Text>
+      {trailingIcon && <Icon name={trailingIcon} className="w-2.5 h-2.5" />}
+    </div>
+  )
+}

--- a/packages/react-kit/src/shared/components/ListItem/ListItem.stories.tsx
+++ b/packages/react-kit/src/shared/components/ListItem/ListItem.stories.tsx
@@ -68,6 +68,19 @@ export const WithDetails: Story = {
   },
 }
 
+export const WithBadge: Story = {
+  args: {
+    iconName: 'wallet',
+    title: 'Verified Wallet',
+    badgeProps: {
+      text: 'Verified',
+      variant: 'secondary',
+      leadingIcon: 'check',
+    },
+    chevron: true,
+  },
+}
+
 export const AlertState: Story = {
   args: {
     iconName: 'warning',

--- a/packages/react-kit/src/shared/components/ListItem/ListItem.test.tsx
+++ b/packages/react-kit/src/shared/components/ListItem/ListItem.test.tsx
@@ -43,6 +43,24 @@ describe('ListItem', () => {
     expect(screen.getByTestId('icon-chevronRight')).toBeDefined()
   })
 
+  it('renders badge when badgeProps is provided', () => {
+    render(
+      <ListItem
+        title="Test Title"
+        badgeProps={{ text: 'New', variant: 'secondary' }}
+      />,
+    )
+    expect(screen.getByText('New')).toBeDefined()
+  })
+
+  it('applies correct gap when badge is present', () => {
+    const { container } = render(
+      <ListItem title="Test Title" badgeProps={{ text: 'Badge' }} />,
+    )
+    const contentDiv = container.querySelector('.gap-2')
+    expect(contentDiv).not.toBeNull()
+  })
+
   it('renders details when provided', () => {
     render(
       <ListItem

--- a/packages/react-kit/src/shared/components/ListItem/index.tsx
+++ b/packages/react-kit/src/shared/components/ListItem/index.tsx
@@ -1,6 +1,7 @@
 import type { HTMLAttributes } from 'react'
 
 import { cn } from '../../utils/common'
+import { Badge, type BadgeProps } from '../Badge'
 import { Icon, type IconName } from '../Icon'
 import { Text } from '../Text'
 import { Wrapper } from '../Wrapper'
@@ -39,6 +40,7 @@ export interface ListItemProps extends HTMLAttributes<HTMLButtonElement> {
   imageUri?: string
   title: string
   subtitle?: string
+  badgeProps?: BadgeProps
   details?: { text: string; subtext?: string }
   chevron?: boolean
   alert?: boolean
@@ -49,6 +51,7 @@ export function ListItem({
   imageUri,
   title,
   subtitle,
+  badgeProps,
   details,
   chevron,
   alert,
@@ -90,11 +93,17 @@ export function ListItem({
               />
             ) : null}
           </div>
-          <div className="flex flex-col justify-center text-left gap-1">
+          <div
+            className={cn(
+              'flex flex-col justify-center text-left',
+              badgeProps ? 'gap-2' : 'gap-1',
+            )}
+          >
             <Text className="text-body1">{title}</Text>
             {subtitle && (
               <Text className="text-body3 text-greyScale/50">{subtitle}</Text>
             )}
+            {badgeProps && <Badge {...badgeProps} />}
           </div>
         </div>
         {details ? (


### PR DESCRIPTION
Closes [FS-1881](https://linear.app/offchain-labs/issue/FS-1881/move-doorway-shared-components-to-zd-wallet)

### Summary

This PR migrates Badge component

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"omar/icons-refactor","parentHead":"720701fdc7805a69084f4e1ee0d3d1d9b921892b","parentPull":94,"trunk":"main"}
```
-->
