### PR TITLE
feat(react-kit): DetailsContainer, MessageDetails, DataRow

### DIFF
--- a/packages/react-kit/src/shared/utils/common.test.ts
+++ b/packages/react-kit/src/shared/utils/common.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import { camelCaseToTitle, capitalizeFirst, cn } from './common'
+
+describe('cn', () => {
+  it('joins multiple class strings', () => {
+    expect(cn('p-2', 'text-white')).toBe('p-2 text-white')
+  })
+
+  it('ignores falsy values', () => {
+    expect(cn('p-2', false, null, undefined, '', 'text-white')).toBe(
+      'p-2 text-white',
+    )
+  })
+
+  it('merges conflicting tailwind utilities, keeping the last one', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4')
+  })
+
+  it('supports conditional object syntax (clsx)', () => {
+    expect(cn('base', { active: true, inactive: false })).toBe('base active')
+  })
+
+  it('merges custom font-size tokens from the extended config', () => {
+    expect(cn('text-body2', 'text-body1')).toBe('text-body1')
+  })
+})
+
+describe('capitalizeFirst', () => {
+  it('uppercases the first character', () => {
+    expect(capitalizeFirst('hello')).toBe('Hello')
+  })
+
+  it('leaves already-capitalized strings untouched', () => {
+    expect(capitalizeFirst('Hello')).toBe('Hello')
+  })
+
+  it('returns an empty string for empty input', () => {
+    expect(capitalizeFirst('')).toBe('')
+  })
+
+  it('returns an empty string for undefined', () => {
+    expect(capitalizeFirst(undefined)).toBe('')
+  })
+
+  it('returns an empty string for null', () => {
+    expect(capitalizeFirst(null)).toBe('')
+  })
+
+  it('only capitalizes the first letter, not the rest', () => {
+    expect(capitalizeFirst('hELLO')).toBe('HELLO')
+  })
+})
+
+describe('camelCaseToTitle', () => {
+  it('converts single-word camelCase to Title Case', () => {
+    expect(camelCaseToTitle('gasFee')).toBe('Gas Fee')
+  })
+
+  it('handles multiple camelCase words', () => {
+    expect(camelCaseToTitle('transactionGasFee')).toBe('Transaction Gas Fee')
+  })
+
+  it('capitalizes a single lowercase word', () => {
+    expect(camelCaseToTitle('amount')).toBe('Amount')
+  })
+
+  it('leaves strings that already start with uppercase untouched', () => {
+    expect(camelCaseToTitle('From')).toBe('From')
+    expect(camelCaseToTitle('PascalCase')).toBe('PascalCase')
+  })
+
+  it('returns empty string unchanged', () => {
+    expect(camelCaseToTitle('')).toBe('')
+  })
+})

