### PR TITLE
feat(react-kit): SignatureRequest usage modes

### DIFF
--- a/apps/react-example/src/App.tsx
+++ b/apps/react-example/src/App.tsx
@@ -1,10 +1,12 @@
 import {
   AuthFlow,
   Button,
+  type PendingRequest,
+  type Request,
   SignatureRequest,
   usePendingRequest,
 } from '@zerodev/wallet-react-kit'
-
+import { useId, useState } from 'react'
 import { encodeFunctionData, erc20Abi, parseEther } from 'viem'
 import {
   useAccount,
@@ -15,6 +17,46 @@ import {
   useSignMessage,
   useSignTypedData,
 } from 'wagmi'
+
+type SignatureRequestMode = 'default' | 'children' | 'controlled'
+
+function CustomConfirmUI({
+  pendingRequest,
+  confirm,
+  reject,
+}: {
+  pendingRequest: PendingRequest | null
+  confirm: () => void
+  reject: () => void
+}) {
+  if (!pendingRequest) return null
+  return (
+    <div className="mt-4 rounded-xl border border-purple-300 bg-purple-50 p-4">
+      <h3 className="text-sm font-semibold text-purple-900 mb-2">
+        Custom UI: {pendingRequest.method}
+      </h3>
+      <pre className="text-xs text-purple-800 mb-3 max-h-32 overflow-auto">
+        {JSON.stringify(pendingRequest.params, null, 2)}
+      </pre>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={confirm}
+          className="flex-1 rounded-lg bg-purple-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-purple-700 cursor-pointer"
+        >
+          Custom Confirm
+        </button>
+        <button
+          type="button"
+          onClick={reject}
+          className="flex-1 rounded-lg bg-gray-200 px-3 py-1.5 text-xs font-medium text-gray-800 hover:bg-gray-300 cursor-pointer"
+        >
+          Custom Reject
+        </button>
+      </div>
+    </div>
+  )
+}
 
 function WalletPanel() {
   const { address } = useAccount()
@@ -32,6 +74,31 @@ function WalletPanel() {
   const { sendCalls } = useSendCalls()
   const { pendingRequests } = usePendingRequest()
 
+  const [mode, setMode] = useState<SignatureRequestMode>('default')
+  const [controlledRequest, setControlledRequest] = useState<Request | null>(
+    null,
+  )
+  const modeSelectId = useId()
+
+  function handleControlledSendEth() {
+    setControlledRequest({
+      method: 'eth_sendTransaction',
+      params: [
+        {
+          from: address!,
+          to: address!,
+          value: `0x${parseEther('0.01').toString(16)}`,
+        },
+      ],
+    })
+  }
+
+  function handleControlledConfirm() {
+    if (!controlledRequest) return
+    sendTransaction({ to: address!, value: parseEther('0.01') })
+    setControlledRequest(null)
+  }
+
   return (
     <>
       <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
@@ -48,83 +115,110 @@ function WalletPanel() {
 
         <p className="text-xs text-gray-400 break-all mb-4">{address}</p>
 
-        <div className="flex flex-col gap-2">
-          <Button
-            text={
-              pendingRequests.length > 0 ? 'Queue ETH transfer' : 'Send ETH'
-            }
-            onClick={() =>
-              sendTransaction({
-                to: address!,
-                value: parseEther('0.01'),
-              })
-            }
-          />
-          <Button
-            text={
-              pendingRequests.length > 0
-                ? 'Queue ERC-20 transfer'
-                : 'Send ERC-20'
-            }
-            onClick={() =>
-              sendTransaction({
-                to: '0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8', // USDC on Sepolia
-                data: encodeFunctionData({
-                  abi: erc20Abi,
-                  functionName: 'transfer',
-                  args: [address!, 1000000n],
-                }),
-              })
-            }
-          />
-          <Button
-            text={
-              pendingRequests.length > 0
-                ? 'Queue ERC-20 approval'
-                : 'Approve ERC-20'
-            }
-            onClick={() =>
-              sendTransaction({
-                to: '0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8', // USDC on Sepolia
-                data: encodeFunctionData({
-                  abi: erc20Abi,
-                  functionName: 'approve',
-                  args: [address!, 1000000n],
-                }),
-              })
-            }
-          />
-          <Button
-            text="Collection Approval"
-            onClick={() =>
-              sendTransaction({
-                // Not an NFT — reusing USDC on Sepolia because it has a name() function,
-                // so the decoded UI loads fast. The setApprovalForAll calldata is the same regardless.
-                to: '0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8',
-                data: encodeFunctionData({
-                  abi: [
-                    {
-                      type: 'function',
-                      name: 'setApprovalForAll',
-                      inputs: [
-                        { name: 'operator', type: 'address' },
-                        { name: 'approved', type: 'bool' },
-                      ],
-                      outputs: [],
-                      stateMutability: 'nonpayable',
-                    },
-                  ],
-                  functionName: 'setApprovalForAll',
-                  args: [address!, true],
-                }),
-              })
-            }
-          />
-          <Button
-            text="Sign Message"
-            onClick={() => signMessage({ message: 'Hello from ZeroDev!' })}
-          />
-          <Button
+        <div className="mb-4 rounded-lg bg-gray-50 p-3">
+          <label
+            htmlFor={modeSelectId}
+            className="block text-xs font-medium text-gray-700 mb-1"
+          >
+            SignatureRequest mode
+          </label>
+          <select
+            id={modeSelectId}
+            value={mode}
+            onChange={(e) => {
+              setMode(e.target.value as SignatureRequestMode)
+              setControlledRequest(null)
+            }}
+            className="w-full rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-900"
+          >
+            <option value="default">Mode 1: default UI</option>
+            <option value="children">
+              Mode 2: custom UI via children function
+            </option>
+            <option value="controlled">
+              Mode 3: default UI via controlled props
+            </option>
+          </select>
+        </div>
+
+        {mode !== 'controlled' && (
+          <div className="flex flex-col gap-2">
+            <Button
+              text={
+                pendingRequests.length > 0 ? 'Queue ETH transfer' : 'Send ETH'
+              }
+              onClick={() =>
+                sendTransaction({
+                  to: address!,
+                  value: parseEther('0.01'),
+                })
+              }
+            />
+            <Button
+              text={
+                pendingRequests.length > 0
+                  ? 'Queue ERC-20 transfer'
+                  : 'Send ERC-20'
+              }
+              onClick={() =>
+                sendTransaction({
+                  to: '0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8', // USDC on Sepolia
+                  data: encodeFunctionData({
+                    abi: erc20Abi,
+                    functionName: 'transfer',
+                    args: [address!, 1000000n],
+                  }),
+                })
+              }
+            />
+            <Button
+              text={
+                pendingRequests.length > 0
+                  ? 'Queue ERC-20 approval'
+                  : 'Approve ERC-20'
+              }
+              onClick={() =>
+                sendTransaction({
+                  to: '0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8', // USDC on Sepolia
+                  data: encodeFunctionData({
+                    abi: erc20Abi,
+                    functionName: 'approve',
+                    args: [address!, 1000000n],
+                  }),
+                })
+              }
+            />
+            <Button
+              text="Collection Approval"
+              onClick={() =>
+                sendTransaction({
+                  // Not an NFT — reusing USDC on Sepolia because it has a name() function,
+                  // so the decoded UI loads fast. The setApprovalForAll calldata is the same regardless.
+                  to: '0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8',
+                  data: encodeFunctionData({
+                    abi: [
+                      {
+                        type: 'function',
+                        name: 'setApprovalForAll',
+                        inputs: [
+                          { name: 'operator', type: 'address' },
+                          { name: 'approved', type: 'bool' },
+                        ],
+                        outputs: [],
+                        stateMutability: 'nonpayable',
+                      },
+                    ],
+                    functionName: 'setApprovalForAll',
+                    args: [address!, true],
+                  }),
+                })
+              }
+            />
+            <Button
+              text="Sign Message"
+              onClick={() => signMessage({ message: 'Hello from ZeroDev!' })}
+            />
+<Button
             text="Sign Typed Data"
             onClick={() =>
               signTypedData({
@@ -173,28 +267,42 @@ function WalletPanel() {
               })
             }
           />
-          <Button
-            text="Batch Calls"
-            onClick={() =>
-              sendCalls({
-                calls: [
-                  {
-                    to: address!,
-                    value: parseEther('0.01'),
-                  },
-                  {
-                    to: '0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8',
-                    data: encodeFunctionData({
-                      abi: erc20Abi,
-                      functionName: 'transfer',
-                      args: [address!, 1000000n],
-                    }),
-                  },
-                ],
-              })
-            }
-          />
-        </div>
+            <Button
+              text="Batch Calls"
+              onClick={() =>
+                sendCalls({
+                  calls: [
+                    {
+                      to: address!,
+                      value: parseEther('0.01'),
+                    },
+                    {
+                      to: '0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8',
+                      data: encodeFunctionData({
+                        abi: erc20Abi,
+                        functionName: 'transfer',
+                        args: [address!, 1000000n],
+                      }),
+                    },
+                  ],
+                })
+              }
+            />
+          </div>
+        )}
+
+        {mode === 'controlled' && (
+          <div className="flex flex-col gap-2">
+            <p className="text-xs text-gray-500">
+              In controlled mode the app captures the request locally, renders
+              the default UI, and dispatches the tx itself on confirm.
+            </p>
+            <Button
+              text="Send ETH (controlled)"
+              onClick={handleControlledSendEth}
+            />
+          </div>
+        )}
 
         {isSuccess && <p className="text-green-600 text-sm mt-2">tx: {data}</p>}
         {isError && (
@@ -218,7 +326,28 @@ function WalletPanel() {
           </p>
         )}
       </div>
-      <SignatureRequest />
+
+      {mode === 'default' && <SignatureRequest />}
+
+      {mode === 'children' && (
+        <SignatureRequest>
+          {({ pendingRequest, confirm, reject }) => (
+            <CustomConfirmUI
+              pendingRequest={pendingRequest}
+              confirm={confirm}
+              reject={reject}
+            />
+          )}
+        </SignatureRequest>
+      )}
+
+      {mode === 'controlled' && controlledRequest && (
+        <SignatureRequest
+          request={controlledRequest}
+          onConfirm={handleControlledConfirm}
+          onReject={() => setControlledRequest(null)}
+        />
+      )}
     </>
   )
 }

--- a/apps/react-example/src/App.tsx
+++ b/apps/react-example/src/App.tsx
@@ -218,55 +218,55 @@ function WalletPanel() {
               text="Sign Message"
               onClick={() => signMessage({ message: 'Hello from ZeroDev!' })}
             />
-<Button
-            text="Sign Typed Data"
-            onClick={() =>
-              signTypedData({
-                domain: {
-                  name: 'Example DApp',
-                  version: '1',
-                  chainId: 11155111,
-                  verifyingContract:
-                    '0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8',
-                },
-                types: {
-                  Person: [
-                    { name: 'name', type: 'string' },
-                    { name: 'wallets', type: 'address[]' },
-                  ],
-                  Mail: [
-                    { name: 'from', type: 'Person' },
-                    { name: 'to', type: 'Person[]' },
-                    { name: 'contents', type: 'string' },
-                  ],
-                },
-                primaryType: 'Mail',
-                message: {
-                  from: {
-                    name: 'Alice',
-                    wallets: [
-                      '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
-                      '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
+            <Button
+              text="Sign Typed Data"
+              onClick={() =>
+                signTypedData({
+                  domain: {
+                    name: 'Example DApp',
+                    version: '1',
+                    chainId: 11155111,
+                    verifyingContract:
+                      '0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8',
+                  },
+                  types: {
+                    Person: [
+                      { name: 'name', type: 'string' },
+                      { name: 'wallets', type: 'address[]' },
+                    ],
+                    Mail: [
+                      { name: 'from', type: 'Person' },
+                      { name: 'to', type: 'Person[]' },
+                      { name: 'contents', type: 'string' },
                     ],
                   },
-                  to: [
-                    {
-                      name: 'Bob',
+                  primaryType: 'Mail',
+                  message: {
+                    from: {
+                      name: 'Alice',
                       wallets: [
-                        '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
-                        '0xB0B0000000000000000000000000000000000000',
+                        '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+                        '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
                       ],
                     },
-                    {
-                      name: 'Charlie',
-                      wallets: ['0xC0FFEE0000000000000000000000000000000000'],
-                    },
-                  ],
-                  contents: 'Hello from ZeroDev!',
-                },
-              })
-            }
-          />
+                    to: [
+                      {
+                        name: 'Bob',
+                        wallets: [
+                          '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+                          '0xB0B0000000000000000000000000000000000000',
+                        ],
+                      },
+                      {
+                        name: 'Charlie',
+                        wallets: ['0xC0FFEE0000000000000000000000000000000000'],
+                      },
+                    ],
+                    contents: 'Hello from ZeroDev!',
+                  },
+                })
+              }
+            />
             <Button
               text="Batch Calls"
               onClick={() =>

--- a/packages/react-kit/src/index.ts
+++ b/packages/react-kit/src/index.ts
@@ -44,6 +44,7 @@ export type { WrapperProps, WrapperVariant } from './shared/components/Wrapper'
 export { Wrapper } from './shared/components/Wrapper'
 
 // Signing
+export type { SignatureRequestProps } from './signing'
 export { SignatureRequest } from './signing'
 export type { AllocationModuleProps } from './signing/components/AllocationModule'
 export { AllocationModule } from './signing/components/AllocationModule'

--- a/packages/react-kit/src/signing/SignatureRequest.test.tsx
+++ b/packages/react-kit/src/signing/SignatureRequest.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createStore } from '../store'
 import type { PendingRequest } from '../types'
@@ -143,5 +143,149 @@ describe('SignatureRequest', () => {
       expect.objectContaining({ message: 'Confirmation listener unmounted' }),
     )
     expect(mockStore.getState().pendingRequests).toEqual([])
+  })
+
+  describe('custom UI via children function', () => {
+    it('invokes children with pendingRequest: null when the queue is empty', () => {
+      const renderFn = vi.fn(() => <div data-testid="custom" />)
+      render(<SignatureRequest>{renderFn}</SignatureRequest>)
+
+      expect(renderFn).toHaveBeenCalledWith(
+        expect.objectContaining({ pendingRequest: null }),
+      )
+      expect(screen.getByTestId('custom')).toBeDefined()
+    })
+
+    it('invokes children with the queued pendingRequest when one is queued', () => {
+      const request = createMockPendingRequest()
+      mockStore.getState().addPendingRequest(request)
+
+      const renderFn = vi.fn(() => null)
+      render(<SignatureRequest>{renderFn}</SignatureRequest>)
+
+      expect(renderFn).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          pendingRequest: expect.objectContaining({ id: request.id }),
+        }),
+      )
+    })
+
+    it('invokes children with the head pendingRequest when multiple are queued', () => {
+      const first = createMockPendingRequest()
+      const second = createMockPendingRequest()
+      mockStore.getState().addPendingRequest(first)
+      mockStore.getState().addPendingRequest(second)
+
+      const renderFn = vi.fn(() => null)
+      render(<SignatureRequest>{renderFn}</SignatureRequest>)
+
+      expect(renderFn).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          pendingRequest: expect.objectContaining({ id: first.id }),
+        }),
+      )
+    })
+
+    it('confirm() resolves the active request and removes it from the queue', () => {
+      const request = createMockPendingRequest()
+      mockStore.getState().addPendingRequest(request)
+
+      let confirmFn: (() => void) | undefined
+      render(
+        <SignatureRequest>
+          {({ confirm }) => {
+            confirmFn = confirm
+            return null
+          }}
+        </SignatureRequest>,
+      )
+
+      act(() => confirmFn?.())
+      expect(request.resolve).toHaveBeenCalled()
+      expect(mockStore.getState().pendingRequests).toEqual([])
+    })
+
+    it('activates the confirmation listener (same as default)', () => {
+      render(<SignatureRequest>{() => null}</SignatureRequest>)
+      expect(mockStore.getState().userConfirmationListenerActive).toBe(true)
+    })
+  })
+
+  describe('default UI via controlled props', () => {
+    it('renders the default UI from the request prop', () => {
+      render(
+        <SignatureRequest
+          request={{
+            method: 'eth_sendTransaction',
+            params: [{ to: '0x1234', value: '0x0' }],
+          }}
+          onConfirm={vi.fn()}
+          onReject={vi.fn()}
+        />,
+      )
+
+      expect(screen.getByText('Confirm')).toBeDefined()
+      expect(screen.getByText('Reject')).toBeDefined()
+    })
+
+    it('invokes onConfirm/onReject directly without touching the store', () => {
+      const onConfirm = vi.fn()
+      const onReject = vi.fn()
+      render(
+        <SignatureRequest
+          request={{
+            method: 'eth_sendTransaction',
+            params: [{ to: '0x1234', value: '0x0' }],
+          }}
+          onConfirm={onConfirm}
+          onReject={onReject}
+        />,
+      )
+
+      fireEvent.click(screen.getByText('Confirm'))
+      expect(onConfirm).toHaveBeenCalled()
+
+      fireEvent.click(screen.getByText('Reject'))
+      expect(onReject).toHaveBeenCalled()
+
+      expect(mockStore.getState().pendingRequests).toEqual([])
+    })
+
+    it('does NOT activate the confirmation listener', () => {
+      render(
+        <SignatureRequest
+          request={{
+            method: 'eth_sendTransaction',
+            params: [{ to: '0x1234', value: '0x0' }],
+          }}
+          onConfirm={vi.fn()}
+          onReject={vi.fn()}
+        />,
+      )
+
+      expect(mockStore.getState().userConfirmationListenerActive).toBe(false)
+    })
+
+    it('ignores any pending request in the store', () => {
+      mockStore.getState().addPendingRequest(
+        createMockPendingRequest({
+          method: 'personal_sign',
+          params: ['0xdead', '0xbeef'],
+        }),
+      )
+
+      render(
+        <SignatureRequest
+          request={{
+            method: 'eth_sendTransaction',
+            params: [{ to: '0x1234', value: '0x0' }],
+          }}
+          onConfirm={vi.fn()}
+          onReject={vi.fn()}
+        />,
+      )
+
+      expect(screen.queryByText(/Sign Message/i)).toBeNull()
+    })
   })
 })

