### PR TITLE
feat(react-kit): TxInformation, TxDetailsItem, AllocationModule

### DIFF
--- a/packages/react-kit/src/index.ts
+++ b/packages/react-kit/src/index.ts
@@ -45,6 +45,8 @@ export { Wrapper } from './shared/components/Wrapper'
 
 // Signing
 export { SignatureRequest } from './signing'
+export type { AllocationModuleProps } from './signing/components/AllocationModule'
+export { AllocationModule } from './signing/components/AllocationModule'
 export type { DetailsContainerProps } from './signing/components/DetailsContainer'
 export { DetailsContainer } from './signing/components/DetailsContainer'
 export type { InfoCardProps } from './signing/components/InfoCard'
@@ -53,12 +55,19 @@ export type { SmartFundingProps } from './signing/components/SmartFunding'
 export { SmartFunding } from './signing/components/SmartFunding'
 export type { SmartFundingGasDetailsProps } from './signing/components/SmartFundingGasDetails'
 export { SmartFundingGasDetails } from './signing/components/SmartFundingGasDetails'
+export type { TxDetailsItemProps } from './signing/components/TxDetailsItem'
+export { TxDetailsItem } from './signing/components/TxDetailsItem'
 export type {
   GasFee,
   GasTier,
   TxGasFeesProps,
 } from './signing/components/TxGasFees'
 export { TxGasFees } from './signing/components/TxGasFees'
+export type {
+  Dapp,
+  TxInformationProps,
+} from './signing/components/TxInformation'
+export { TxInformation } from './signing/components/TxInformation'
 export { usePendingRequest } from './signing/hooks/usePendingRequest.js'
 
 export type { PendingRequest, Request, RequestMethod } from './types.js'