--- a/packages/react-kit/src/shared/utils/common.ts
+++ b/packages/react-kit/src/shared/utils/common.ts
@@ -14,3 +14,20 @@ const customTwMerge = extendTailwindMerge({
 export function cn(...inputs: ClassValue[]) {
   return customTwMerge(clsx(inputs))
 }
+
+export function capitalizeFirst(str: string): string {
+  if (str.length === 0) return str
+  return str.charAt(0).toUpperCase() + str.slice(1)
+}
+
+export function camelCaseToTitle(str: string): string {
+  if (str.length === 0 || str.at(0) === str.at(0)?.toUpperCase()) {
+    return str
+  }
+
+  const words = str.replace(/([a-z])([A-Z])/g, '$1 $2').trim()
+  return words
+    .split(' ')
+    .map((word) => capitalizeFirst(word))
+    .join(' ')
+}

--- a/packages/react-kit/src/shared/utils/common.ts
+++ b/packages/react-kit/src/shared/utils/common.ts
@@ -15,9 +15,10 @@ export function cn(...inputs: ClassValue[]) {
   return customTwMerge(clsx(inputs))
 }
 
-export function capitalizeFirst(str: string): string {
-  if (str.length === 0) return str
-  return str.charAt(0).toUpperCase() + str.slice(1)
+export function capitalizeFirst(str?: string | null): string {
+  if (!str) return ''
+  const first = str.at(0) ?? ''
+  return first.toUpperCase() + str.slice(1)
 }
 
 export function camelCaseToTitle(str: string): string {

--- a/packages/react-kit/src/signing/components/DataRow/DataRow.stories.tsx
+++ b/packages/react-kit/src/signing/components/DataRow/DataRow.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { icons } from '../../../shared/components/Icon'
+import { Text } from '../../../shared/components/Text'
+import { DataRow } from '.'
+
+const iconNames = Object.keys(icons)
+
+const meta = {
+  title: 'Signing/DataRow',
+  component: DataRow,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    iconName: {
+      control: 'select',
+      options: [undefined, ...iconNames],
+    },
+    leadingIconName: {
+      control: 'select',
+      options: [undefined, ...iconNames],
+    },
+  },
+  args: {
+    label: 'amount',
+    value: '0.05 ETH',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof DataRow>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const CamelCaseLabel: Story = {
+  args: {
+    label: 'gasFee',
+    value: '0.00123 ETH',
+  },
+}
+
+export const WithLeadingIcon: Story = {
+  args: {
+    label: 'gas',
+    value: '0.0012 ETH',
+    leadingIconName: 'flame',
+  },
+}
+
+export const WithTrailingIcon: Story = {
+  args: {
+    label: 'network',
+    value: 'Sepolia',
+    iconName: 'info',
+  },
+}
+
+export const WithCustomValue: Story = {
+  args: {
+    label: 'status',
+    value: <Text className="text-solarOrange">Pending</Text>,
+  },
+}

--- a/packages/react-kit/src/signing/components/DataRow/DataRow.test.tsx
+++ b/packages/react-kit/src/signing/components/DataRow/DataRow.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../shared/components/Icon', async () => {
+  const React = await import('react')
+
+  const MockIcon = ({
+    name,
+    ...props
+  }: { name: string } & React.SVGProps<SVGSVGElement>) =>
+    React.createElement('svg', { 'data-testid': `icon-${name}`, ...props })
+
+  return {
+    Icon: MockIcon,
+    icons: {},
+  }
+})
+
+import { DataRow } from './index'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('DataRow', () => {
+  describe('rendering', () => {
+    it('renders label and string value', () => {
+      render(<DataRow label="amount" value="0.05 ETH" />)
+      expect(screen.getByText('Amount')).toBeDefined()
+      expect(screen.getByText('0.05 ETH')).toBeDefined()
+    })
+
+    it('renders ReactNode value as-is (no Text wrapping)', () => {
+      render(
+        <DataRow
+          label="recipient"
+          value={<span data-testid="custom-value">Alice</span>}
+        />,
+      )
+      expect(screen.getByTestId('custom-value')).toBeDefined()
+    })
+
+    it('returns null when label is missing', () => {
+      const { container } = render(<DataRow value="x" />)
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('returns null when label is an empty string', () => {
+      const { container } = render(<DataRow label="" value="x" />)
+      expect(container.firstChild).toBeNull()
+    })
+  })
+
+  describe('label formatting', () => {
+    it('converts camelCase labels to Title Case', () => {
+      render(<DataRow label="gasFee" value="0.001" />)
+      expect(screen.getByText('Gas Fee')).toBeDefined()
+    })
+
+    it('leaves already-capitalized labels untouched', () => {
+      render(<DataRow label="From" value="0x1" />)
+      expect(screen.getByText('From')).toBeDefined()
+    })
+  })
+
+  describe('icons', () => {
+    it('renders a leading icon before the value when leadingIconName is provided', () => {
+      render(
+        <DataRow label="amount" value="0.05 ETH" leadingIconName="flame" />,
+      )
+      expect(screen.getByTestId('icon-flame')).toBeDefined()
+    })
+
+    it('renders a trailing icon after the value when iconName is provided', () => {
+      render(<DataRow label="amount" value="0.05 ETH" iconName="info" />)
+      expect(screen.getByTestId('icon-info')).toBeDefined()
+    })
+
+    it('renders no icons by default', () => {
+      const { container } = render(<DataRow label="amount" value="x" />)
+      expect(container.querySelector('svg')).toBeNull()
+    })
+  })
+
+  describe('className', () => {
+    it('merges custom className onto the root element', () => {
+      const { container } = render(
+        <DataRow label="amount" value="x" className="mt-4" />,
+      )
+      const root = container.firstChild as HTMLElement
+      expect(root.className).toContain('mt-4')
+      expect(root.className).toContain('flex')
+      expect(root.className).toContain('flex-row')
+    })
+  })
+})

--- a/packages/react-kit/src/signing/components/DataRow/index.tsx
+++ b/packages/react-kit/src/signing/components/DataRow/index.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react'
+
+import { Icon, type IconName } from '../../../shared/components/Icon'
+import { Text } from '../../../shared/components/Text'
+import { camelCaseToTitle, cn } from '../../../shared/utils/common'
+
+export interface DataRowProps {
+  label?: string
+  value: string | ReactNode
+  iconName?: IconName
+  leadingIconName?: IconName
+  className?: string
+}
+
+export function DataRow({
+  label,
+  value,
+  iconName,
+  leadingIconName,
+  className,
+}: DataRowProps) {
+  if (!label) return null
+
+  return (
+    <div
+      className={cn('flex flex-row items-center justify-between', className)}
+    >
+      <Text>{camelCaseToTitle(label)}</Text>
+      <div className="flex flex-row items-center gap-1">
+        {leadingIconName && (
+          <Icon name={leadingIconName} className="h-3 w-3 text-solarOrange" />
+        )}
+        {typeof value === 'string' ? (
+          <Text className="text-body1">{value}</Text>
+        ) : (
+          value
+        )}
+        {iconName && (
+          <Icon name={iconName} className="w-4 h-4 text-solarOrange" />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/react-kit/src/signing/components/DetailsContainer/DetailsContainer.stories.tsx
+++ b/packages/react-kit/src/signing/components/DetailsContainer/DetailsContainer.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { icons } from '../../../shared/components/Icon'
+import { Text } from '../../../shared/components/Text'
+import { DetailsContainer } from '.'
+
+const iconNames = Object.keys(icons)
+
+const meta = {
+  title: 'Signing/DetailsContainer',
+  component: DetailsContainer,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    iconName: {
+      control: 'select',
+      options: iconNames,
+    },
+    collapsible: {
+      control: 'select',
+      options: [undefined, true, false],
+    },
+  },
+  args: {
+    title: 'Transaction details',
+    iconName: 'wallet',
+    children: (
+      <div className="flex flex-col gap-2">
+        <Text>From: 0x1234...5678</Text>
+        <Text>To: 0xabcd...efab</Text>
+        <Text>Amount: 0.05 ETH</Text>
+      </div>
+    ),
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof DetailsContainer>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Static: Story = {}
+
+export const Expanded: Story = {
+  args: {
+    collapsible: false,
+  },
+}
+
+export const Collapsed: Story = {
+  args: {
+    collapsible: true,
+  },
+}

--- a/packages/react-kit/src/signing/components/DetailsContainer/DetailsContainer.stories.tsx
+++ b/packages/react-kit/src/signing/components/DetailsContainer/DetailsContainer.stories.tsx
@@ -28,9 +28,7 @@ const meta = {
     iconName: 'wallet',
     children: (
       <div className="flex flex-col gap-2">
-        <Text>From: 0x1234...5678</Text>
-        <Text>To: 0xabcd...efab</Text>
-        <Text>Amount: 0.05 ETH</Text>
+        <Text>Some random text</Text>
       </div>
     ),
   },

--- a/packages/react-kit/src/signing/components/DetailsContainer/DetailsContainer.test.tsx
+++ b/packages/react-kit/src/signing/components/DetailsContainer/DetailsContainer.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../shared/components/Icon', async () => {
+  const React = await import('react')
+
+  const MockIcon = ({
+    name,
+    ...props
+  }: { name: string } & React.SVGProps<SVGSVGElement>) =>
+    React.createElement('svg', { 'data-testid': `icon-${name}`, ...props })
+
+  return {
+    Icon: MockIcon,
+    icons: {},
+  }
+})
+
+import { DetailsContainer } from './index'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('DetailsContainer', () => {
+  describe('rendering', () => {
+    it('renders title and leading icon', () => {
+      render(
+        <DetailsContainer title="Details" iconName="wallet">
+          <span>body</span>
+        </DetailsContainer>,
+      )
+      expect(screen.getByText('Details')).toBeDefined()
+      expect(screen.getByTestId('icon-wallet')).toBeDefined()
+    })
+
+    it('renders children by default (not collapsible)', () => {
+      render(
+        <DetailsContainer title="Details" iconName="wallet">
+          <span>body</span>
+        </DetailsContainer>,
+      )
+      expect(screen.getByText('body')).toBeDefined()
+    })
+
+    it('does not render a toggle button when collapsible prop is omitted', () => {
+      render(
+        <DetailsContainer title="Details" iconName="wallet">
+          <span>body</span>
+        </DetailsContainer>,
+      )
+      expect(screen.queryByRole('button')).toBeNull()
+    })
+  })
+
+  describe('collapsible=false (starts expanded)', () => {
+    it('renders children initially and shows a chevronUp icon', () => {
+      render(
+        <DetailsContainer title="Details" iconName="wallet" collapsible={false}>
+          <span>body</span>
+        </DetailsContainer>,
+      )
+      expect(screen.getByText('body')).toBeDefined()
+      expect(screen.getByTestId('icon-chevronUp')).toBeDefined()
+    })
+
+    it('hides children after clicking the toggle', () => {
+      render(
+        <DetailsContainer title="Details" iconName="wallet" collapsible={false}>
+          <span>body</span>
+        </DetailsContainer>,
+      )
+      fireEvent.click(screen.getByRole('button'))
+      expect(screen.queryByText('body')).toBeNull()
+      expect(screen.getByTestId('icon-chevronDown')).toBeDefined()
+    })
+  })
+
+  describe('collapsible=true (starts collapsed)', () => {
+    it('hides children initially and shows a chevronDown icon', () => {
+      render(
+        <DetailsContainer title="Details" iconName="wallet" collapsible>
+          <span>body</span>
+        </DetailsContainer>,
+      )
+      expect(screen.queryByText('body')).toBeNull()
+      expect(screen.getByTestId('icon-chevronDown')).toBeDefined()
+    })
+
+    it('reveals children after clicking the toggle', () => {
+      render(
+        <DetailsContainer title="Details" iconName="wallet" collapsible>
+          <span>body</span>
+        </DetailsContainer>,
+      )
+      fireEvent.click(screen.getByRole('button'))
+      expect(screen.getByText('body')).toBeDefined()
+      expect(screen.getByTestId('icon-chevronUp')).toBeDefined()
+    })
+  })
+})

--- a/packages/react-kit/src/signing/components/DetailsContainer/MessageDetails/MessageDetails.stories.tsx
+++ b/packages/react-kit/src/signing/components/DetailsContainer/MessageDetails/MessageDetails.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { MessageDetails } from '.'
+
+const meta = {
+  title: 'Signing/MessageDetails',
+  component: MessageDetails,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof MessageDetails>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    details: {
+      From: '0x1234...5678',
+      To: '0xabcd...efab',
+      Amount: '0.05 ETH',
+      Nonce: '42',
+    },
+  },
+}
+
+export const SingleEntry: Story = {
+  args: {
+    details: {
+      Message: 'Sign in to zerodev.app',
+    },
+  },
+}
+
+export const Empty: Story = {
+  args: {
+    details: {},
+  },
+}

--- a/packages/react-kit/src/signing/components/DetailsContainer/MessageDetails/MessageDetails.stories.tsx
+++ b/packages/react-kit/src/signing/components/DetailsContainer/MessageDetails/MessageDetails.stories.tsx
@@ -31,17 +31,3 @@ export const Default: Story = {
     },
   },
 }
-
-export const SingleEntry: Story = {
-  args: {
-    details: {
-      Message: 'Sign in to zerodev.app',
-    },
-  },
-}
-
-export const Empty: Story = {
-  args: {
-    details: {},
-  },
-}

--- a/packages/react-kit/src/signing/components/DetailsContainer/MessageDetails/MessageDetails.test.tsx
+++ b/packages/react-kit/src/signing/components/DetailsContainer/MessageDetails/MessageDetails.test.tsx
@@ -1,0 +1,50 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../../shared/components/Icon', async () => {
+  const React = await import('react')
+
+  const MockIcon = ({
+    name,
+    ...props
+  }: { name: string } & React.SVGProps<SVGSVGElement>) =>
+    React.createElement('svg', { 'data-testid': `icon-${name}`, ...props })
+
+  return {
+    Icon: MockIcon,
+    icons: {},
+  }
+})
+
+import { MessageDetails } from './index'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('MessageDetails', () => {
+  it('renders the "Message Details" title and message icon', () => {
+    render(<MessageDetails details={{ from: '0x1', to: '0x2' }} />)
+    expect(screen.getByText('Message Details')).toBeDefined()
+    expect(screen.getByTestId('icon-message')).toBeDefined()
+  })
+
+  it('renders a row per entry in the details object (labels title-cased)', () => {
+    render(
+      <MessageDetails
+        details={{ from: '0xfrom', to: '0xto', gasFee: '0.001' }}
+      />,
+    )
+    expect(screen.getByText('From')).toBeDefined()
+    expect(screen.getByText('0xfrom')).toBeDefined()
+    expect(screen.getByText('To')).toBeDefined()
+    expect(screen.getByText('0xto')).toBeDefined()
+    expect(screen.getByText('Gas Fee')).toBeDefined()
+    expect(screen.getByText('0.001')).toBeDefined()
+  })
+
+  it('renders nothing below the header when details is empty', () => {
+    render(<MessageDetails details={{}} />)
+    expect(screen.getByText('Message Details')).toBeDefined()
+  })
+})

--- a/packages/react-kit/src/signing/components/DetailsContainer/MessageDetails/index.tsx
+++ b/packages/react-kit/src/signing/components/DetailsContainer/MessageDetails/index.tsx
@@ -1,0 +1,16 @@
+import { DataRow } from '../../DataRow'
+import { DetailsContainer } from '..'
+
+export interface MessageDetailsProps {
+  details: Record<string, string>
+}
+
+export function MessageDetails({ details }: MessageDetailsProps) {
+  return (
+    <DetailsContainer title="Message Details" iconName="message">
+      {Object.entries(details).map(([label, value]) => (
+        <DataRow key={label} label={label} value={value} />
+      ))}
+    </DetailsContainer>
+  )
+}

--- a/packages/react-kit/src/signing/components/DetailsContainer/index.tsx
+++ b/packages/react-kit/src/signing/components/DetailsContainer/index.tsx
@@ -1,0 +1,45 @@
+import { type ReactNode, useState } from 'react'
+
+import { Icon, type IconName } from '../../../shared/components/Icon'
+import { Text } from '../../../shared/components/Text'
+import { Wrapper } from '../../../shared/components/Wrapper'
+
+export interface DetailsContainerProps {
+  title: string
+  iconName: IconName
+  children: ReactNode
+  collapsible?: boolean
+}
+
+export function DetailsContainer({
+  title,
+  iconName,
+  collapsible,
+  children,
+}: DetailsContainerProps) {
+  const [collapsed, setCollapsed] = useState(collapsible === true)
+
+  return (
+    <Wrapper className="p-4 flex flex-col gap-3 rounded-xl w-full">
+      <div className="flex flex-row justify-between items-center">
+        <div className="flex flex-row items-center gap-2">
+          <Icon name={iconName} className="h-4 w-4 text-solarOrange" />
+          <Text className="text-h3">{title}</Text>
+        </div>
+        {collapsible !== undefined && (
+          <button
+            type="button"
+            onClick={() => setCollapsed((c) => !c)}
+            className="flex items-center justify-center cursor-pointer"
+          >
+            <Icon
+              name={collapsed ? 'chevronDown' : 'chevronUp'}
+              className="w-4 h-4 text-greyScale"
+            />
+          </button>
+        )}
+      </div>
+      {!collapsed && children}
+    </Wrapper>
+  )
+}


### PR DESCRIPTION
Closes [FS-2047](https://linear.app/offchain-labs/issue/FS-2047/detailscontainer-component)

### Summary

This PR migrates the following components: DetailsContainer, MessageDetails, DataRow

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
