### PR TITLE
feat(react-kit): trigger auth flow on connect instead of on init

### DIFF
--- a/apps/react-example/src/App.tsx
+++ b/apps/react-example/src/App.tsx
@@ -7,6 +7,7 @@ import {
 import { encodeFunctionData, erc20Abi, parseEther } from 'viem'
 import {
   useAccount,
+  useConnect,
   useDisconnect,
   useSendCalls,
   useSendTransaction,
@@ -193,10 +194,25 @@ function WalletPanel() {
 }
 
 export function App() {
+  const { connect, connectors } = useConnect()
   const { isConnected } = useAccount()
+
   return (
-    <div className="mx-auto h-full w-[500px]">
-      {isConnected ? <WalletPanel /> : <AuthFlow />}
+    <div className="mx-auto h-[800px] w-[500px]">
+      {!isConnected ? (
+        <>
+          <button
+            type="button"
+            onClick={() => connect({ connector: connectors[0] })}
+            className="mb-4 w-full rounded-lg bg-blue-600 px-4 py-2 text-white font-medium hover:bg-blue-700 cursor-pointer"
+          >
+            Connect
+          </button>
+          <AuthFlow />
+        </>
+      ) : (
+        <WalletPanel />
+      )}
     </div>
   )
 }

--- a/packages/react-kit/src/auth/authStoreSlice.test.ts
+++ b/packages/react-kit/src/auth/authStoreSlice.test.ts
@@ -37,7 +37,7 @@ describe('authStoreSlice', () => {
       const { auth } = store.getState()
       expect(auth.config).toEqual(config)
       expect(auth.enabledMethods).toEqual(['email', 'google', 'passkey'])
-      expect(auth.step).toBe('sign-up')
+      expect(auth.step).toBe('initializing')
     })
 
     it('sets custom enabled methods from config', () => {
@@ -60,18 +60,20 @@ describe('authStoreSlice', () => {
       const store = createStore()
       const config = createMockAuthConfig()
       store.getState().auth.initialize(config)
+      store.getState().auth.goToStep('sign-up')
 
       store.getState().auth.goToStep('email-verification')
 
       const { auth } = store.getState()
       expect(auth.step).toBe('email-verification')
-      expect(auth.stepHistory).toEqual(['sign-up'])
+      expect(auth.stepHistory).toEqual(['initializing', 'sign-up'])
     })
 
     it('builds up step history on multiple transitions', () => {
       const store = createStore()
       const config = createMockAuthConfig()
       store.getState().auth.initialize(config)
+      store.getState().auth.goToStep('sign-up')
 
       store.getState().auth.goToStep('email-verification')
       store.getState().auth.goToStep('otp-input')
@@ -80,6 +82,7 @@ describe('authStoreSlice', () => {
       const { auth } = store.getState()
       expect(auth.step).toBe('verifying-otp')
       expect(auth.stepHistory).toEqual([
+        'initializing',
         'sign-up',
         'email-verification',
         'otp-input',
@@ -92,6 +95,7 @@ describe('authStoreSlice', () => {
       const store = createStore()
       const config = createMockAuthConfig()
       store.getState().auth.initialize(config)
+      store.getState().auth.goToStep('sign-up')
 
       store.getState().auth.goToStep('email-verification')
       store.getState().auth.goToStep('otp-input')
@@ -100,7 +104,7 @@ describe('authStoreSlice', () => {
 
       const { auth } = store.getState()
       expect(auth.step).toBe('email-verification')
-      expect(auth.stepHistory).toEqual(['sign-up'])
+      expect(auth.stepHistory).toEqual(['initializing', 'sign-up'])
     })
 
     it('returns to sign-up when history is empty', () => {
@@ -119,6 +123,7 @@ describe('authStoreSlice', () => {
       const store = createStore()
       const config = createMockAuthConfig()
       store.getState().auth.initialize(config)
+      store.getState().auth.goToStep('sign-up')
 
       store.getState().auth.goToStep('email-verification')
       store.getState().auth.goToStep('otp-input')
@@ -132,7 +137,7 @@ describe('authStoreSlice', () => {
 
       store.getState().auth.goBack()
       expect(store.getState().auth.step).toBe('sign-up')
-      expect(store.getState().auth.stepHistory).toEqual([])
+      expect(store.getState().auth.stepHistory).toEqual(['initializing'])
     })
   })
 
@@ -207,6 +212,7 @@ describe('authStoreSlice', () => {
 
       // Initialize
       store.getState().auth.initialize(config)
+      store.getState().auth.goToStep('sign-up')
       expect(store.getState().auth.step).toBe('sign-up')
 
       // User enters email
@@ -231,6 +237,7 @@ describe('authStoreSlice', () => {
       expect(auth.email).toBe('user@example.com')
       expect(auth.otpId).toBe('otp-123')
       expect(auth.stepHistory).toEqual([
+        'initializing',
         'sign-up',
         'email-verification',
         'otp-input',
@@ -243,6 +250,7 @@ describe('authStoreSlice', () => {
       const config = createMockAuthConfig()
 
       store.getState().auth.initialize(config)
+      store.getState().auth.goToStep('sign-up')
       store.getState().auth.setEmail('user@example.com')
       store.getState().auth.goToStep('email-verification')
       store.getState().auth.setOtpId('otp-123')
@@ -294,11 +302,11 @@ describe('authStoreSlice', () => {
       store.subscribe((state) => state.auth.step, listener)
 
       store.getState().auth.initialize(config)
-      expect(listener).toHaveBeenCalledWith('sign-up', 'initializing')
+      expect(listener).not.toHaveBeenCalled()
 
-      store.getState().auth.goToStep('email-verification')
-      expect(listener).toHaveBeenCalledWith('email-verification', 'sign-up')
-      expect(listener).toHaveBeenCalledTimes(2)
+      store.getState().auth.goToStep('sign-up')
+      expect(listener).toHaveBeenCalledWith('sign-up', 'initializing')
+      expect(listener).toHaveBeenCalledTimes(1)
     })
 
     it('fires subscription on email change', () => {
@@ -333,7 +341,7 @@ describe('authStoreSlice', () => {
       store1.getState().auth.setEmail('user1@example.com')
 
       expect(store1.getState().auth.email).toBe('user1@example.com')
-      expect(store1.getState().auth.step).toBe('sign-up')
+      expect(store1.getState().auth.step).toBe('initializing')
 
       expect(store2.getState().auth.email).toBeNull()
       expect(store2.getState().auth.step).toBe('initializing')

--- a/packages/react-kit/src/auth/authStoreSlice.ts
+++ b/packages/react-kit/src/auth/authStoreSlice.ts
@@ -43,7 +43,6 @@ export const createAuthStoreSlice: StateCreator<
           ...state.auth,
           config,
           enabledMethods: config.enabledMethods,
-          step: 'sign-up',
         },
       }))
     },

--- a/packages/react-kit/src/auth/hooks/useAuth.test.ts
+++ b/packages/react-kit/src/auth/hooks/useAuth.test.ts
@@ -79,7 +79,7 @@ describe('useAuth', () => {
 
     const { result } = renderHook(() => useAuth())
 
-    expect(result.current.step).toBe('sign-up')
+    expect(result.current.step).toBe('initializing')
     expect(result.current.enabledMethods).toEqual([
       'email',
       'google',
@@ -178,6 +178,7 @@ describe('useAuth', () => {
 
     // Change store state
     store.getState().auth.initialize(config)
+    store.getState().auth.goToStep('sign-up')
     rerender()
 
     expect(result.current.step).toBe('sign-up')
@@ -187,6 +188,7 @@ describe('useAuth', () => {
     const store = createStore()
     const config = createMockAuthConfig()
     store.getState().auth.initialize(config)
+    store.getState().auth.goToStep('sign-up')
     mockConnector.getKitStore.mockReturnValue(store)
 
     const { result, rerender } = renderHook(() => useAuth())

--- a/packages/react-kit/src/auth/index.test.tsx
+++ b/packages/react-kit/src/auth/index.test.tsx
@@ -66,17 +66,11 @@ vi.mock('./hooks/useAuth', () => ({
 }))
 
 describe('AuthFlow', () => {
-  it('renders initializing state', () => {
+  it('renders nothing in initializing state', () => {
     mockStep = 'initializing'
-    render(<AuthFlow />)
+    const { container } = render(<AuthFlow />)
 
-    expect(screen.getByTestId('status-view')).toBeDefined()
-    expect(screen.getByTestId('status-title').textContent).toBe(
-      'Initializing...',
-    )
-    expect(screen.getByTestId('status-content').textContent).toBe(
-      'Setting up authentication...',
-    )
+    expect(container.firstChild).toBeNull()
   })
 
   it('renders sign-up page', () => {

--- a/packages/react-kit/src/auth/index.tsx
+++ b/packages/react-kit/src/auth/index.tsx
@@ -27,11 +27,7 @@ export function AuthFlow() {
 
   switch (step) {
     case 'initializing':
-      return (
-        <StatusView imageName="loading" title="Initializing...">
-          Setting up authentication...
-        </StatusView>
-      )
+      return null
     case 'sign-up':
       return <SignUp />
     case 'email-verification':

--- a/packages/react-kit/src/connector.test.ts
+++ b/packages/react-kit/src/connector.test.ts
@@ -243,7 +243,7 @@ describe('connector', () => {
 
       expect(store.getState().auth.config).toEqual(authConfig)
       expect(store.getState().auth.enabledMethods).toEqual(['email', 'google'])
-      expect(store.getState().auth.step).toBe('sign-up')
+      expect(store.getState().auth.step).toBe('initializing')
     })
 
     it('does not initialize auth when config is not provided', () => {
@@ -294,7 +294,7 @@ describe('connector', () => {
 
       // Auth should be reset and reinitialized
       expect(store.getState().auth.email).toBeNull()
-      expect(store.getState().auth.step).toBe('sign-up')
+      expect(store.getState().auth.step).toBe('initializing')
       expect(store.getState().auth.config).toEqual(authConfig)
     })
 

--- a/packages/react-kit/src/connector.ts
+++ b/packages/react-kit/src/connector.ts
@@ -60,6 +60,29 @@ export function zeroDevKitWallet(
     return {
       ...connector,
 
+      async connect(connectParams) {
+        const isAuthorized = await connector.isAuthorized()
+        if (
+          !isAuthorized &&
+          params.config?.auth &&
+          store.getState().auth.step === 'initializing'
+        ) {
+          store.getState().auth.goToStep('sign-up')
+          await new Promise<void>((resolve) => {
+            const unsub = store.subscribe(
+              (state) => state.auth.step,
+              (step) => {
+                if (step === 'authenticated') {
+                  unsub()
+                  resolve()
+                }
+              },
+            )
+          })
+        }
+        return connector.connect(connectParams)
+      },
+
       async disconnect() {
         await connector.disconnect?.()
         // Reset auth state on disconnect


### PR DESCRIPTION
closes FS-2089

Now auth flow will only show when `connect` is called, instead of displaying the screen right away.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
