### PR TITLE
feat(react-kit): decode personal_sign messages in signing UI

### DIFF
--- a/apps/react-example/src/App.tsx
+++ b/apps/react-example/src/App.tsx
@@ -4,7 +4,12 @@ import {
   usePendingRequest,
 } from '@zerodev/wallet-react-kit'
 import { encodeFunctionData, erc20Abi, parseEther } from 'viem'
-import { useAccount, useDisconnect, useSendTransaction } from 'wagmi'
+import {
+  useAccount,
+  useDisconnect,
+  useSendTransaction,
+  useSignMessage,
+} from 'wagmi'
 import { AuthExample } from './AuthExample'
 
 function WalletPanel() {
@@ -12,6 +17,13 @@ function WalletPanel() {
   const { disconnect } = useDisconnect()
   const { sendTransaction, isSuccess, isError, error, data } =
     useSendTransaction()
+  const {
+    signMessage,
+    data: signature,
+    isSuccess: signSuccess,
+    isError: signError,
+    error: signMessageError,
+  } = useSignMessage()
   const { pendingRequests } = usePendingRequest()
 
   return (
@@ -71,6 +83,10 @@ function WalletPanel() {
             })
           }
         />
+        <Button
+          text="Sign Message"
+          onClick={() => signMessage({ message: 'Hello from ZeroDev!' })}
+        />
       </div>
 
       {isSuccess && <p className="text-green-600 text-sm mt-2">tx: {data}</p>}
@@ -79,6 +95,19 @@ function WalletPanel() {
           {error?.message?.includes('User rejected')
             ? 'Rejected by user'
             : error?.message}
+        </p>
+      )}
+
+      {signSuccess && (
+        <p className="text-green-600 text-sm mt-2 break-all">
+          sig: {signature}
+        </p>
+      )}
+      {signError && (
+        <p className="text-red-500 text-sm mt-2">
+          {signMessageError?.message?.includes('User rejected')
+            ? 'Rejected by user'
+            : signMessageError?.message}
         </p>
       )}
 

--- a/packages/react-kit/src/signing/index.tsx
+++ b/packages/react-kit/src/signing/index.tsx
@@ -6,6 +6,7 @@ import { Erc20Approval } from './pages/Erc20Approval.js'
 import { Erc20Transfer } from './pages/Erc20Transfer.js'
 import { EthTransfer } from './pages/EthTransfer.js'
 import { GenericRequest } from './pages/GenericRequest.js'
+import { PersonalSign } from './pages/PersonalSign.js'
 import { decodeErc20Approval, isErc20Approval } from './utils/erc20Approval.js'
 import { decodeErc20Transfer, isErc20Transfer } from './utils/erc20Transfer.js'
 import { isEthTransfer } from './utils/ethTransfer.js'
@@ -62,6 +63,19 @@ export function SignatureRequest() {
             )
           }
         }
+        break
+      }
+
+      case 'personal_sign': {
+        const [data, address] = pendingRequest.params
+        return (
+          <PersonalSign
+            data={data}
+            address={address}
+            confirm={confirm}
+            reject={reject}
+          />
+        )
       }
     }
 

