### PR TITLE
fix(expo-example): add EAS local build config and fix HMR bug with secureStoreStamper

### DIFF
--- a/apps/expo-example/eas.json
+++ b/apps/expo-example/eas.json
@@ -7,7 +7,8 @@
     "preview": {
       "distribution": "internal",
       "env": {
-        "EXPO_PUBLIC_ZERODEV_PROJECT_ID": "your-zerodev-project-id"
+        "EXPO_PUBLIC_ZERODEV_PROJECT_ID": "ad5725c6-06a7-4d28-80ba-a65c1e870128",
+        "EXPO_PUBLIC_USE_APP_LINKS": "true"
       },
       "android": {
         "buildType": "apk",

--- a/apps/expo-example/package.json
+++ b/apps/expo-example/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "eas-build-pre-install": "cd ../.. && pnpm install --frozen-lockfile --ignore-scripts && pnpm --filter @zerodev/wallet-core --filter @zerodev/wallet-react build"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/apps/expo-example/src/lib/secureStoreStamper.ts
+++ b/apps/expo-example/src/lib/secureStoreStamper.ts
@@ -68,9 +68,30 @@ class SecureStoreStamperInner {
   }
 }
 
+async function warmApiKeyStamperForMetroDev(
+  inner: SecureStoreStamperInner,
+): Promise<void> {
+  // biome-ignore lint/correctness/noUndeclaredVariables: This variable is set to true when react-native is running in Dev mode
+  if (!__DEV__) return
+
+  // In Expo dev, Turnkey's API key stamper loads its React Native signer with a
+  // dynamic import the first time `stamp()` runs. OTP verification is usually
+  // the first code path that stamps a payload, and if the app was backgrounded
+  // while the user copied the code, Metro can serve that lazy module after
+  // foregrounding and trigger a full JS reload. Warming the stamper during dev
+  // startup makes Metro load the signer while the app is foregrounded; production
+  // builds do not use Metro and skip this block via `__DEV__`.
+  try {
+    await inner.stamp('{"purpose":"metro-dev-warmup"}')
+  } catch (error) {
+    console.warn('Failed to warm API key stamper in dev:', error)
+  }
+}
+
 export async function createSecureStoreStamper(): Promise<ZDApiKeyStamper> {
   const inner = new SecureStoreStamperInner()
   await inner.init()
+  await warmApiKeyStamperForMetroDev(inner)
 
   let pendingKeyPair: { publicKey: string; privateKey: string } | null = null
 


### PR DESCRIPTION
<!-- av pr stack begin -->
<table><tr><td><details><summary>This PR is part of a stack created with <a href="https://github.com/aviator-co/av">Aviator</a>.</summary>

* **#168**
* **#142**
* ➡️ **#141**
* `main`
</details></td></tr></table>
<!-- av pr stack end -->


I discovered a bug when testing OTP. If I backgrounded the app to copy the code from the email and then went back to the app to verify the code it caused an app refresh. This only appeared in dev mode as I tested with EAS CLI using a local APK build too (package.json and eas.json change are for the local APK build).
The cause is a dynamic import in Turnkey which gets bundled only at the first stamp with the `secureStoreStamper`. So the fix is essentially a "warmup" to trigger a dummy stamp on initialization. This fix only runs in DEV mode.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