--- a/packages/react-kit/src/signing/components/renderRequestContent.tsx
+++ b/packages/react-kit/src/signing/components/renderRequestContent.tsx
@@ -1,0 +1,119 @@
+import type { ReactNode } from 'react'
+import type { Address, Hex } from 'viem'
+import type { Request } from '../../types.js'
+import { BatchCalls } from '../pages/BatchCalls.js'
+import { CollectionApproval } from '../pages/CollectionApproval.js'
+import { Erc20Approval } from '../pages/Erc20Approval.js'
+import { Erc20Transfer } from '../pages/Erc20Transfer.js'
+import { EthTransfer } from '../pages/EthTransfer.js'
+import { GenericRequest } from '../pages/GenericRequest.js'
+import { PersonalSign } from '../pages/PersonalSign.js'
+import { SignTypedData } from '../pages/SignTypedData.js'
+import {
+  decodeCollectionApproval,
+  isCollectionApproval,
+} from '../utils/collectionApproval.js'
+import { decodeErc20Approval, isErc20Approval } from '../utils/erc20Approval.js'
+import { decodeErc20Transfer, isErc20Transfer } from '../utils/erc20Transfer.js'
+import { isEthTransfer } from '../utils/ethTransfer.js'
+
+export function renderRequestContent(
+  request: Request,
+  confirm: () => void,
+  reject: () => void,
+): ReactNode {
+  switch (request.method) {
+    case 'eth_sendTransaction':
+    case 'wallet_sendTransaction': {
+      const tx = request.params[0]
+
+      if (isEthTransfer(tx)) {
+        return (
+          <EthTransfer
+            to={tx.to as Address}
+            value={tx.value as Hex}
+            confirm={confirm}
+            reject={reject}
+          />
+        )
+      }
+
+      if (isErc20Transfer(tx)) {
+        const decoded = decodeErc20Transfer(tx)
+        if (decoded) {
+          return (
+            <Erc20Transfer
+              contract={tx.to as Address}
+              to={decoded.to}
+              amount={decoded.amount}
+              confirm={confirm}
+              reject={reject}
+            />
+          )
+        }
+      }
+
+      if (isErc20Approval(tx)) {
+        const decoded = decodeErc20Approval(tx)
+        if (decoded) {
+          return (
+            <Erc20Approval
+              contract={tx.to as Address}
+              spender={decoded.spender}
+              amount={decoded.amount}
+              confirm={confirm}
+              reject={reject}
+            />
+          )
+        }
+      }
+
+      if (isCollectionApproval(tx)) {
+        const decoded = decodeCollectionApproval(tx)
+        if (decoded) {
+          return (
+            <CollectionApproval
+              contract={tx.to as Address}
+              operator={decoded.operator}
+              approved={decoded.approved}
+              confirm={confirm}
+              reject={reject}
+            />
+          )
+        }
+      }
+      break
+    }
+
+    case 'wallet_sendCalls': {
+      const { calls } = request.params[0]
+      return <BatchCalls calls={calls} confirm={confirm} reject={reject} />
+    }
+
+    case 'personal_sign': {
+      const [data, address] = request.params
+      return (
+        <PersonalSign
+          data={data}
+          address={address}
+          confirm={confirm}
+          reject={reject}
+        />
+      )
+    }
+
+    case 'eth_signTypedData_v4': {
+      const [address, typedData] = request.params
+      return (
+        <SignTypedData
+          address={address}
+          typedData={typedData}
+          confirm={confirm}
+          reject={reject}
+        />
+      )
+    }
+  }
+
+  return <GenericRequest request={request} confirm={confirm} reject={reject} />
+}

