### PR TITLE
fix(react): preserve caller pathname in OAuth returnTo

### DIFF
--- a/.changeset/gentle-adults-talk.md
+++ b/.changeset/gentle-adults-talk.md
@@ -1,0 +1,5 @@
+---
+"@zerodev/wallet-react": patch
+---
+
+fix(react): preserve caller's pathname in OAuth `returnTo` so the popup lands on the same route as the parent. Previously the SDK used `window.location.origin` only, which redirected the popup to `/`. If `/` rendered a different app (or no SDK provider), the OAuth callback handler never ran and the popup hung.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -15,6 +15,7 @@
     "floppy-glasses-attack",
     "free-grapes-teach",
     "funky-pillows-fall",
+    "gentle-adults-talk",
     "giant-garlics-make",
     "humble-sheep-kiss",
     "khaki-ways-listen",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @zerodev/wallet-react
 
+## 0.0.1-alpha.19
+
+### Patch Changes
+
+- fix(react): preserve caller's pathname in OAuth `returnTo` so the popup lands on the same route as the parent. Previously the SDK used `window.location.origin` only, which redirected the popup to `/`. If `/` rendered a different app (or no SDK provider), the OAuth callback handler never ran and the popup hung.
+
 ## 0.0.1-alpha.18
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-react",
-  "version": "0.0.1-alpha.18",
+  "version": "0.0.1-alpha.19",
   "description": "React hooks for ZeroDev Wallet SDK",
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",

--- a/packages/react/src/actions.test.ts
+++ b/packages/react/src/actions.test.ts
@@ -577,6 +577,32 @@ describe('React Actions', () => {
       })
     })
 
+    it('preserves the caller pathname in returnTo so popup lands on the same route', async () => {
+      const original = window.location.href
+      window.history.replaceState({}, '', '/dashboard?utm=src#section')
+
+      const wallet = createMockWallet()
+      const store = createMockStore(wallet)
+      const connector = createMockConnector(store)
+      const config = createMockConfig(connector)
+
+      mockOpenOAuthPopup.mockReturnValue({ closed: false } as Window)
+      mockListenForOAuthMessage.mockImplementation(() => () => {})
+
+      authenticateOAuth(config, { provider: 'google' }).catch(() => {})
+      await new Promise((r) => setTimeout(r, 10))
+
+      const returnTo = mockBuildBackendOAuthUrl.mock.calls[0][0].returnTo
+      const parsed = new URL(returnTo)
+      expect(parsed.pathname).toBe('/dashboard')
+      expect(parsed.searchParams.get('oauth_success')).toBe('true')
+      expect(parsed.searchParams.get('oauth_provider')).toBe('google')
+      expect(parsed.searchParams.get('utm')).toBe('src')
+      expect(parsed.hash).toBe('')
+
+      window.history.replaceState({}, '', original)
+    })
+
     it('completes full OAuth success flow with sessionId', async () => {
       const wallet = createMockWallet()
       wallet.getSession.mockResolvedValue({ id: 'oauth-session' })

--- a/packages/react/src/actions.ts
+++ b/packages/react/src/actions.ts
@@ -138,13 +138,19 @@ export async function authenticateOAuth(
   }
 
   // Build OAuth URL that redirects to backend
-  // Use current origin as redirect - SDK auto-detects callback on any page
+  // Preserve the caller's full path so the popup lands on the same route
+  // (e.g. /dashboard) where the SDK is mounted, not just the origin.
+  const returnUrl = new URL(window.location.href)
+  returnUrl.hash = ''
+  returnUrl.searchParams.set('oauth_success', 'true')
+  returnUrl.searchParams.set('oauth_provider', parameters.provider)
+
   const oauthUrl = buildBackendOAuthUrl({
     provider: parameters.provider,
     backendUrl: oauthConfig.backendUrl,
     projectId: oauthConfig.projectId,
     publicKey,
-    returnTo: `${window.location.origin}?oauth_success=true&oauth_provider=${parameters.provider}`,
+    returnTo: returnUrl.toString(),
   })
 
   // Open popup


### PR DESCRIPTION
## Summary

The OAuth flow was using `window.location.origin` for `returnTo`, which drops the pathname — the popup always redirected to `/` after the backend's OAuth callback, regardless of which route the user triggered OAuth from.

If the consumer triggers OAuth from a non-root route (e.g. `/dashboard`), and `/` renders a different app or doesn't include the SDK's `<WagmiProvider>`, the connector's auto-detect callback in the popup never runs and the popup hangs on the success URL while the parent never completes the auth.

This swaps to `window.location.href` as the base, strips any `#hash`, and adds `oauth_success` / `oauth_provider` as URL params (preserving any pre-existing query params).

## Repro

1. Mount the SDK on a non-root route (`/dashboard`)
2. Trigger `useAuthenticateOAuth().mutate({ provider: 'google' })`
3. Pre-fix: popup ends up at `/?oauth_success=true&...`, hangs there if `/` is a different app
4. Post-fix: popup ends up at `/dashboard?oauth_success=true&...`, callback handler runs, popup closes, parent completes auth

## Reported by

Srinjoy hit this on a Wallet Provider Demo app where `/dashboard` triggered OAuth but the popup ended up at `/` (a different app instance).

## Released as

`@zerodev/wallet-react@0.0.1-alpha.19`