### PR TITLE
feat(react-kit): personal sign UI

### DIFF
--- a/packages/react-kit/src/signing/pages/PersonalSign.tsx
+++ b/packages/react-kit/src/signing/pages/PersonalSign.tsx
@@ -1,4 +1,7 @@
 import type { Hex } from 'viem'
+
+import { Text } from '../../shared/components/Text'
+import { DetailsContainer } from '../components/DetailsContainer'
 import { SigningLayout } from '../components/SigningLayout'
 import { decodePersonalSignMessage } from '../utils/personalSign.js'
 
@@ -9,37 +12,21 @@ interface PersonalSignProps {
   reject: () => void
 }
 
-export function PersonalSign({
-  data,
-  address,
-  confirm,
-  reject,
-}: PersonalSignProps) {
+export function PersonalSign({ data, confirm, reject }: PersonalSignProps) {
   const message = decodePersonalSignMessage(data)
 
   return (
     <SigningLayout onConfirm={confirm} onReject={reject}>
-      <div className="flex flex-col gap-3">
-        <h3 className="text-lg font-semibold text-gray-900">Sign Message</h3>
-
-        <div className="rounded-lg bg-gray-50 p-4 border border-gray-100">
-          {message !== null ? (
-            <pre className="text-sm text-gray-900 whitespace-pre-wrap break-all">
-              {message}
-            </pre>
-          ) : (
-            <div>
-              <p className="text-xs text-gray-500 mb-1">Raw data:</p>
-              <pre className="text-sm text-gray-900 whitespace-pre-wrap break-all">
-                {data}
-              </pre>
-            </div>
-          )}
-          <div className="mt-2 text-sm text-gray-500">
-            <span className="font-medium">Signer: </span>
-            <span className="font-mono break-all">{address}</span>
-          </div>
+      <div className="flex flex-col gap-2 pt-4">
+        <div className="flex flex-col items-center justify-center gap-2 pb-2">
+          <Text className="text-h2">Signature Request</Text>
+          <Text className="text-center">
+            Review request details before you confirm.
+          </Text>
         </div>
+        <DetailsContainer title="Message Details" iconName="message">
+          <Text className="break-all">{message ?? data}</Text>
+        </DetailsContainer>
       </div>
     </SigningLayout>
   )


### PR DESCRIPTION
Closes [FS-1892](https://linear.app/offchain-labs/issue/FS-1892/ui-variant-for-personal-sign)

### Summary

This PR migrates personal sign page UI


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