--- a/packages/react-kit/src/signing/index.tsx
+++ b/packages/react-kit/src/signing/index.tsx
@@ -1,136 +1,84 @@
-import type { Address, Hex } from 'viem'
+import type { ReactNode } from 'react'
 import { ScreenWrapper } from '../shared/components/ScreenWrapper'
+import type { PendingRequest, Request } from '../types.js'
+import { renderRequestContent } from './components/renderRequestContent.js'
 import { usePendingRequest } from './hooks/usePendingRequest.js'
-import { BatchCalls } from './pages/BatchCalls.js'
-import { CollectionApproval } from './pages/CollectionApproval.js'
-import { Erc20Approval } from './pages/Erc20Approval.js'
-import { Erc20Transfer } from './pages/Erc20Transfer.js'
-import { EthTransfer } from './pages/EthTransfer.js'
-import { GenericRequest } from './pages/GenericRequest.js'
-import { PersonalSign } from './pages/PersonalSign.js'
-import { SignTypedData } from './pages/SignTypedData.js'
-import {
-  decodeCollectionApproval,
-  isCollectionApproval,
-} from './utils/collectionApproval.js'
-import { decodeErc20Approval, isErc20Approval } from './utils/erc20Approval.js'
-import { decodeErc20Transfer, isErc20Transfer } from './utils/erc20Transfer.js'
-import { isEthTransfer } from './utils/ethTransfer.js'
 