--- a/packages/react-kit/src/signing/components/AllocationModule/AllocationModule.stories.tsx
+++ b/packages/react-kit/src/signing/components/AllocationModule/AllocationModule.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
+
+import { AllocationModule } from '.'
+
+const meta = {
+  title: 'Signing/AllocationModule',
+  component: AllocationModule,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  args: {
+    token: {
+      symbol: 'ETH',
+      network: 'ethereum',
+      imageSource: 'https://cryptologos.cc/logos/ethereum-eth-logo.png',
+    },
+    availableAmount: 1.5,
+    checked: true,
+    onCheck: () => {},
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 420 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof AllocationModule>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: (args) => {
+    const [checked, setChecked] = useState(args.checked)
+    return (
+      <AllocationModule
+        {...args}
+        checked={checked}
+        onCheck={() => {
+          setChecked((c) => !c)
+        }}
+      />
+    )
+  },
+}

--- a/packages/react-kit/src/signing/components/AllocationModule/AllocationModule.test.tsx
+++ b/packages/react-kit/src/signing/components/AllocationModule/AllocationModule.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../shared/components/Icon', async () => {
+  const React = await import('react')
+
+  const MockIcon = ({
+    name,
+    ...props
+  }: { name: string } & React.SVGProps<SVGSVGElement>) =>
+    React.createElement('svg', { 'data-testid': `icon-${name}`, ...props })
+
+  return {
+    Icon: MockIcon,
+    icons: {},
+  }
+})
+
+import { AllocationModule, type AllocationModuleProps } from './index'
+
+afterEach(() => {
+  cleanup()
+})
+
+const baseProps: AllocationModuleProps = {
+  token: {
+    symbol: 'ETH',
+    network: 'ethereum',
+    imageSource: 'https://example.com/eth.png',
+  },
+  availableAmount: 1.5,
+  checked: true,
+  onCheck: () => {},
+}
+
+describe('AllocationModule', () => {
+  describe('token info', () => {
+    it('renders the token symbol and capitalized network', () => {
+      render(<AllocationModule {...baseProps} />)
+      expect(screen.getByText('ETH')).toBeDefined()
+      expect(screen.getByText('Ethereum')).toBeDefined()
+    })
+
+    it('renders the network icon', () => {
+      render(<AllocationModule {...baseProps} />)
+      expect(screen.getByTestId('icon-ethereum')).toBeDefined()
+    })
+
+    it('renders the token image when imageSource is provided', () => {
+      const { container } = render(<AllocationModule {...baseProps} />)
+      const img = container.querySelector('img')
+      expect(img?.getAttribute('src')).toBe('https://example.com/eth.png')
+    })
+
+    it('omits the token image when imageSource is missing', () => {
+      const { container } = render(
+        <AllocationModule
+          {...baseProps}
+          token={{ symbol: 'ETH', network: 'ethereum' }}
+        />,
+      )
+      expect(container.querySelector('img')).toBeNull()
+    })
+  })
+
+  describe('checkbox', () => {
+    it('renders the available amount with the symbol as the label', () => {
+      render(<AllocationModule {...baseProps} />)
+      expect(screen.getByText('1.5 ETH')).toBeDefined()
+    })
+
+    it('reflects the checked prop', () => {
+      render(<AllocationModule {...baseProps} checked={true} />)
+      expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(
+        true,
+      )
+    })
+
+    it('reflects an unchecked state', () => {
+      render(<AllocationModule {...baseProps} checked={false} />)
+      expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(
+        false,
+      )
+    })
+
+    it('calls onCheck when the checkbox is toggled', () => {
+      const onCheck = vi.fn()
+      render(<AllocationModule {...baseProps} onCheck={onCheck} />)
+      fireEvent.click(screen.getByRole('checkbox'))
+      expect(onCheck).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('amount input', () => {
+    it('renders the input with the "0" placeholder', () => {
+      render(<AllocationModule {...baseProps} />)
+      expect(screen.getByPlaceholderText('0')).toBeDefined()
+    })
+
+    it('renders a Max button next to the input', () => {
+      render(<AllocationModule {...baseProps} />)
+      expect(screen.getByText('Max')).toBeDefined()
+    })
+  })
+})

--- a/packages/react-kit/src/signing/components/AllocationModule/index.tsx
+++ b/packages/react-kit/src/signing/components/AllocationModule/index.tsx
@@ -1,0 +1,68 @@
+import { useId } from 'react'
+
+import { Icon, type IconName } from '../../../shared/components/Icon'
+import { Input } from '../../../shared/components/Input'
+import { Text } from '../../../shared/components/Text'
+import { WrappedPressable } from '../../../shared/components/WrappedPressable'
+import { capitalizeFirst } from '../../../shared/utils/common'
+import type { Token } from '../TokenCard'
+
+export interface AllocationModuleProps {
+  token: Token
+  availableAmount: number
+  checked: boolean
+  onCheck: () => void
+}
+
+export function AllocationModule({
+  token,
+  availableAmount,
+  checked,
+  onCheck,
+}: AllocationModuleProps) {
+  const { symbol, imageSource, network } = token
+  const checkboxId = useId()
+
+  return (
+    <div className="w-full flex flex-col p-2 pb-3 gap-2 border-b border-offWhite/50">
+      <div className="flex flex-row items-center justify-between">
+        <div className="flex flex-row items-center gap-2">
+          <div className="bg-offWhite rounded-xl w-11 h-11 flex items-center justify-center shrink-0">
+            {imageSource && (
+              <img src={imageSource} alt="" className="w-6 h-6" />
+            )}
+          </div>
+          <div className="flex flex-col">
+            <Text className="text-body1">{symbol}</Text>
+            <div className="flex flex-row gap-1 items-center">
+              <Icon name={network as IconName} className="h-3 w-3" />
+              <Text className="text-body3 text-greyScale/50">
+                {capitalizeFirst(network)}
+              </Text>
+            </div>
+          </div>
+        </div>
+        <label
+          htmlFor={checkboxId}
+          className="flex flex-row items-center gap-2 cursor-pointer select-none"
+        >
+          <Text className="text-body1">
+            {availableAmount} {symbol}
+          </Text>
+          <input
+            id={checkboxId}
+            type="checkbox"
+            checked={checked}
+            onChange={onCheck}
+            className="h-4 w-4 cursor-pointer accent-solarOrange"
+          />
+        </label>
+      </div>
+      <Input placeholder="0">
+        <WrappedPressable className="w-14 h-7">
+          <Text>Max</Text>
+        </WrappedPressable>
+      </Input>
+    </div>
+  )
+}

--- a/packages/react-kit/src/signing/components/TxDetailsItem/TxDetailsItem.stories.tsx
+++ b/packages/react-kit/src/signing/components/TxDetailsItem/TxDetailsItem.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { TxDetailsItem } from '.'
+
+const meta = {
+  title: 'Signing/TxDetailsItem',
+  component: TxDetailsItem,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  args: {
+    title: 'Approve USDC',
+    index: 1,
+    data: {
+      from: '0x1234...abcd',
+      to: '0x5678...ef01',
+      amount: '100 USDC',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 420 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TxDetailsItem>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/packages/react-kit/src/signing/components/TxDetailsItem/TxDetailsItem.test.tsx
+++ b/packages/react-kit/src/signing/components/TxDetailsItem/TxDetailsItem.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../shared/components/Icon', async () => {
+  const React = await import('react')
+
+  const MockIcon = ({
+    name,
+    ...props
+  }: { name: string } & React.SVGProps<SVGSVGElement>) =>
+    React.createElement('svg', { 'data-testid': `icon-${name}`, ...props })
+
+  return {
+    Icon: MockIcon,
+    icons: {},
+  }
+})
+
+import { TxDetailsItem, type TxDetailsItemProps } from './index'
+
+afterEach(() => {
+  cleanup()
+})
+
+const baseProps: TxDetailsItemProps = {
+  title: 'Approve USDC',
+  index: 1,
+  data: {
+    from: '0x1234...abcd',
+    to: '0x5678...ef01',
+    amount: '100 USDC',
+  },
+}
+
+describe('TxDetailsItem', () => {
+  describe('header', () => {
+    it('renders the title and index', () => {
+      render(<TxDetailsItem {...baseProps} />)
+      expect(screen.getByText('Approve USDC')).toBeDefined()
+      expect(screen.getByText('1')).toBeDefined()
+    })
+
+    it('shows a chevronDown icon when collapsed (default)', () => {
+      render(<TxDetailsItem {...baseProps} />)
+      expect(screen.getByTestId('icon-chevronDown')).toBeDefined()
+    })
+  })
+
+  describe('expand/collapse', () => {
+    it('hides data rows by default', () => {
+      render(<TxDetailsItem {...baseProps} />)
+      expect(screen.queryByText('From')).toBeNull()
+      expect(screen.queryByText('To')).toBeNull()
+      expect(screen.queryByText('Amount')).toBeNull()
+    })
+
+    it('shows data rows when toggled and switches the chevron icon', () => {
+      render(<TxDetailsItem {...baseProps} />)
+      fireEvent.click(screen.getByRole('button'))
+
+      expect(screen.getByText('From')).toBeDefined()
+      expect(screen.getByText('0x1234...abcd')).toBeDefined()
+      expect(screen.getByText('To')).toBeDefined()
+      expect(screen.getByText('Amount')).toBeDefined()
+      expect(screen.getByTestId('icon-chevronUp')).toBeDefined()
+    })
+
+    it('hides data rows again on a second click', () => {
+      render(<TxDetailsItem {...baseProps} />)
+      const button = screen.getByRole('button')
+
+      fireEvent.click(button)
+      expect(screen.getByText('From')).toBeDefined()
+
+      fireEvent.click(button)
+      expect(screen.queryByText('From')).toBeNull()
+      expect(screen.getByTestId('icon-chevronDown')).toBeDefined()
+    })
+  })
+
+  describe('data rows', () => {
+    it('renders a DataRow for each entry in data', () => {
+      render(<TxDetailsItem {...baseProps} />)
+      fireEvent.click(screen.getByRole('button'))
+
+      expect(screen.getByText('0x1234...abcd')).toBeDefined()
+      expect(screen.getByText('0x5678...ef01')).toBeDefined()
+      expect(screen.getByText('100 USDC')).toBeDefined()
+    })
+
+    it('renders no data rows when data is empty', () => {
+      render(<TxDetailsItem {...baseProps} data={{}} />)
+      fireEvent.click(screen.getByRole('button'))
+
+      expect(screen.queryByText('From')).toBeNull()
+      expect(screen.queryByText('To')).toBeNull()
+    })
+  })
+})

--- a/packages/react-kit/src/signing/components/TxDetailsItem/index.tsx
+++ b/packages/react-kit/src/signing/components/TxDetailsItem/index.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react'
+
+import { Icon } from '../../../shared/components/Icon'
+import { Text } from '../../../shared/components/Text'
+import { Wrapper } from '../../../shared/components/Wrapper'
+import { DataRow } from '../DataRow'
+
+export interface TxDetailsItemProps {
+  title: string
+  index: number
+  data: Record<string, string>
+}
+
+export function TxDetailsItem({ title, index, data }: TxDetailsItemProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <Wrapper className="w-full flex flex-col rounded-xl gap-2" variant="ghost">
+      <Wrapper className="w-full h-[68px] rounded-xl p-4 flex flex-row justify-between items-center">
+        <div className="flex flex-row gap-2 items-center">
+          <div className="w-11 h-11 bg-white flex items-center justify-center rounded-xl">
+            <Text className="text-body1">{index}</Text>
+          </div>
+          <Text className="text-body1">{title}</Text>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            setExpanded(!expanded)
+          }}
+          aria-label={expanded ? 'Collapse' : 'Expand'}
+          aria-expanded={expanded}
+          className="cursor-pointer"
+        >
+          <Icon
+            name={expanded ? 'chevronUp' : 'chevronDown'}
+            className="w-4 h-4"
+          />
+        </button>
+      </Wrapper>
+      {expanded && (
+        <div className="flex flex-col px-5 pb-2 gap-2">
+          {Object.entries(data).map(([label, value]) => (
+            <DataRow key={label} label={label} value={value} />
+          ))}
+        </div>
+      )}
+    </Wrapper>
+  )
+}

--- a/packages/react-kit/src/signing/components/TxInformation/TxInformation.stories.tsx
+++ b/packages/react-kit/src/signing/components/TxInformation/TxInformation.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { TxInformation } from '.'
+
+const meta = {
+  title: 'Signing/TxInformation',
+  component: TxInformation,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  args: {
+    dapp: {
+      name: 'Uniswap',
+      domain: 'app.uniswap.org',
+      network: 'ethereum',
+      imageSource: 'https://cryptologos.cc/logos/uniswap-uni-logo.png',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 400 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TxInformation>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/packages/react-kit/src/signing/components/TxInformation/TxInformation.test.tsx
+++ b/packages/react-kit/src/signing/components/TxInformation/TxInformation.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../shared/components/Icon', async () => {
+  const React = await import('react')
+
+  const MockIcon = ({
+    name,
+    ...props
+  }: { name: string } & React.SVGProps<SVGSVGElement>) =>
+    React.createElement('svg', { 'data-testid': `icon-${name}`, ...props })
+
+  return {
+    Icon: MockIcon,
+    icons: {},
+  }
+})
+
+import { type Dapp, TxInformation } from './index'
+
+afterEach(() => {
+  cleanup()
+})
+
+const baseDapp: Dapp = {
+  name: 'Uniswap',
+  domain: 'app.uniswap.org',
+  network: 'ethereum',
+  imageSource: 'https://example.com/logo.png',
+}
+
+describe('TxInformation', () => {
+  describe('header', () => {
+    it('renders the "Request from" label and dapp name', () => {
+      render(<TxInformation dapp={baseDapp} />)
+      expect(screen.getByText('Request from')).toBeDefined()
+      expect(screen.getByText('Uniswap')).toBeDefined()
+    })
+
+    it('renders the dapp logo with the provided image source', () => {
+      const { container } = render(<TxInformation dapp={baseDapp} />)
+      const img = container.querySelector('img')
+      expect(img).not.toBeNull()
+      expect(img?.getAttribute('src')).toBe('https://example.com/logo.png')
+    })
+  })
+
+  describe('domain', () => {
+    it('renders the domain when provided', () => {
+      render(<TxInformation dapp={baseDapp} />)
+      expect(screen.getByText('Domain')).toBeDefined()
+      expect(screen.getByText('app.uniswap.org')).toBeDefined()
+    })
+
+    it('falls back to "Unknown" when domain is undefined', () => {
+      render(<TxInformation dapp={{ ...baseDapp, domain: undefined }} />)
+      expect(screen.getByText('Unknown')).toBeDefined()
+    })
+  })
+
+  describe('network', () => {
+    it('renders the network row with capitalized name and matching icon', () => {
+      render(<TxInformation dapp={baseDapp} />)
+      expect(screen.getByText('Network')).toBeDefined()
+      expect(screen.getByText('Ethereum')).toBeDefined()
+      expect(screen.getByTestId('icon-ethereum')).toBeDefined()
+    })
+
+    it('omits the network row when network is undefined', () => {
+      render(<TxInformation dapp={{ ...baseDapp, network: undefined }} />)
+      expect(screen.queryByText('Network')).toBeNull()
+    })
+  })
+})

--- a/packages/react-kit/src/signing/components/TxInformation/index.tsx
+++ b/packages/react-kit/src/signing/components/TxInformation/index.tsx
@@ -1,0 +1,58 @@
+import { Icon, type IconName } from '../../../shared/components/Icon'
+import { Text } from '../../../shared/components/Text'
+import { Wrapper } from '../../../shared/components/Wrapper'
+import { capitalizeFirst } from '../../../shared/utils/common'
+
+export interface Dapp {
+  name: string | undefined
+  domain: string | undefined
+  network?: string
+  imageSource: string
+}
+
+export interface TxInformationProps {
+  dapp: Dapp
+}
+
+export function TxInformation({ dapp }: TxInformationProps) {
+  const { name, domain, network, imageSource } = dapp
+
+  return (
+    <Wrapper className="rounded-2xl w-full">
+      <div className="flex flex-row justify-between items-center p-4">
+        <div className="flex flex-row gap-2 items-center">
+          <img
+            src={imageSource}
+            alt=""
+            className="w-11 h-11 rounded-xl object-cover"
+          />
+          <div className="flex flex-col">
+            <Text>Request from</Text>
+            <Text className="text-body1">{name}</Text>
+          </div>
+        </div>
+      </div>
+      <div className="h-px bg-offWhite/50" />
+      <div className="flex flex-col pt-2 pb-4 px-4 gap-2">
+        <div className="flex flex-row justify-between">
+          <Text>Domain</Text>
+          <Text className="text-body1">{domain ?? 'Unknown'}</Text>
+        </div>
+        {network && (
+          <div className="flex flex-row justify-between">
+            <Text>Network</Text>
+            <div className="flex flex-row gap-2 items-center">
+              <Text className="text-body1">{capitalizeFirst(network)}</Text>
+              <div className="h-[18px] w-[18px] bg-white flex items-center justify-center rounded-full">
+                <Icon
+                  name={network as IconName}
+                  className="h-[18px] w-[18px]"
+                />
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </Wrapper>
+  )
+}


### PR DESCRIPTION
Closes [FS-2056](https://linear.app/offchain-labs/issue/FS-2056/txinformation-component), [FS-2055](https://linear.app/offchain-labs/issue/FS-2055/txdetailsitem-component), [FS-2050](https://linear.app/offchain-labs/issue/FS-2050/allocationmodule-component)

### Summary

This PR migrates the following components: `TxInformation`, `TxDetailsItem`, `AllocationModule`


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
