### PR TITLE
fix: update authenticator types to camelCase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,10 @@ jobs:
       - name: Extract demo branch from PR body
         id: demo-branch
         if: github.event_name == 'pull_request'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          BRANCH=$(echo "${{ github.event.pull_request.body }}" | grep -oE 'demo-branch:\s*\S+' | head -1 | sed 's/demo-branch:\s*//')
+          BRANCH=$(echo "$PR_BODY" | grep -oE 'demo-branch:[[:space:]]*[^[:space:]]+' | head -1 | sed 's/demo-branch:[[:space:]]*//')
           echo "ref=${BRANCH:-main}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout demo app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,10 +133,18 @@ jobs:
       - name: Checkout SDK
         uses: actions/checkout@v4
 
+      - name: Extract demo branch from PR body
+        id: demo-branch
+        if: github.event_name == 'pull_request'
+        run: |
+          BRANCH=$(echo "${{ github.event.pull_request.body }}" | grep -oE 'demo-branch:\s*\S+' | head -1 | sed 's/demo-branch:\s*//')
+          echo "ref=${BRANCH:-main}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout demo app
         uses: actions/checkout@v4
         with:
           repository: zerodevapp/zerodev-signer-demo
+          ref: ${{ steps.demo-branch.outputs.ref || 'main' }}
           path: zerodev-signer-demo
 
       - name: Setup pnpm

--- a/packages/core/src/actions/auth/auth.test.ts
+++ b/packages/core/src/actions/auth/auth.test.ts
@@ -355,11 +355,11 @@ describe('registerWithPasskey', () => {
 describe('getAuthenticators', () => {
   const mockResponse = {
     oauths: [
-      { Provider: 'google', ClientId: 'some-client-id', Subject: 'sub' },
+      { provider: 'google', clientId: 'some-client-id', subject: 'sub' },
     ],
-    passkeys: [{ RpId: 'example.com', PublicKey: 'pk', CredentialId: 'cred' }],
-    emailContacts: [{ Email: 'user@example.com' }],
-    apiKeys: [{ ApiKey: 'compressed-pub-key' }],
+    passkeys: [{ rpId: 'example.com', publicKey: 'pk', credentialId: 'cred' }],
+    emailContacts: [{ email: 'user@example.com' }],
+    apiKeys: [{ apiKey: 'compressed-pub-key' }],
   }
 
   it('sends authenticators request with correct parameters', async () => {
@@ -397,8 +397,8 @@ describe('getAuthenticators', () => {
 
     expect(result.oauths).toHaveLength(1)
     expect(result.passkeys).toHaveLength(1)
-    expect(result.emailContacts[0]?.Email).toBe('user@example.com')
-    expect(result.apiKeys[0]?.ApiKey).toBe('compressed-pub-key')
+    expect(result.emailContacts[0]?.email).toBe('user@example.com')
+    expect(result.apiKeys[0]?.apiKey).toBe('compressed-pub-key')
   })
 
   it('requests stamping', async () => {

--- a/packages/core/src/actions/auth/getAuthenticators.ts
+++ b/packages/core/src/actions/auth/getAuthenticators.ts
@@ -9,31 +9,31 @@ export type GetAuthenticatorsParameters = {
   token: string
 }
 
-/** An OAuth authenticator linked to the user (PascalCase from Go default marshaling) */
+/** An OAuth authenticator linked to the user */
 export type OAuthAuthenticator = {
-  Provider?: string
-  ClientId?: string
-  Subject?: string
+  provider?: string
+  clientId?: string
+  subject?: string
   [key: string]: unknown
 }
 
-/** A passkey (WebAuthn) authenticator (PascalCase from Go default marshaling) */
+/** A passkey (WebAuthn) authenticator */
 export type PasskeyAuthenticator = {
-  RpId?: string
-  PublicKey?: string
-  CredentialId?: string
+  rpId?: string
+  publicKey?: string
+  credentialId?: string
   [key: string]: unknown
 }
 
-/** An email contact linked to the user (PascalCase from Go default marshaling) */
+/** An email contact linked to the user */
 export type EmailContact = {
-  Email?: string
+  email?: string
   [key: string]: unknown
 }
 
-/** An API key authenticator (PascalCase from Go default marshaling) */
+/** An API key authenticator */
 export type ApiKeyAuthenticator = {
-  ApiKey?: string
+  apiKey?: string
   [key: string]: unknown
 }
 

--- a/packages/react/src/actions.test.ts
+++ b/packages/react/src/actions.test.ts
@@ -51,7 +51,7 @@ function createMockWallet() {
       getAuthenticators: vi.fn().mockResolvedValue({
         oauths: [],
         passkeys: [],
-        emailContacts: [{ Email: 'user@example.com' }],
+        emailContacts: [{ email: 'user@example.com' }],
         apiKeys: [],
       }),
     },
@@ -461,7 +461,7 @@ describe('React Actions', () => {
     it('returns authenticators from wallet client', async () => {
       const wallet = createMockWallet()
       const response = {
-        oauths: [{ Provider: 'google', ClientId: 'cid', Subject: 'sub' }],
+        oauths: [{ provider: 'google', clientId: 'cid', subject: 'sub' }],
         passkeys: [],
         emailContacts: [],
         apiKeys: [],


### PR DESCRIPTION
## Summary

- Backend PR OffchainLabs/doorway-kms#590 adds `json` tags to authenticator structs, changing field names from PascalCase to camelCase
- Update SDK types to match: `Provider`→`provider`, `ClientId`→`clientId`, `Email`→`email`, `RpId`→`rpId`, `PublicKey`→`publicKey`, `CredentialId`→`credentialId`, `ApiKey`→`apiKey`
- Update tests accordingly
- Add `demo-branch` support to E2E workflow to resolve circular dependency between SDK and demo repos

demo-branch: fix/authenticator-camelcase