-export function SignatureRequest() {
-  const { pendingRequest, pendingRequests, confirm, reject } =
-    usePendingRequest()
+type RenderPropArgs = {
+  pendingRequest: PendingRequest | null
+  confirm: () => void
+  reject: () => void
+}
 
-  if (!pendingRequest) return null
-
-  function renderContent() {
-    switch (pendingRequest.method) {
-      case 'eth_sendTransaction':
-      case 'wallet_sendTransaction': {
-        const tx = pendingRequest.params[0]
-
-        if (isEthTransfer(tx)) {
-          return (
-            <EthTransfer
-              to={tx.to as Address}
-              value={tx.value as Hex}
-              confirm={confirm}
-              reject={reject}
-            />
-          )
-        }
-
-        if (isErc20Transfer(tx)) {
-          const decoded = decodeErc20Transfer(tx)
-          if (decoded) {
-            return (
-              <Erc20Transfer
-                contract={tx.to as Address}
-                to={decoded.to}
-                amount={decoded.amount}
-                confirm={confirm}
-                reject={reject}
-              />
-            )
-          }
-        }
-
-        if (isErc20Approval(tx)) {
-          const decoded = decodeErc20Approval(tx)
-          if (decoded) {
-            return (
-              <Erc20Approval
-                contract={tx.to as Address}
-                spender={decoded.spender}
-                amount={decoded.amount}
-                confirm={confirm}
-                reject={reject}
-              />
-            )
-          }
-        }
-
-        if (isCollectionApproval(tx)) {
-          const decoded = decodeCollectionApproval(tx)
-          if (decoded) {
-            return (
-              <CollectionApproval
-                contract={tx.to as Address}
-                operator={decoded.operator}
-                approved={decoded.approved}
-                confirm={confirm}
-                reject={reject}
-              />
-            )
-          }
-        }
-        break
-      }
-
-      case 'wallet_sendCalls': {
-        const { calls } = pendingRequest.params[0]
-        return <BatchCalls calls={calls} confirm={confirm} reject={reject} />
-      }
-
-      case 'personal_sign': {
-        const [data, address] = pendingRequest.params
-        return (
-          <PersonalSign
-            data={data}
-            address={address}
-            confirm={confirm}
-            reject={reject}
-          />
-        )
-      }
-
-      case 'eth_signTypedData_v4': {
-        const [address, typedData] = pendingRequest.params
-        return (
-          <SignTypedData
-            address={address}
-            typedData={typedData}
-            confirm={confirm}
-            reject={reject}
-          />
-        )
-      }
+export type SignatureRequestProps =
+  | {
+      request?: never
+      onConfirm?: never
+      onReject?: never
+      children?: (args: RenderPropArgs) => ReactNode
+    }
+  | {
+      request: Request
+      onConfirm: () => void
+      onReject: () => void
+      children?: never
     }
 
+export function SignatureRequest(props: SignatureRequestProps = {}) {
+  if (props.request) {
     return (
-      <GenericRequest
-        request={pendingRequest}
-        confirm={confirm}
-        reject={reject}
+      <ControlledSignatureRequest
+        request={props.request}
+        onConfirm={props.onConfirm}
+        onReject={props.onReject}
       />
     )
   }
+  return (
+    <UncontrolledSignatureRequest>
+      {props.children}
+    </UncontrolledSignatureRequest>
+  )
+}
 
+function ControlledSignatureRequest({
+  request,
+  onConfirm,
+  onReject,
+}: {
+  request: Request
+  onConfirm: () => void
+  onReject: () => void
+}) {
   return (
     <ScreenWrapper>
-      {() => (
-        <div className="h-full flex flex-col" style={{ paddingTop: 20 }}>
-          {renderContent()}
+      {({ paddingTop }) => (
+        <div style={{ paddingTop }}>
+          {renderRequestContent(request, onConfirm, onReject)}
+        </div>
+      )}
+    </ScreenWrapper>
+  )
+}
+
+function UncontrolledSignatureRequest({
+  children,
+}: {
+  children: ((args: RenderPropArgs) => ReactNode) | undefined
+}) {
+  const { pendingRequest, pendingRequests, confirm, reject } =
+    usePendingRequest()
+
+  if (typeof children === 'function') {
+    return children({ pendingRequest, confirm, reject })
+  }
+
+  if (!pendingRequest) return null
+  return (
+    <ScreenWrapper>
+      {({ paddingTop }) => (
+        <div style={{ paddingTop }}>
+          {renderRequestContent(pendingRequest, confirm, reject)}
           {pendingRequests.length > 1 && (
             <p className="text-xs text-gray-500 mt-3">
               +{pendingRequests.length - 1} more pending{' '}

--- a/packages/react-kit/src/signing/index.tsx
+++ b/packages/react-kit/src/signing/index.tsx
@@ -76,8 +76,8 @@ function UncontrolledSignatureRequest({
   if (!pendingRequest) return null
   return (
     <ScreenWrapper>
-      {({ paddingTop }) => (
-        <div style={{ paddingTop }}>
+      {() => (
+        <div className="h-full flex flex-col" style={{ paddingTop: 20 }}>
           {renderRequestContent(pendingRequest, confirm, reject)}
           {pendingRequests.length > 1 && (
             <p className="text-xs text-gray-500 mt-3">

--- a/packages/react-kit/src/signing/pages/GenericRequest.tsx
+++ b/packages/react-kit/src/signing/pages/GenericRequest.tsx
@@ -1,8 +1,8 @@
-import type { PendingRequest } from '../../types.js'
+import type { Request } from '../../types.js'
 import { SigningLayout } from '../components/SigningLayout'
 
 interface GenericRequestProps {
-  request: PendingRequest
+  request: Request
   confirm: () => void
   reject: () => void
 }


### PR DESCRIPTION
closes FS-1891

`<SignatureRequest />` can now be used in different modes:
1. Simply mounting and all signing displays automatically (like so far):
```typescript
<SignatureRequest />
```
2. Using props to create a custom UI:
```typescript
<SignatureRequest>
  {({ pendingRequest, confirm, reject }) => (
    <CustomConfirmUI
      pendingRequest={pendingRequest}
      confirm={confirm}
      reject={reject}
    />
  )}
</SignatureRequest>
```
3. Passing request props - keeps the same UI but isn't tied to automatic request tracking. Dev can display whatever request they want here.
```typescript
<SignatureRequest
  request={controlledRequest}
  onConfirm={handleControlledConfirm}
  onReject={() => setControlledRequest(null)}
/>
```

All modes testable in the example app. Next I can do the same for authentication.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