--- a/packages/react-kit/src/signing/pages/PersonalSign.tsx
+++ b/packages/react-kit/src/signing/pages/PersonalSign.tsx
@@ -22,9 +22,18 @@ export function PersonalSign({
       <h3 className="text-lg font-semibold text-gray-900">Sign Message</h3>
 
       <div className="rounded-lg bg-gray-50 p-4 border border-gray-100">
-        <pre className="text-sm text-gray-900 whitespace-pre-wrap break-all">
-          {message}
-        </pre>
+        {message !== null ? (
+          <pre className="text-sm text-gray-900 whitespace-pre-wrap break-all">
+            {message}
+          </pre>
+        ) : (
+          <div>
+            <p className="text-xs text-gray-500 mb-1">Raw data:</p>
+            <pre className="text-sm text-gray-900 whitespace-pre-wrap break-all">
+              {data}
+            </pre>
+          </div>
+        )}
         <div className="mt-2 text-sm text-gray-500">
           <span className="font-medium">Signer: </span>
           <span className="font-mono break-all">{address}</span>

--- a/packages/react-kit/src/signing/pages/PersonalSign.tsx
+++ b/packages/react-kit/src/signing/pages/PersonalSign.tsx
@@ -1,0 +1,37 @@
+import type { Hex } from 'viem'
+import { SigningActions } from '../components/SigningActions.js'
+import { decodePersonalSignMessage } from '../utils/personalSign.js'
+
+interface PersonalSignProps {
+  data: Hex
+  address: Hex
+  confirm: () => void
+  reject: () => void
+}
+
+export function PersonalSign({
+  data,
+  address,
+  confirm,
+  reject,
+}: PersonalSignProps) {
+  const message = decodePersonalSignMessage(data)
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h3 className="text-lg font-semibold text-gray-900">Sign Message</h3>
+
+      <div className="rounded-lg bg-gray-50 p-4 border border-gray-100">
+        <pre className="text-sm text-gray-900 whitespace-pre-wrap break-all">
+          {message}
+        </pre>
+        <div className="mt-2 text-sm text-gray-500">
+          <span className="font-medium">Signer: </span>
+          <span className="font-mono break-all">{address}</span>
+        </div>
+      </div>
+
+      <SigningActions confirm={confirm} reject={reject} />
+    </div>
+  )
+}

--- a/packages/react-kit/src/signing/utils/personalSign.test.ts
+++ b/packages/react-kit/src/signing/utils/personalSign.test.ts
@@ -16,9 +16,8 @@ describe('decodePersonalSignMessage', () => {
     )
   })
 
-  it('returns raw hex for malformed input', () => {
+  it('returns null for malformed input', () => {
     const badHex = '0xgg' as Hex
-    const result = decodePersonalSignMessage(badHex)
-    expect(result).toBe(badHex)
+    expect(decodePersonalSignMessage(badHex)).toBeNull()
   })
 })

--- a/packages/react-kit/src/signing/utils/personalSign.test.ts
+++ b/packages/react-kit/src/signing/utils/personalSign.test.ts
@@ -1,0 +1,24 @@
+import type { Hex } from 'viem'
+import { stringToHex } from 'viem'
+import { describe, expect, it } from 'vitest'
+import { decodePersonalSignMessage } from './personalSign'
+
+describe('decodePersonalSignMessage', () => {
+  it('decodes a hex-encoded string', () => {
+    const hex = stringToHex('Hello, world!')
+    expect(decodePersonalSignMessage(hex)).toBe('Hello, world!')
+  })
+
+  it('decodes a multiline message', () => {
+    const hex = stringToHex('Sign in to Example.com\n\nNonce: abc123')
+    expect(decodePersonalSignMessage(hex)).toBe(
+      'Sign in to Example.com\n\nNonce: abc123',
+    )
+  })
+
+  it('returns raw hex for malformed input', () => {
+    const badHex = '0xgg' as Hex
+    const result = decodePersonalSignMessage(badHex)
+    expect(result).toBe(badHex)
+  })
+})

--- a/packages/react-kit/src/signing/utils/personalSign.ts
+++ b/packages/react-kit/src/signing/utils/personalSign.ts
@@ -1,9 +1,9 @@
 import { type Hex, hexToString } from 'viem'
 
-export function decodePersonalSignMessage(data: Hex): string {
+export function decodePersonalSignMessage(data: Hex): string | null {
   try {
     return hexToString(data)
   } catch {
-    return data
+    return null
   }
 }

--- a/packages/react-kit/src/signing/utils/personalSign.ts
+++ b/packages/react-kit/src/signing/utils/personalSign.ts
@@ -1,0 +1,9 @@
+import { type Hex, hexToString } from 'viem'
+
+export function decodePersonalSignMessage(data: Hex): string {
+  try {
+    return hexToString(data)
+  } catch {
+    return data
+  }
+}


### PR DESCRIPTION
closes FS-1964

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
