### PR TITLE
feat(otp): switch to encrypted OTP attempts (Turnkey OTP_V3)

### DIFF
--- a/e2e/helpers/otp-login.ts
+++ b/e2e/helpers/otp-login.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared helper: completes an end-to-end OTP login against a real backend.
+ *
+ * Used by integration tests that need an authenticated session as a setup
+ * step (`session-management`, `wallet-operations`). Handles the full
+ * register → email → encrypted-verify → login flow and returns the
+ * authenticated client + session.
+ */
+
+import { createAuthProxyClient } from '../../packages/core/src/client/authProxy.js'
+import { buildClientSignature } from '../../packages/core/src/utils/buildClientSignature.js'
+import { encryptOtpAttempt } from '../../packages/core/src/utils/encryptOtpAttempt.js'
+import { parseSession } from '../../packages/core/src/utils/utils.js'
+import {
+  EMAIL_POLL_INTERVAL_MS,
+  EMAIL_POLL_TIMEOUT_MS,
+  OTP_CODE_LENGTH,
+} from './constants.js'
+import { extractOtpCode } from './otp-utils.js'
+import { createNewAccount, searchForNewEmail } from './temp-email.js'
+import { createTestClient } from './test-client.js'
+import { createTestStamper } from './test-stamper.js'
+
+export async function completeOtpLogin(
+  projectId: string,
+  authProxyConfigId: string,
+) {
+  const emailAccount = await createNewAccount()
+  const stamper = createTestStamper()
+  const publicKey = (await stamper.getPublicKey())!
+
+  const client = createTestClient(stamper)
+
+  const registerResult = await client.registerWithOTP({
+    email: emailAccount.address,
+    contact: { type: 'email', contact: emailAccount.address },
+    projectId,
+    otpCodeCustomization: {
+      length: OTP_CODE_LENGTH as 6 | 7 | 8 | 9,
+      alphanumeric: false,
+    },
+  })
+
+  const emailContent = await searchForNewEmail(
+    emailAccount.authToken,
+    EMAIL_POLL_INTERVAL_MS,
+    EMAIL_POLL_TIMEOUT_MS,
+  )
+  const otpCode = extractOtpCode(emailContent, OTP_CODE_LENGTH)!
+
+  const encryptedOtpBundle = await encryptOtpAttempt({
+    otpCode,
+    publicKey,
+    encryptionTargetBundle: registerResult.otpEncryptionTargetBundle,
+  })
+
+  const authProxyClient = createAuthProxyClient({ authProxyConfigId })
+  const verifyResult = await authProxyClient.verifyOtp({
+    otpId: registerResult.otpId,
+    encryptedOtpBundle,
+  })
+
+  const clientSignature = await buildClientSignature({
+    verificationToken: verifyResult.verificationToken,
+    publicKey,
+    stamper,
+  })
+
+  const loginResult = await client.loginWithOTP({
+    verificationToken: verifyResult.verificationToken,
+    clientSignature,
+    projectId,
+  })
+
+  const session = parseSession(loginResult.session)
+  return { client, stamper, session, sessionToken: loginResult.session }
+}

--- a/e2e/helpers/temp-email.ts
+++ b/e2e/helpers/temp-email.ts
@@ -75,16 +75,32 @@ export async function createNewAccount(): Promise<TempEmailAccount> {
   const address = `email_${randomHex}@${domain}`
   const password = '123456'
 
-  // Create account
-  const createRes = await fetch(`${MAIL_API_BASE}/accounts`, {
-    method: 'POST',
-    headers: defaultHeaders,
-    body: JSON.stringify({ address, password }),
-  })
-  if (!createRes.ok) {
-    const text = await createRes.text()
+  // Create account. mail.tm rate-limits account creation aggressively
+  // (~3–5/min). On 429 we back off and retry; for any other failure we
+  // fail loud immediately.
+  const ACCOUNT_CREATE_ATTEMPTS = 5
+  let createRes: Response | undefined
+  for (let attempt = 0; attempt < ACCOUNT_CREATE_ATTEMPTS; attempt++) {
+    createRes = await fetch(`${MAIL_API_BASE}/accounts`, {
+      method: 'POST',
+      headers: defaultHeaders,
+      body: JSON.stringify({ address, password }),
+    })
+    if (createRes.ok) break
+    if (createRes.status !== 429) {
+      const text = await createRes.text()
+      throw new Error(
+        `Failed to create email account: ${createRes.status} ${text}`,
+      )
+    }
+    // Exponential backoff: 5s, 10s, 20s, 40s. mail.tm's window is short
+    // enough that this almost always recovers within two retries.
+    const delayMs = 5_000 * 2 ** attempt
+    await new Promise((r) => setTimeout(r, delayMs))
+  }
+  if (!createRes || !createRes.ok) {
     throw new Error(
-      `Failed to create email account: ${createRes.status} ${text}`,
+      `Failed to create email account after ${ACCOUNT_CREATE_ATTEMPTS} attempts: ${createRes?.status ?? 'no response'}`,
     )
   }
 

--- a/e2e/helpers/temp-email.ts
+++ b/e2e/helpers/temp-email.ts
@@ -1,12 +1,16 @@
 /**
- * Temporary email service using mail.gw API.
- * Port of doorway-kms/pkg/test/temp_mail_api.go
+ * Temporary email service using the mail.tm/mail.gw API.
  *
- * Note: The mail.gw API returns plain JSON arrays/objects
- * (not hydra:member wrapped like the older API version).
+ * Both endpoints serve the same backend; mail.gw has been intermittently
+ * unreachable (HTTP 502) so we default to mail.tm. Override via
+ * `MAIL_API_BASE` if a different mirror is needed.
+ *
+ * Response handling tolerates both shapes the API has shipped:
+ *   - bare JSON arrays / objects (newer mail.gw responses)
+ *   - `hydra:member`-wrapped collections (older / mail.tm responses)
  */
 
-const MAIL_API_BASE = 'https://api.mail.gw'
+const MAIL_API_BASE = process.env.MAIL_API_BASE || 'https://api.mail.tm'
 
 export type TempEmailAccount = {
   address: string

--- a/e2e/integration/magic-link-flow.test.ts
+++ b/e2e/integration/magic-link-flow.test.ts
@@ -19,6 +19,7 @@
 import { beforeAll, describe, expect, it } from 'vitest'
 import { createAuthProxyClient } from '../../packages/core/src/client/authProxy.js'
 import { buildClientSignature } from '../../packages/core/src/utils/buildClientSignature.js'
+import { encryptOtpAttempt } from '../../packages/core/src/utils/encryptOtpAttempt.js'
 import { parseSession } from '../../packages/core/src/utils/utils.js'
 import {
   getAuthProxyConfigId,
@@ -109,6 +110,7 @@ describe('Magic Link Authentication Flow', () => {
       },
     })
     expect(registerResult.otpId).toBeTruthy()
+    expect(registerResult.otpEncryptionTargetBundle).toBeTruthy()
     console.log(`OTP initiated with magic link, otpId: ${registerResult.otpId}`)
 
     // Step 5: Poll for email and extract OTP code from magic link URL
@@ -131,12 +133,16 @@ describe('Magic Link Authentication Flow', () => {
     expect(otpCode).toBeTruthy()
     console.log(`Extracted OTP code: ${otpCode}`)
 
-    // Step 6: Verify OTP with Auth Proxy (same as regular OTP flow)
+    // Step 6: HPKE-seal the OTP attempt and verify with Auth Proxy.
+    const encryptedOtpBundle = await encryptOtpAttempt({
+      otpCode: otpCode!,
+      publicKey: publicKey!,
+      encryptionTargetBundle: registerResult.otpEncryptionTargetBundle,
+    })
     const authProxyClient = createAuthProxyClient({ authProxyConfigId })
     const verifyResult = await authProxyClient.verifyOtp({
       otpId: registerResult.otpId,
-      otpCode: otpCode!,
-      public_key: publicKey!,
+      encryptedOtpBundle,
     })
     expect(verifyResult.verificationToken).toBeTruthy()
     console.log('OTP verified with Auth Proxy')

--- a/e2e/integration/otp-flow.test.ts
+++ b/e2e/integration/otp-flow.test.ts
@@ -16,6 +16,7 @@
 import { beforeAll, describe, expect, it } from 'vitest'
 import { createAuthProxyClient } from '../../packages/core/src/client/authProxy.js'
 import { buildClientSignature } from '../../packages/core/src/utils/buildClientSignature.js'
+import { encryptOtpAttempt } from '../../packages/core/src/utils/encryptOtpAttempt.js'
 import { parseSession } from '../../packages/core/src/utils/utils.js'
 import {
   getAuthProxyConfigId,
@@ -97,6 +98,7 @@ describe('OTP Authentication Flow', () => {
       },
     })
     expect(registerResult.otpId).toBeTruthy()
+    expect(registerResult.otpEncryptionTargetBundle).toBeTruthy()
     console.log(`OTP initiated, otpId: ${registerResult.otpId}`)
 
     // Step 5: Poll for email and extract OTP code
@@ -110,12 +112,17 @@ describe('OTP Authentication Flow', () => {
     expect(otpCode).toBeTruthy()
     console.log(`Extracted OTP code: ${otpCode}`)
 
-    // Step 6: Verify OTP with Auth Proxy
+    // Step 6: HPKE-seal the OTP attempt to the enclave's per-session target
+    // key, then verify with Auth Proxy.
+    const encryptedOtpBundle = await encryptOtpAttempt({
+      otpCode: otpCode!,
+      publicKey: publicKey!,
+      encryptionTargetBundle: registerResult.otpEncryptionTargetBundle,
+    })
     const authProxyClient = createAuthProxyClient({ authProxyConfigId })
     const verifyResult = await authProxyClient.verifyOtp({
       otpId: registerResult.otpId,
-      otpCode: otpCode!,
-      public_key: publicKey!,
+      encryptedOtpBundle,
     })
     expect(verifyResult.verificationToken).toBeTruthy()
     console.log('OTP verified with Auth Proxy')
@@ -185,12 +192,16 @@ describe('OTP Authentication Flow', () => {
     })
 
     // Try to verify with a wrong code
+    const wrongEncryptedBundle = await encryptOtpAttempt({
+      otpCode: 'WRONG12',
+      publicKey: publicKey!,
+      encryptionTargetBundle: registerResult.otpEncryptionTargetBundle,
+    })
     const authProxyClient = createAuthProxyClient({ authProxyConfigId })
     await expect(
       authProxyClient.verifyOtp({
         otpId: registerResult.otpId,
-        otpCode: 'WRONG12',
-        public_key: publicKey!,
+        encryptedOtpBundle: wrongEncryptedBundle,
       }),
     ).rejects.toThrow()
   })

--- a/e2e/integration/otp-init-shape.test.ts
+++ b/e2e/integration/otp-init-shape.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Smoke test: verifies the new `otpEncryptionTargetBundle` is returned by
+ * `/auth/init/otp` and that `encryptOtpAttempt` accepts a real bundle signed
+ * by the production TLS Fetcher key (no `dangerouslyOverrideSignerPublicKey`).
+ *
+ * Doesn't require email service — only the backend on `upgrade_turnkey` and a
+ * test project. Skipped without ZD_PROJECT_ID set.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest'
+import { encryptOtpAttempt } from '../../packages/core/src/utils/encryptOtpAttempt.js'
+import { waitForBackend } from '../helpers/backend-health.js'
+import { BACKEND_URL } from '../helpers/constants.js'
+
+describe('OTP init wire shape', () => {
+  let projectId: string
+  let skipReason = ''
+
+  beforeAll(async () => {
+    try {
+      await waitForBackend(BACKEND_URL)
+    } catch {
+      skipReason = `Backend not reachable at ${BACKEND_URL}`
+      return
+    }
+    projectId = process.env.ZD_PROJECT_ID || ''
+    if (!projectId) {
+      skipReason = 'ZD_PROJECT_ID not set'
+      return
+    }
+  })
+
+  it('returns otpEncryptionTargetBundle that encryptOtpAttempt accepts under the production pinned key', async (context) => {
+    context.skip(!!skipReason, skipReason)
+
+    const res = await fetch(`${BACKEND_URL}/${projectId}/auth/init/otp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'http://localhost:3000',
+      },
+      body: JSON.stringify({
+        email: `smoke-${Date.now()}@example.com`,
+        contact: {
+          type: 'email',
+          contact: `smoke-${Date.now()}@example.com`,
+        },
+        otpCodeCustomization: { length: 7, alphanumeric: false },
+      }),
+    })
+    expect(res.ok).toBe(true)
+    const body = await res.json()
+
+    expect(body.otpId).toBeTruthy()
+    expect(body.otpEncryptionTargetBundle).toBeTruthy()
+
+    const envelope = JSON.parse(body.otpEncryptionTargetBundle)
+    expect(envelope.version).toBe('v1.0.0')
+    expect(typeof envelope.data).toBe('string')
+    expect(typeof envelope.dataSignature).toBe('string')
+    expect(typeof envelope.enclaveQuorumPublic).toBe('string')
+
+    // Encrypt under the production pinned signer key (no test override). If
+    // this throws, either the production key is rotated and we need to update
+    // TURNKEY_TLS_FETCHER_SIGN_PUBLIC_KEY, or the bundle is malformed.
+    const encrypted = await encryptOtpAttempt({
+      otpCode: '0000000',
+      publicKey:
+        '02aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899',
+      encryptionTargetBundle: body.otpEncryptionTargetBundle,
+    })
+    const parsed = JSON.parse(encrypted)
+    expect(typeof parsed.encappedPublic).toBe('string')
+    expect(parsed.encappedPublic.length).toBe(130) // 65 bytes uncompressed
+    expect(parsed.encappedPublic.slice(0, 2)).toBe('04')
+    expect(typeof parsed.ciphertext).toBe('string')
+  })
+})

--- a/e2e/integration/session-management.test.ts
+++ b/e2e/integration/session-management.test.ts
@@ -7,75 +7,16 @@
  */
 
 import { beforeAll, describe, expect, it } from 'vitest'
-import { createAuthProxyClient } from '../../packages/core/src/client/authProxy.js'
-import { buildClientSignature } from '../../packages/core/src/utils/buildClientSignature.js'
 import { parseSession } from '../../packages/core/src/utils/utils.js'
 import {
   getAuthProxyConfigId,
   waitForBackend,
 } from '../helpers/backend-health.js'
-import {
-  BACKEND_URL,
-  EMAIL_POLL_INTERVAL_MS,
-  EMAIL_POLL_TIMEOUT_MS,
-  OTP_CODE_LENGTH,
-} from '../helpers/constants.js'
-import { extractOtpCode } from '../helpers/otp-utils.js'
-import {
-  createNewAccount,
-  ping,
-  searchForNewEmail,
-} from '../helpers/temp-email.js'
+import { BACKEND_URL } from '../helpers/constants.js'
+import { completeOtpLogin } from '../helpers/otp-login.js'
+import { ping } from '../helpers/temp-email.js'
 import { createTestClient } from '../helpers/test-client.js'
 import { createTestStamper } from '../helpers/test-stamper.js'
-
-/** Helper to complete an OTP login flow, returning the session and org ID */
-async function completeOtpLogin(projectId: string, authProxyConfigId: string) {
-  const emailAccount = await createNewAccount()
-  const stamper = createTestStamper()
-  const publicKey = (await stamper.getPublicKey())!
-
-  const client = createTestClient(stamper)
-
-  const registerResult = await client.registerWithOTP({
-    email: emailAccount.address,
-    contact: { type: 'email', contact: emailAccount.address },
-    projectId,
-    otpCodeCustomization: {
-      length: OTP_CODE_LENGTH as 6 | 7 | 8 | 9,
-      alphanumeric: false,
-    },
-  })
-
-  const emailContent = await searchForNewEmail(
-    emailAccount.authToken,
-    EMAIL_POLL_INTERVAL_MS,
-    EMAIL_POLL_TIMEOUT_MS,
-  )
-  const otpCode = extractOtpCode(emailContent, OTP_CODE_LENGTH)!
-
-  const authProxyClient = createAuthProxyClient({ authProxyConfigId })
-  const verifyResult = await authProxyClient.verifyOtp({
-    otpId: registerResult.otpId,
-    otpCode,
-    public_key: publicKey,
-  })
-
-  const clientSignature = await buildClientSignature({
-    verificationToken: verifyResult.verificationToken,
-    publicKey,
-    stamper,
-  })
-
-  const loginResult = await client.loginWithOTP({
-    verificationToken: verifyResult.verificationToken,
-    clientSignature,
-    projectId,
-  })
-
-  const session = parseSession(loginResult.session)
-  return { client, stamper, session, sessionToken: loginResult.session }
-}
 
 describe('Session Management', () => {
   let projectId: string

--- a/e2e/integration/wallet-operations.test.ts
+++ b/e2e/integration/wallet-operations.test.ts
@@ -7,75 +7,13 @@
  */
 
 import { beforeAll, describe, expect, it } from 'vitest'
-import { createAuthProxyClient } from '../../packages/core/src/client/authProxy.js'
-import { buildClientSignature } from '../../packages/core/src/utils/buildClientSignature.js'
-import { parseSession } from '../../packages/core/src/utils/utils.js'
 import {
   getAuthProxyConfigId,
   waitForBackend,
 } from '../helpers/backend-health.js'
-import {
-  BACKEND_URL,
-  EMAIL_POLL_INTERVAL_MS,
-  EMAIL_POLL_TIMEOUT_MS,
-  OTP_CODE_LENGTH,
-} from '../helpers/constants.js'
-import { extractOtpCode } from '../helpers/otp-utils.js'
-import {
-  createNewAccount,
-  ping,
-  searchForNewEmail,
-} from '../helpers/temp-email.js'
-import { createTestClient } from '../helpers/test-client.js'
-import { createTestStamper } from '../helpers/test-stamper.js'
-
-/** Helper to complete an OTP login flow */
-async function completeOtpLogin(projectId: string, authProxyConfigId: string) {
-  const emailAccount = await createNewAccount()
-  const stamper = createTestStamper()
-  const publicKey = (await stamper.getPublicKey())!
-
-  const client = createTestClient(stamper)
-
-  const registerResult = await client.registerWithOTP({
-    email: emailAccount.address,
-    contact: { type: 'email', contact: emailAccount.address },
-    projectId,
-    otpCodeCustomization: {
-      length: OTP_CODE_LENGTH as 6 | 7 | 8 | 9,
-      alphanumeric: false,
-    },
-  })
-
-  const emailContent = await searchForNewEmail(
-    emailAccount.authToken,
-    EMAIL_POLL_INTERVAL_MS,
-    EMAIL_POLL_TIMEOUT_MS,
-  )
-  const otpCode = extractOtpCode(emailContent, OTP_CODE_LENGTH)!
-
-  const authProxyClient = createAuthProxyClient({ authProxyConfigId })
-  const verifyResult = await authProxyClient.verifyOtp({
-    otpId: registerResult.otpId,
-    otpCode,
-    public_key: publicKey,
-  })
-
-  const clientSignature = await buildClientSignature({
-    verificationToken: verifyResult.verificationToken,
-    publicKey,
-    stamper,
-  })
-
-  const loginResult = await client.loginWithOTP({
-    verificationToken: verifyResult.verificationToken,
-    clientSignature,
-    projectId,
-  })
-
-  const session = parseSession(loginResult.session)
-  return { client, stamper, session, sessionToken: loginResult.session }
-}
+import { BACKEND_URL } from '../helpers/constants.js'
+import { completeOtpLogin } from '../helpers/otp-login.js'
+import { ping } from '../helpers/temp-email.js'
 
 describe('Wallet Operations', () => {
   let projectId: string

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -20,6 +20,9 @@ export default defineConfig({
     baseURL: process.env.DEMO_APP_URL || 'http://localhost:3000',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+    // Local backend uses a self-signed TLS cert. Opt in via env so CI /
+    // staging runs (where backend has a real cert) stay strict.
+    ignoreHTTPSErrors: process.env.ALLOW_SELF_SIGNED_TLS === '1',
   },
   projects: [
     {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,6 +58,8 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@noble/curves": "^2.2.0",
+    "@noble/hashes": "^2.2.0",
     "@turnkey/http": "^3.12.1",
     "@turnkey/iframe-stamper": "^2.5.0",
     "@turnkey/indexed-db-stamper": "^1.1.1",
@@ -68,6 +70,7 @@
     "viem": "^2.38.0"
   },
   "devDependencies": {
+    "@hpke/core": "^1.9.0",
     "@types/node": "^20.0.0",
     "typescript": "5.9.3"
   },

--- a/packages/core/src/actions/auth/otp.test.ts
+++ b/packages/core/src/actions/auth/otp.test.ts
@@ -34,7 +34,10 @@ function createMockClient(
 
 describe('registerWithOTP', () => {
   it('sends OTP init request with correct parameters', async () => {
-    const mockClient = createMockClient(async () => ({ otpId: 'otp-123' }))
+    const mockClient = createMockClient(async () => ({
+      otpId: 'otp-123',
+      otpEncryptionTargetBundle: 'bundle-stub',
+    }))
 
     const result = await registerWithOTP(mockClient, {
       email: 'user@example.com',
@@ -57,11 +60,17 @@ describe('registerWithOTP', () => {
         emailCustomization: undefined,
       },
     })
-    expect(result).toEqual({ otpId: 'otp-123' })
+    expect(result).toEqual({
+      otpId: 'otp-123',
+      otpEncryptionTargetBundle: 'bundle-stub',
+    })
   })
 
   it('includes email customization when provided', async () => {
-    const mockClient = createMockClient(async () => ({ otpId: 'otp-123' }))
+    const mockClient = createMockClient(async () => ({
+      otpId: 'otp-123',
+      otpEncryptionTargetBundle: 'bundle-stub',
+    }))
 
     await registerWithOTP(mockClient, {
       email: 'user@example.com',
@@ -87,7 +96,10 @@ describe('registerWithOTP', () => {
   })
 
   it('supports SMS contact type', async () => {
-    const mockClient = createMockClient(async () => ({ otpId: 'otp-sms' }))
+    const mockClient = createMockClient(async () => ({
+      otpId: 'otp-sms',
+      otpEncryptionTargetBundle: 'bundle-stub',
+    }))
 
     await registerWithOTP(mockClient, {
       email: 'user@example.com',

--- a/packages/core/src/actions/auth/registerWithOTP.ts
+++ b/packages/core/src/actions/auth/registerWithOTP.ts
@@ -31,6 +31,12 @@ export type RegisterWithOTPParameters = {
 export type RegisterWithOTPReturnType = {
   /** The OTP ID needed for verification */
   otpId: string
+  /**
+   * Signed encryption target bundle issued by the TLS Fetcher enclave for
+   * this OTP session. Passed verbatim to the verify step so the SDK can
+   * HPKE-encrypt the OTP attempt to the enclave's ephemeral target key.
+   */
+  otpEncryptionTargetBundle: string
 }
 
 /**

--- a/packages/core/src/client/authProxy.ts
+++ b/packages/core/src/client/authProxy.ts
@@ -10,10 +10,11 @@ export type AuthProxyClientConfig = {
 export type AuthProxyVerifyOtpRequest = {
   /** The OTP ID from registration */
   otpId: string
-  /** The OTP code entered by the user */
-  otpCode: string
-  /** The public key to associate with the verification */
-  public_key: string
+  /**
+   * HPKE-sealed bundle containing `{otp_code, public_key}` encrypted to the
+   * enclave's per-session target key. Produced by `encryptOtpAttempt`.
+   */
+  encryptedOtpBundle: string
 }
 
 export type AuthProxyVerifyOtpResponse = {
@@ -62,15 +63,20 @@ export function createAuthProxyClient(config: AuthProxyClientConfig) {
 
   return {
     /**
-     * Verifies an OTP code with Turnkey's Auth Proxy
+     * Verifies an OTP attempt with Turnkey's Auth Proxy.
      *
-     * Returns a verificationToken that should be passed to the backend's
-     * /auth/login/otp endpoint along with a client signature.
+     * The `encryptedOtpBundle` is HPKE-sealed `{otp_code, public_key}` JSON
+     * (see `encryptOtpAttempt`). The auth proxy forwards the ciphertext to
+     * the TLS Fetcher enclave, which decrypts it, verifies the OTP code, and
+     * returns a `verificationToken` bound to the embedded public key.
+     *
+     * Pass the returned `verificationToken` to `/auth/login/otp` along with
+     * a client signature to complete the login.
      */
     async verifyOtp(
       params: AuthProxyVerifyOtpRequest,
     ): Promise<AuthProxyVerifyOtpResponse> {
-      return request<AuthProxyVerifyOtpResponse>('/v1/otp_verify', params)
+      return request<AuthProxyVerifyOtpResponse>('/v1/otp_verify_v2', params)
     },
   }
 }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -3,3 +3,11 @@ export const DEFAULT_IFRAME_CONTAINER_ID = 'turnkey-auth-iframe-container-id'
 export const DEFAULT_IFRAME_ELEMENT_ID = 'turnkey-default-iframe-element-id'
 export const DEFAULT_ORGANIZATION_ID = '0d98e826-dd8f-44ca-a585-3afcd27d4002'
 export const KMS_SERVER_URL = 'https://kms.staging.zerodev.app'
+
+// Pinned ECDSA P-256 public key (uncompressed, 65 bytes hex) of Turnkey's
+// TLS Fetcher Sign enclave. Used to verify the signature on the OTP encryption
+// target bundle returned by /auth/init/otp before HPKE-encrypting the OTP
+// attempt. The bundle's `dataSignature` is verified against this key, so a
+// compromised proxy cannot substitute its own ephemeral key.
+export const TURNKEY_TLS_FETCHER_SIGN_PUBLIC_KEY =
+  '046b4f88421f76b6ba418afc2ea1d8ced671337d7db6b80478a60d8531bf8f17fa9a512f0fef96fc0c9b4cd9dff70b34992e520ce04c79d931f6ff6296b547d201'

--- a/packages/core/src/core/createZeroDevWallet.ts
+++ b/packages/core/src/core/createZeroDevWallet.ts
@@ -25,6 +25,7 @@ import {
 } from '../storage/manager.js'
 import { SessionType, type ZeroDevWalletSession } from '../types/session.js'
 import { buildClientSignature } from '../utils/buildClientSignature.js'
+import { encryptOtpAttempt } from '../utils/encryptOtpAttempt.js'
 import {
   base64UrlEncode,
   generateCompressedPublicKeyFromKeyPair,
@@ -72,6 +73,11 @@ export type AuthParams =
       mode: 'verifyOtp'
       otpId: string
       otpCode: string
+      /**
+       * The encryption target bundle returned by the matching `sendOtp` call.
+       * Required — used to HPKE-encrypt the OTP attempt to the enclave.
+       */
+      otpEncryptionTargetBundle: string
     }
   | {
       type: 'magicLink'
@@ -85,6 +91,11 @@ export type AuthParams =
       mode: 'verify'
       otpId: string
       code: string
+      /**
+       * The encryption target bundle returned by the matching `sendMagicLink`
+       * (a.k.a. magicLink `send`) call. Required for the encrypted-OTP flow.
+       */
+      otpEncryptionTargetBundle: string
     }
 
 export interface ZeroDevWalletSDK {
@@ -379,6 +390,7 @@ export async function createZeroDevWallet(
                 mode: 'verifyOtp',
                 otpId: params.otpId,
                 otpCode: params.code,
+                otpEncryptionTargetBundle: params.otpEncryptionTargetBundle,
               }
             }
           } else {
@@ -401,7 +413,7 @@ export async function createZeroDevWallet(
           }
 
           if (otpParams.mode === 'verifyOtp') {
-            const { otpId, otpCode } = otpParams
+            const { otpId, otpCode, otpEncryptionTargetBundle } = otpParams
 
             // Step 1: Generate new key pair
             await client.indexedDbStamper.resetKeyPair()
@@ -411,7 +423,15 @@ export async function createZeroDevWallet(
               throw new Error('Failed to get public key')
             }
 
-            // Step 2: Verify OTP via Auth Proxy
+            // Step 2a: HPKE-seal the OTP attempt to the enclave's per-session
+            // target key. The auth proxy never sees the plaintext OTP code.
+            const encryptedOtpBundle = await encryptOtpAttempt({
+              otpCode,
+              publicKey: targetPublicKey,
+              encryptionTargetBundle: otpEncryptionTargetBundle,
+            })
+
+            // Step 2b: Verify OTP via Auth Proxy
             if (!cachedAuthProxyConfigId) {
               const { authProxyConfigId } = await client.getAuthProxyConfigId()
               cachedAuthProxyConfigId = authProxyConfigId
@@ -422,8 +442,7 @@ export async function createZeroDevWallet(
 
             const { verificationToken } = await authProxyClient.verifyOtp({
               otpId,
-              otpCode,
-              public_key: targetPublicKey,
+              encryptedOtpBundle,
             })
 
             // Step 3: Build client signature

--- a/packages/core/src/utils/encryptOtpAttempt.test.ts
+++ b/packages/core/src/utils/encryptOtpAttempt.test.ts
@@ -1,0 +1,201 @@
+import { p256 } from '@noble/curves/nist.js'
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js'
+import { describe, expect, it } from 'vitest'
+import { encryptOtpAttempt } from './encryptOtpAttempt.js'
+
+/**
+ * Build a v1 encryption target bundle signed by `signerSk`. Returns the JSON
+ * envelope as a string plus the (uncompressed) HPKE target pubkey hex —
+ * the latter so tests can decrypt and verify if they want to (we don't,
+ * but exposing it makes the helper less magical).
+ */
+function buildBundle({
+  signerSk,
+  signerPubHex,
+  targetPublicHex,
+  organizationId = 'test-org',
+  version = 'v1.0.0',
+  tamperSignature = false,
+  tamperData = false,
+}: {
+  signerSk: Uint8Array
+  signerPubHex: string
+  targetPublicHex: string
+  organizationId?: string
+  version?: string
+  tamperSignature?: boolean
+  tamperData?: boolean
+}): string {
+  const signedData = JSON.stringify({
+    targetPublic: targetPublicHex,
+    organizationId,
+    userId: '',
+  })
+  const dataBytes = new TextEncoder().encode(signedData)
+  const dataHex = bytesToHex(tamperData ? flipFirstByte(dataBytes) : dataBytes)
+
+  const sigBytes = p256.sign(dataBytes, signerSk, {
+    prehash: true,
+    format: 'der',
+    lowS: false,
+  })
+  const dataSignature = bytesToHex(
+    tamperSignature ? flipFirstByte(sigBytes) : sigBytes,
+  )
+
+  return JSON.stringify({
+    version,
+    data: dataHex,
+    dataSignature,
+    enclaveQuorumPublic: signerPubHex,
+  })
+}
+
+function flipFirstByte(b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(b)
+  out[0] ^= 0x01
+  return out
+}
+
+async function generateTargetPubHex(): Promise<string> {
+  const pair = (await crypto.subtle.generateKey(
+    { name: 'ECDH', namedCurve: 'P-256' },
+    true,
+    ['deriveBits'],
+  )) as CryptoKeyPair
+  const raw = new Uint8Array(
+    await crypto.subtle.exportKey('raw', pair.publicKey),
+  )
+  return bytesToHex(raw)
+}
+
+describe('encryptOtpAttempt', () => {
+  it('produces a valid clientSendMsg for a well-formed bundle', async () => {
+    const { secretKey: signerSk, publicKey: signerPub } = p256.keygen()
+    const signerPubHex = bytesToHex(p256.getPublicKey(signerSk, false))
+    void signerPub // consumed via signerPubHex
+
+    const targetPublicHex = await generateTargetPubHex()
+    const bundle = buildBundle({
+      signerSk,
+      signerPubHex,
+      targetPublicHex,
+    })
+
+    const out = await encryptOtpAttempt({
+      otpCode: '123456',
+      publicKey:
+        '02aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899',
+      encryptionTargetBundle: bundle,
+      dangerouslyOverrideSignerPublicKey: signerPubHex,
+    })
+
+    const parsed = JSON.parse(out)
+    expect(typeof parsed.encappedPublic).toBe('string')
+    expect(typeof parsed.ciphertext).toBe('string')
+
+    // encappedPublic = uncompressed P-256 = 65 bytes = 130 hex chars, leading 04
+    expect(parsed.encappedPublic.length).toBe(130)
+    expect(parsed.encappedPublic.slice(0, 2)).toBe('04')
+
+    // ciphertext = plaintext + 16-byte AES-GCM tag. Plaintext is JSON of
+    // { otp_code, public_key }; we don't pin the exact length but it must be
+    // at least 16 (tag-only) and divisible by 2 hex chars.
+    expect(hexToBytes(parsed.ciphertext).length).toBeGreaterThan(16)
+  })
+
+  it('rejects a bundle whose enclaveQuorumPublic does not match the pinned key', async () => {
+    const { secretKey: signerSk } = p256.keygen()
+    const signerPubHex = bytesToHex(p256.getPublicKey(signerSk, false))
+    const targetPublicHex = await generateTargetPubHex()
+    const bundle = buildBundle({ signerSk, signerPubHex, targetPublicHex })
+
+    // Override with a different pubkey to simulate the real pinned key not
+    // matching the bundle's claimed quorum key.
+    const { secretKey: otherSk } = p256.keygen()
+    const otherPubHex = bytesToHex(p256.getPublicKey(otherSk, false))
+
+    await expect(
+      encryptOtpAttempt({
+        otpCode: '123456',
+        publicKey: '02aa',
+        encryptionTargetBundle: bundle,
+        dangerouslyOverrideSignerPublicKey: otherPubHex,
+      }),
+    ).rejects.toThrow(/does not match pinned signing key/)
+  })
+
+  it('rejects a tampered signature', async () => {
+    const { secretKey: signerSk } = p256.keygen()
+    const signerPubHex = bytesToHex(p256.getPublicKey(signerSk, false))
+    const targetPublicHex = await generateTargetPubHex()
+    const bundle = buildBundle({
+      signerSk,
+      signerPubHex,
+      targetPublicHex,
+      tamperSignature: true,
+    })
+
+    await expect(
+      encryptOtpAttempt({
+        otpCode: '123456',
+        publicKey: '02aa',
+        encryptionTargetBundle: bundle,
+        dangerouslyOverrideSignerPublicKey: signerPubHex,
+      }),
+    ).rejects.toThrow(/invalid enclave signature/)
+  })
+
+  it('rejects a tampered data field (signature still over original)', async () => {
+    const { secretKey: signerSk } = p256.keygen()
+    const signerPubHex = bytesToHex(p256.getPublicKey(signerSk, false))
+    const targetPublicHex = await generateTargetPubHex()
+    const bundle = buildBundle({
+      signerSk,
+      signerPubHex,
+      targetPublicHex,
+      tamperData: true,
+    })
+
+    await expect(
+      encryptOtpAttempt({
+        otpCode: '123456',
+        publicKey: '02aa',
+        encryptionTargetBundle: bundle,
+        dangerouslyOverrideSignerPublicKey: signerPubHex,
+      }),
+    ).rejects.toThrow(/invalid enclave signature/)
+  })
+
+  it('rejects an unsupported bundle version', async () => {
+    const { secretKey: signerSk } = p256.keygen()
+    const signerPubHex = bytesToHex(p256.getPublicKey(signerSk, false))
+    const targetPublicHex = await generateTargetPubHex()
+    const bundle = buildBundle({
+      signerSk,
+      signerPubHex,
+      targetPublicHex,
+      version: 'v2.0.0',
+    })
+
+    await expect(
+      encryptOtpAttempt({
+        otpCode: '123456',
+        publicKey: '02aa',
+        encryptionTargetBundle: bundle,
+        dangerouslyOverrideSignerPublicKey: signerPubHex,
+      }),
+    ).rejects.toThrow(/unsupported bundle version/)
+  })
+
+  it('rejects malformed JSON bundle', async () => {
+    await expect(
+      encryptOtpAttempt({
+        otpCode: '123456',
+        publicKey: '02aa',
+        encryptionTargetBundle: 'not json',
+        dangerouslyOverrideSignerPublicKey: '04aa',
+      }),
+    ).rejects.toThrow(/failed to parse encryption target bundle/)
+  })
+})

--- a/packages/core/src/utils/encryptOtpAttempt.ts
+++ b/packages/core/src/utils/encryptOtpAttempt.ts
@@ -1,0 +1,142 @@
+/**
+ * Wraps the OTP code + client public key in a Turnkey-compatible HPKE bundle
+ * for the `/v1/otp_verify_v2` auth-proxy endpoint.
+ *
+ * Bundle flow (RFC 9180 mode_base over Turnkey's TLS Fetcher enclave):
+ *   1. The backend's /init/otp returns a signed envelope that contains an
+ *      ephemeral HPKE public key (`targetPublic`) generated fresh by the
+ *      enclave for this OTP attempt.
+ *   2. We verify the envelope's ECDSA signature against a pinned production
+ *      key (`TURNKEY_TLS_FETCHER_SIGN_PUBLIC_KEY`) so a compromised proxy
+ *      cannot substitute its own ephemeral key.
+ *   3. We HPKE-seal `{otp_code, public_key}` to `targetPublic`. The auth proxy
+ *      forwards the ciphertext to the enclave; only the enclave can decrypt
+ *      it. The enclave then issues a `verificationToken` bound to the public
+ *      key embedded in the plaintext.
+ *
+ * See: tkhq/go-sdk `examples/email_otp` and `pkg/enclave_encrypt`.
+ */
+
+import { p256 } from '@noble/curves/nist.js'
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js'
+import { TURNKEY_TLS_FETCHER_SIGN_PUBLIC_KEY } from '../constants.js'
+import { hpkeSealP256 } from './hpke.js'
+
+const BUNDLE_DATA_VERSION = 'v1.0.0'
+
+type EncryptionTargetEnvelope = {
+  version: string
+  /** Hex-encoded JSON: `{ targetPublic, organizationId, userId? }` */
+  data: string
+  /** Hex-encoded ECDSA-P256 signature over the raw `data` bytes (DER). */
+  dataSignature: string
+  /** Hex-encoded uncompressed P-256 pubkey of the signing enclave. */
+  enclaveQuorumPublic: string
+}
+
+type SignedTargetData = {
+  targetPublic: string
+  organizationId?: string
+  userId?: string
+}
+
+export type EncryptOtpAttemptParams = {
+  /** The OTP code the user entered. */
+  otpCode: string
+  /**
+   * The client's session public key (compressed P-256 hex). The enclave binds
+   * this key into the `verificationToken` it issues.
+   */
+  publicKey: string
+  /** The signed envelope returned by `/auth/init/otp`. */
+  encryptionTargetBundle: string
+  /**
+   * Test-only override for the pinned signing key. Production callers should
+   * leave this undefined; it exists so tests don't have to use the real key.
+   */
+  dangerouslyOverrideSignerPublicKey?: string
+}
+
+/**
+ * Returns a JSON string ready to be sent as `encryptedOtpBundle` on
+ * `POST /v1/otp_verify_v2`.
+ */
+export async function encryptOtpAttempt({
+  otpCode,
+  publicKey,
+  encryptionTargetBundle,
+  dangerouslyOverrideSignerPublicKey,
+}: EncryptOtpAttemptParams): Promise<string> {
+  const expectedSignerHex =
+    dangerouslyOverrideSignerPublicKey ?? TURNKEY_TLS_FETCHER_SIGN_PUBLIC_KEY
+
+  let envelope: EncryptionTargetEnvelope
+  try {
+    envelope = JSON.parse(encryptionTargetBundle)
+  } catch (err) {
+    throw new Error(
+      `encryptOtpAttempt: failed to parse encryption target bundle: ${(err as Error).message}`,
+    )
+  }
+
+  if (envelope.version !== BUNDLE_DATA_VERSION) {
+    throw new Error(
+      `encryptOtpAttempt: unsupported bundle version ${envelope.version}`,
+    )
+  }
+
+  if (
+    envelope.enclaveQuorumPublic.toLowerCase() !==
+    expectedSignerHex.toLowerCase()
+  ) {
+    throw new Error(
+      'encryptOtpAttempt: enclave quorum public key does not match pinned signing key',
+    )
+  }
+
+  const dataBytes = hexToBytes(envelope.data)
+  const signatureBytes = hexToBytes(envelope.dataSignature)
+  const signerPublicKeyBytes = hexToBytes(envelope.enclaveQuorumPublic)
+
+  // The Go side does sha256(data) then ASN.1 DER ECDSA verify, without
+  // enforcing low-S. Match that here.
+  const valid = p256.verify(signatureBytes, dataBytes, signerPublicKeyBytes, {
+    prehash: true,
+    format: 'der',
+    lowS: false,
+  })
+  if (!valid) {
+    throw new Error('encryptOtpAttempt: invalid enclave signature on bundle')
+  }
+
+  let signedData: SignedTargetData
+  try {
+    signedData = JSON.parse(new TextDecoder().decode(dataBytes))
+  } catch (err) {
+    throw new Error(
+      `encryptOtpAttempt: failed to parse signed bundle data: ${(err as Error).message}`,
+    )
+  }
+  if (!signedData.targetPublic) {
+    throw new Error('encryptOtpAttempt: missing targetPublic in signed data')
+  }
+
+  const targetPublicKey = hexToBytes(signedData.targetPublic)
+
+  // Plaintext shape matches what the Go example marshals:
+  //   { otp_code: string, public_key: string }
+  const plaintext = new TextEncoder().encode(
+    JSON.stringify({ otp_code: otpCode, public_key: publicKey }),
+  )
+
+  const { encappedPublic, ciphertext } = await hpkeSealP256({
+    receiverPublicKey: targetPublicKey,
+    plaintext,
+  })
+
+  // Wire format = the Go SDK's `ClientSendMsg`: Bytes fields hex-encoded.
+  return JSON.stringify({
+    encappedPublic: bytesToHex(encappedPublic),
+    ciphertext: bytesToHex(ciphertext),
+  })
+}

--- a/packages/core/src/utils/hpke.test.ts
+++ b/packages/core/src/utils/hpke.test.ts
@@ -1,0 +1,132 @@
+import {
+  Aes256Gcm,
+  CipherSuite,
+  DhkemP256HkdfSha256,
+  HkdfSha256,
+} from '@hpke/core'
+import { describe, expect, it } from 'vitest'
+import { hpkeSealP256 } from './hpke.js'
+
+const TURNKEY_HPKE_INFO = new TextEncoder().encode('turnkey_hpke')
+
+/**
+ * Reference round-trip helper: opens a Turnkey-style sealed payload using
+ * `@hpke/core`. The AAD shape (`enc || pkR`) and info string match what
+ * `hpkeSealP256` produces and what `enclave_encrypt.EnclaveEncryptServer`
+ * expects on the Go side.
+ */
+async function openWithHpkeCore({
+  recipientKey, // CryptoKeyPair, P-256
+  recipientPubRaw, // 65-byte uncompressed P-256 pubkey
+  encappedPublic,
+  ciphertext,
+}: {
+  recipientKey: CryptoKeyPair
+  recipientPubRaw: Uint8Array
+  encappedPublic: Uint8Array
+  ciphertext: Uint8Array
+}): Promise<Uint8Array> {
+  const suite = new CipherSuite({
+    kem: new DhkemP256HkdfSha256(),
+    kdf: new HkdfSha256(),
+    aead: new Aes256Gcm(),
+  })
+  const recipient = await suite.createRecipientContext({
+    recipientKey: recipientKey.privateKey,
+    enc: encappedPublic.buffer.slice(
+      encappedPublic.byteOffset,
+      encappedPublic.byteOffset + encappedPublic.byteLength,
+    ),
+    info: TURNKEY_HPKE_INFO.buffer.slice(
+      TURNKEY_HPKE_INFO.byteOffset,
+      TURNKEY_HPKE_INFO.byteOffset + TURNKEY_HPKE_INFO.byteLength,
+    ),
+  })
+
+  const aad = new Uint8Array(encappedPublic.length + recipientPubRaw.length)
+  aad.set(encappedPublic, 0)
+  aad.set(recipientPubRaw, encappedPublic.length)
+
+  const pt = await recipient.open(
+    ciphertext.buffer.slice(
+      ciphertext.byteOffset,
+      ciphertext.byteOffset + ciphertext.byteLength,
+    ),
+    aad.buffer.slice(aad.byteOffset, aad.byteOffset + aad.byteLength),
+  )
+  return new Uint8Array(pt)
+}
+
+async function generateRecipientKey(): Promise<{
+  pair: CryptoKeyPair
+  raw: Uint8Array
+}> {
+  const pair = (await crypto.subtle.generateKey(
+    { name: 'ECDH', namedCurve: 'P-256' },
+    /* extractable */ true,
+    ['deriveBits'],
+  )) as CryptoKeyPair
+  const raw = new Uint8Array(
+    await crypto.subtle.exportKey('raw', pair.publicKey),
+  )
+  return { pair, raw }
+}
+
+describe('hpkeSealP256', () => {
+  it('produces a 65-byte encappedPublic and ciphertext = plaintext + 16-byte tag', async () => {
+    const { raw } = await generateRecipientKey()
+    const plaintext = new TextEncoder().encode('hello turnkey')
+
+    const { encappedPublic, ciphertext } = await hpkeSealP256({
+      receiverPublicKey: raw,
+      plaintext,
+    })
+
+    expect(encappedPublic.length).toBe(65)
+    expect(encappedPublic[0]).toBe(0x04) // SEC1 uncompressed prefix
+    expect(ciphertext.length).toBe(plaintext.length + 16) // GCM tag is 16 bytes
+  })
+
+  it('round-trips against @hpke/core (Turnkey suite + AAD shape)', async () => {
+    const { pair, raw } = await generateRecipientKey()
+    const plaintext = new TextEncoder().encode(
+      JSON.stringify({ otp_code: '123456', public_key: '0204aabb...' }),
+    )
+
+    const sealed = await hpkeSealP256({
+      receiverPublicKey: raw,
+      plaintext,
+    })
+
+    const opened = await openWithHpkeCore({
+      recipientKey: pair,
+      recipientPubRaw: raw,
+      encappedPublic: sealed.encappedPublic,
+      ciphertext: sealed.ciphertext,
+    })
+
+    expect(new TextDecoder().decode(opened)).toBe(
+      new TextDecoder().decode(plaintext),
+    )
+  })
+
+  it('produces different ciphertexts on each call (ephemeral key randomness)', async () => {
+    const { raw } = await generateRecipientKey()
+    const plaintext = new TextEncoder().encode('same input')
+
+    const a = await hpkeSealP256({ receiverPublicKey: raw, plaintext })
+    const b = await hpkeSealP256({ receiverPublicKey: raw, plaintext })
+
+    expect(a.encappedPublic).not.toEqual(b.encappedPublic)
+    expect(a.ciphertext).not.toEqual(b.ciphertext)
+  })
+
+  it('rejects a non-65-byte receiver public key', async () => {
+    await expect(
+      hpkeSealP256({
+        receiverPublicKey: new Uint8Array(33), // compressed, wrong size
+        plaintext: new Uint8Array(),
+      }),
+    ).rejects.toThrow(/65 bytes/)
+  })
+})

--- a/packages/core/src/utils/hpke.ts
+++ b/packages/core/src/utils/hpke.ts
@@ -1,0 +1,245 @@
+/**
+ * HPKE (RFC 9180) seal for Turnkey enclave-encrypted requests.
+ *
+ * Suite: DHKEM(P-256, HKDF-SHA256) / HKDF-SHA256 / AES-256-GCM
+ *   - KEM ID  = 0x0010 (DHKEM-P256-HKDF-SHA256)
+ *   - KDF ID  = 0x0001 (HKDF-SHA256)
+ *   - AEAD ID = 0x0002 (AES-256-GCM)
+ *
+ * Wire format and AAD construction match Turnkey's enclave_encrypt Go package:
+ *   info = "turnkey_hpke"
+ *   aad  = enc || pkR  (both 65-byte uncompressed P-256 points)
+ *
+ * References:
+ *   - RFC 9180 §4 / §5
+ *   - tkhq/go-sdk/pkg/enclave_encrypt
+ */
+
+import { p256 } from '@noble/curves/nist.js'
+import { expand, extract } from '@noble/hashes/hkdf.js'
+import { sha256 } from '@noble/hashes/sha2.js'
+
+const KEM_ID = 0x0010
+const KDF_ID = 0x0001
+const AEAD_ID = 0x0002
+
+// Output sizes for the chosen primitives.
+const NH = 32 // SHA-256 output
+const NK = 32 // AES-256 key
+const NN = 12 // AES-GCM nonce
+const NPK = 65 // uncompressed P-256 point: 0x04 || X || Y
+
+const TURNKEY_HPKE_INFO = new TextEncoder().encode('turnkey_hpke')
+
+const HPKE_VERSION = new TextEncoder().encode('HPKE-v1')
+
+// suite_id for the HPKE context: "HPKE" || I2OSP(KEM,2) || I2OSP(KDF,2) || I2OSP(AEAD,2)
+const HPKE_SUITE_ID = concat(
+  new TextEncoder().encode('HPKE'),
+  i2osp(KEM_ID, 2),
+  i2osp(KDF_ID, 2),
+  i2osp(AEAD_ID, 2),
+)
+
+// suite_id for the KEM scope: "KEM" || I2OSP(KEM,2)
+const KEM_SUITE_ID = concat(new TextEncoder().encode('KEM'), i2osp(KEM_ID, 2))
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, p) => sum + p.length, 0)
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const p of parts) {
+    out.set(p, offset)
+    offset += p.length
+  }
+  return out
+}
+
+function i2osp(n: number, len: number): Uint8Array {
+  const out = new Uint8Array(len)
+  for (let i = len - 1; i >= 0; i--) {
+    out[i] = n & 0xff
+    n >>>= 8
+  }
+  return out
+}
+
+// LabeledExtract(salt, label, ikm, suite_id) =
+//   HKDF-Extract(salt, "HPKE-v1" || suite_id || label || ikm)
+function labeledExtract(
+  salt: Uint8Array,
+  label: string,
+  ikm: Uint8Array,
+  suiteId: Uint8Array,
+): Uint8Array {
+  const labeledIkm = concat(
+    HPKE_VERSION,
+    suiteId,
+    new TextEncoder().encode(label),
+    ikm,
+  )
+  return extract(sha256, labeledIkm, salt)
+}
+
+// LabeledExpand(prk, label, info, L, suite_id) =
+//   HKDF-Expand(prk, I2OSP(L,2) || "HPKE-v1" || suite_id || label || info, L)
+function labeledExpand(
+  prk: Uint8Array,
+  label: string,
+  info: Uint8Array,
+  length: number,
+  suiteId: Uint8Array,
+): Uint8Array {
+  const labeledInfo = concat(
+    i2osp(length, 2),
+    HPKE_VERSION,
+    suiteId,
+    new TextEncoder().encode(label),
+    info,
+  )
+  return expand(sha256, prk, labeledInfo, length)
+}
+
+// DHKEM Encap: returns (sharedSecret, enc)
+// sharedSecret is 32 bytes; enc is the serialized ephemeral pubkey (65 bytes uncompressed).
+function encap(receiverPublicKey: Uint8Array): {
+  sharedSecret: Uint8Array
+  enc: Uint8Array
+} {
+  const ephSk = p256.utils.randomSecretKey()
+  const ephPkUncompressed = p256.getPublicKey(ephSk, false)
+
+  // ECDH: returns the serialized shared point. Pass isCompressed=true so the
+  // first byte is the SEC1 prefix and bytes [1, 33) are the x-coordinate.
+  const sharedPoint = p256.getSharedSecret(
+    ephSk,
+    receiverPublicKey,
+    /* isCompressed */ true,
+  )
+  const dh = sharedPoint.slice(1, 33)
+
+  const kemContext = concat(ephPkUncompressed, receiverPublicKey)
+
+  const eaePrk = labeledExtract(new Uint8Array(0), 'eae_prk', dh, KEM_SUITE_ID)
+  const sharedSecret = labeledExpand(
+    eaePrk,
+    'shared_secret',
+    kemContext,
+    NH,
+    KEM_SUITE_ID,
+  )
+
+  return { sharedSecret, enc: ephPkUncompressed }
+}
+
+// KeySchedule for mode_base: returns (key, base_nonce).
+function keySchedule(
+  sharedSecret: Uint8Array,
+  info: Uint8Array,
+): { key: Uint8Array; baseNonce: Uint8Array } {
+  const empty = new Uint8Array(0)
+
+  const pskIdHash = labeledExtract(empty, 'psk_id_hash', empty, HPKE_SUITE_ID)
+  const infoHash = labeledExtract(empty, 'info_hash', info, HPKE_SUITE_ID)
+
+  // mode_base = 0x00 prepended to (psk_id_hash || info_hash)
+  const keyScheduleContext = concat(new Uint8Array([0]), pskIdHash, infoHash)
+
+  const secret = labeledExtract(sharedSecret, 'secret', empty, HPKE_SUITE_ID)
+
+  const key = labeledExpand(
+    secret,
+    'key',
+    keyScheduleContext,
+    NK,
+    HPKE_SUITE_ID,
+  )
+  const baseNonce = labeledExpand(
+    secret,
+    'base_nonce',
+    keyScheduleContext,
+    NN,
+    HPKE_SUITE_ID,
+  )
+
+  return { key, baseNonce }
+}
+
+// Web Crypto's BufferSource type rejects `Uint8Array<ArrayBufferLike>` (which
+// noble/v2 returns) under strict TS lib settings because the underlying buffer
+// could in principle be a SharedArrayBuffer. Copy into a fresh ArrayBuffer to
+// satisfy the type.
+function toArrayBuffer(u8: Uint8Array): ArrayBuffer {
+  const out = new ArrayBuffer(u8.byteLength)
+  new Uint8Array(out).set(u8)
+  return out
+}
+
+async function aesGcmSeal(
+  key: Uint8Array,
+  nonce: Uint8Array,
+  aad: Uint8Array,
+  plaintext: Uint8Array,
+): Promise<Uint8Array> {
+  // Web Crypto returns ciphertext || tag (16 bytes appended). Matches the
+  // single-blob format Turnkey's `Sealer.Seal` produces.
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    toArrayBuffer(key),
+    { name: 'AES-GCM' },
+    /* extractable */ false,
+    ['encrypt'],
+  )
+  const ct = await crypto.subtle.encrypt(
+    {
+      name: 'AES-GCM',
+      iv: toArrayBuffer(nonce),
+      additionalData: toArrayBuffer(aad),
+      tagLength: 128,
+    },
+    cryptoKey,
+    toArrayBuffer(plaintext),
+  )
+  return new Uint8Array(ct)
+}
+
+export type HpkeSealResult = {
+  /** Ephemeral sender public key (uncompressed P-256, 65 bytes). */
+  encappedPublic: Uint8Array
+  /** AES-256-GCM ciphertext with a 16-byte authentication tag appended. */
+  ciphertext: Uint8Array
+}
+
+/**
+ * Single-shot HPKE seal in mode_base for Turnkey's TLS Fetcher enclave.
+ *
+ * Uses the fixed Turnkey `info = "turnkey_hpke"` and the AAD shape
+ * `enc || receiverPublicKey` so the resulting bundle is decryptable by
+ * `enclave_encrypt.EnclaveEncryptServer.Decrypt`.
+ *
+ * @param receiverPublicKey - The enclave's ephemeral target public key
+ *   (uncompressed P-256, 65 bytes), extracted from the encryption target bundle.
+ * @param plaintext - The bytes to encrypt (e.g. the JSON-encoded OTP attempt).
+ */
+export async function hpkeSealP256({
+  receiverPublicKey,
+  plaintext,
+}: {
+  receiverPublicKey: Uint8Array
+  plaintext: Uint8Array
+}): Promise<HpkeSealResult> {
+  if (receiverPublicKey.length !== NPK) {
+    throw new Error(
+      `hpkeSealP256: receiverPublicKey must be ${NPK} bytes (uncompressed P-256), got ${receiverPublicKey.length}`,
+    )
+  }
+
+  const { sharedSecret, enc } = encap(receiverPublicKey)
+  const { key, baseNonce } = keySchedule(sharedSecret, TURNKEY_HPKE_INFO)
+
+  // First message of the context, sequence 0 → nonce = base_nonce.
+  const aad = concat(enc, receiverPublicKey)
+  const ciphertext = await aesGcmSeal(key, baseNonce, aad, plaintext)
+
+  return { encappedPublic: enc, ciphertext }
+}

--- a/packages/react-kit/src/auth/authStoreSlice.test.ts
+++ b/packages/react-kit/src/auth/authStoreSlice.test.ts
@@ -148,7 +148,10 @@ describe('authStoreSlice', () => {
       store.getState().auth.initialize(config)
 
       store.getState().auth.setEmail('test@example.com')
-      store.getState().auth.setOtpId('otp-123')
+      store.getState().auth.setOtpSession({
+        otpId: 'otp-123',
+        otpEncryptionTargetBundle: 'bundle-123',
+      })
       store.getState().auth.goToStep('email-verification')
       store.getState().auth.goToStep('otp-input')
 
@@ -185,23 +188,39 @@ describe('authStoreSlice', () => {
     })
   })
 
-  describe('setOtpId', () => {
-    it('sets the otpId', () => {
+  describe('setOtpSession', () => {
+    it('sets otpId and otpEncryptionTargetBundle together', () => {
       const store = createStore()
 
-      store.getState().auth.setOtpId('otp-abc-123')
+      store.getState().auth.setOtpSession({
+        otpId: 'otp-abc-123',
+        otpEncryptionTargetBundle: 'bundle-abc',
+      })
 
       expect(store.getState().auth.otpId).toBe('otp-abc-123')
+      expect(store.getState().auth.otpEncryptionTargetBundle).toBe('bundle-abc')
     })
 
-    it('updates otpId value', () => {
+    it('replaces previous values on subsequent calls', () => {
       const store = createStore()
 
-      store.getState().auth.setOtpId('otp-first')
+      store.getState().auth.setOtpSession({
+        otpId: 'otp-first',
+        otpEncryptionTargetBundle: 'bundle-first',
+      })
       expect(store.getState().auth.otpId).toBe('otp-first')
+      expect(store.getState().auth.otpEncryptionTargetBundle).toBe(
+        'bundle-first',
+      )
 
-      store.getState().auth.setOtpId('otp-second')
+      store.getState().auth.setOtpSession({
+        otpId: 'otp-second',
+        otpEncryptionTargetBundle: 'bundle-second',
+      })
       expect(store.getState().auth.otpId).toBe('otp-second')
+      expect(store.getState().auth.otpEncryptionTargetBundle).toBe(
+        'bundle-second',
+      )
     })
   })
 
@@ -221,7 +240,10 @@ describe('authStoreSlice', () => {
       expect(store.getState().auth.step).toBe('email-verification')
 
       // OTP sent
-      store.getState().auth.setOtpId('otp-123')
+      store.getState().auth.setOtpSession({
+        otpId: 'otp-123',
+        otpEncryptionTargetBundle: 'bundle-123',
+      })
       store.getState().auth.goToStep('otp-input')
       expect(store.getState().auth.step).toBe('otp-input')
 
@@ -253,7 +275,10 @@ describe('authStoreSlice', () => {
       store.getState().auth.goToStep('sign-up')
       store.getState().auth.setEmail('user@example.com')
       store.getState().auth.goToStep('email-verification')
-      store.getState().auth.setOtpId('otp-123')
+      store.getState().auth.setOtpSession({
+        otpId: 'otp-123',
+        otpEncryptionTargetBundle: 'bundle-123',
+      })
       store.getState().auth.goToStep('otp-input')
 
       // User goes back to change email
@@ -275,7 +300,10 @@ describe('authStoreSlice', () => {
       store.getState().auth.initialize(config)
       store.getState().auth.setEmail('user@example.com')
       store.getState().auth.goToStep('email-verification')
-      store.getState().auth.setOtpId('otp-123')
+      store.getState().auth.setOtpSession({
+        otpId: 'otp-123',
+        otpEncryptionTargetBundle: 'bundle-123',
+      })
       store.getState().auth.goToStep('otp-input')
 
       // Error occurs
@@ -326,7 +354,10 @@ describe('authStoreSlice', () => {
 
       store.subscribe((state) => state.auth.email, listener)
 
-      store.getState().auth.setOtpId('otp-123')
+      store.getState().auth.setOtpSession({
+        otpId: 'otp-123',
+        otpEncryptionTargetBundle: 'bundle-123',
+      })
       expect(listener).not.toHaveBeenCalled()
     })
   })

--- a/packages/react-kit/src/auth/authStoreSlice.ts
+++ b/packages/react-kit/src/auth/authStoreSlice.ts
@@ -10,7 +10,16 @@ export interface AuthStoreSlice {
     email: string | null
     setEmail: (email: string) => void
     otpId: string | null
-    setOtpId: (otpId: string) => void
+    /**
+     * HPKE encryption target bundle returned by the latest `sendOTP` call.
+     * Required by `verifyOTP` so the OTP attempt can be sealed to the enclave.
+     */
+    otpEncryptionTargetBundle: string | null
+    /** Set both fields produced by `sendOTP` together. */
+    setOtpSession: (input: {
+      otpId: string
+      otpEncryptionTargetBundle: string
+    }) => void
     config: AuthConfig | null
 
     // Actions
@@ -34,6 +43,7 @@ export const createAuthStoreSlice: StateCreator<
     enabledMethods: [],
     email: null,
     otpId: null,
+    otpEncryptionTargetBundle: null,
     config: null,
 
     // Actions
@@ -78,6 +88,7 @@ export const createAuthStoreSlice: StateCreator<
           stepHistory: [],
           email: null,
           otpId: null,
+          otpEncryptionTargetBundle: null,
         },
       }))
     },
@@ -91,11 +102,12 @@ export const createAuthStoreSlice: StateCreator<
       }))
     },
 
-    setOtpId: (otpId) => {
+    setOtpSession: ({ otpId, otpEncryptionTargetBundle }) => {
       set((state) => ({
         auth: {
           ...state.auth,
           otpId,
+          otpEncryptionTargetBundle,
         },
       }))
     },

--- a/packages/react-kit/src/auth/hooks/useAuth.test.ts
+++ b/packages/react-kit/src/auth/hooks/useAuth.test.ts
@@ -88,16 +88,20 @@ describe('useAuth', () => {
     expect(result.current.config).toEqual(config)
   })
 
-  it('returns email and otpId from store', () => {
+  it('returns email, otpId, and otpEncryptionTargetBundle from store', () => {
     const store = createStore()
     store.getState().auth.setEmail('user@example.com')
-    store.getState().auth.setOtpId('otp-123')
+    store.getState().auth.setOtpSession({
+      otpId: 'otp-123',
+      otpEncryptionTargetBundle: 'bundle-xyz',
+    })
     mockConnector.getKitStore.mockReturnValue(store)
 
     const { result } = renderHook(() => useAuth())
 
     expect(result.current.email).toBe('user@example.com')
     expect(result.current.otpId).toBe('otp-123')
+    expect(result.current.otpEncryptionTargetBundle).toBe('bundle-xyz')
   })
 
   it('exposes goToStep function', () => {
@@ -156,15 +160,19 @@ describe('useAuth', () => {
     expect(store.getState().auth.email).toBe('new@example.com')
   })
 
-  it('exposes setOtpId function', () => {
+  it('exposes setOtpSession function', () => {
     const store = createStore()
     mockConnector.getKitStore.mockReturnValue(store)
 
     const { result } = renderHook(() => useAuth())
 
-    result.current.setOtpId('otp-456')
+    result.current.setOtpSession({
+      otpId: 'otp-456',
+      otpEncryptionTargetBundle: 'bundle-456',
+    })
 
     expect(store.getState().auth.otpId).toBe('otp-456')
+    expect(store.getState().auth.otpEncryptionTargetBundle).toBe('bundle-456')
   })
 
   it('reactively updates when store changes', () => {
@@ -230,11 +238,15 @@ describe('useAuth', () => {
     expect(result.current.email).toBe('user@example.com')
     expect(result.current.step).toBe('email-verification')
 
-    // Set OTP ID
-    result.current.setOtpId('otp-123')
+    // Set OTP session
+    result.current.setOtpSession({
+      otpId: 'otp-123',
+      otpEncryptionTargetBundle: 'bundle-123',
+    })
     result.current.goToStep('otp-input')
     rerender()
     expect(result.current.otpId).toBe('otp-123')
+    expect(result.current.otpEncryptionTargetBundle).toBe('bundle-123')
     expect(result.current.step).toBe('otp-input')
 
     // Verify

--- a/packages/react-kit/src/auth/hooks/useAuth.ts
+++ b/packages/react-kit/src/auth/hooks/useAuth.ts
@@ -22,6 +22,10 @@ export function useAuth() {
   const step = useStore(store, (state) => state.auth.step)
   const email = useStore(store, (state) => state.auth.email)
   const otpId = useStore(store, (state) => state.auth.otpId)
+  const otpEncryptionTargetBundle = useStore(
+    store,
+    (state) => state.auth.otpEncryptionTargetBundle,
+  )
   const enabledMethods = useStore(store, (state) => state.auth.enabledMethods)
   const authConfig = useStore(store, (state) => state.auth.config)
 
@@ -29,12 +33,13 @@ export function useAuth() {
     step,
     email,
     otpId,
+    otpEncryptionTargetBundle,
     enabledMethods,
     config: authConfig,
     goToStep: store.getState().auth.goToStep,
     goBack: store.getState().auth.goBack,
     reset: store.getState().auth.reset,
     setEmail: store.getState().auth.setEmail,
-    setOtpId: store.getState().auth.setOtpId,
+    setOtpSession: store.getState().auth.setOtpSession,
   }
 }

--- a/packages/react-kit/src/auth/pages/EmailVerification.tsx
+++ b/packages/react-kit/src/auth/pages/EmailVerification.tsx
@@ -7,7 +7,7 @@ import { Text } from '../../shared/components/Text'
 import { useAuth } from '../hooks/useAuth'
 
 export function EmailVerification() {
-  const { email, setOtpId, goToStep } = useAuth()
+  const { email, setOtpSession, goToStep } = useAuth()
   const { mutateAsync: sendOtp, isPending: isSendOtpPending } = useSendOTP()
 
   const [secondsLeftUntilResend, setSecondsLeftUntilResend] = useState(60)
@@ -29,8 +29,8 @@ export function EmailVerification() {
     if (!email || !canResend) return
 
     try {
-      const { otpId } = await sendOtp({ email })
-      setOtpId(otpId)
+      const { otpId, otpEncryptionTargetBundle } = await sendOtp({ email })
+      setOtpSession({ otpId, otpEncryptionTargetBundle })
       setSecondsLeftUntilResend(60)
     } catch {
       // Error sending OTP

--- a/packages/react-kit/src/auth/pages/OtpInput.tsx
+++ b/packages/react-kit/src/auth/pages/OtpInput.tsx
@@ -8,7 +8,14 @@ import { CodeInput } from '../components/CodeInput'
 import { useAuth } from '../hooks/useAuth'
 
 export function OtpInput() {
-  const { email, otpId, setOtpId, goToStep, config } = useAuth()
+  const {
+    email,
+    otpId,
+    otpEncryptionTargetBundle,
+    setOtpSession,
+    goToStep,
+    config,
+  } = useAuth()
   const { mutateAsync: sendOtp, isPending: isSendOtpPending } = useSendOTP()
   const { mutateAsync: verifyOtp, isPending } = useVerifyOTP()
 
@@ -27,11 +34,15 @@ export function OtpInput() {
   }, [secondsUntilResend])
 
   const handleVerify = async () => {
-    if (!otp.trim() || !otpId) return
+    if (!otp.trim() || !otpId || !otpEncryptionTargetBundle) return
 
     setError(false)
     try {
-      await verifyOtp({ otpId, code: otp.trim() })
+      await verifyOtp({
+        otpId,
+        code: otp.trim(),
+        otpEncryptionTargetBundle,
+      })
       goToStep('authenticated')
       config?.onSuccess?.()
     } catch (err) {
@@ -48,8 +59,12 @@ export function OtpInput() {
     if (!email || secondsUntilResend > 0 || isSendOtpPending) return
 
     try {
-      const { otpId: newOtpId } = await sendOtp({ email })
-      setOtpId(newOtpId)
+      const { otpId: newOtpId, otpEncryptionTargetBundle: newBundle } =
+        await sendOtp({ email })
+      setOtpSession({
+        otpId: newOtpId,
+        otpEncryptionTargetBundle: newBundle,
+      })
       setSecondsUntilResend(60)
       setError(false)
     } catch {

--- a/packages/react-kit/src/auth/pages/SignUp.tsx
+++ b/packages/react-kit/src/auth/pages/SignUp.tsx
@@ -19,7 +19,7 @@ function isOAuthWindowClosedError(message: string): boolean {
 }
 
 export function SignUp() {
-  const { goToStep, setEmail, setOtpId, config } = useAuth()
+  const { goToStep, setEmail, setOtpSession, config } = useAuth()
   const [agreedToTerms, setAgreedToTerms] = useState(false)
   const [emailInput, setEmailInput] = useState('')
   const { mutateAsync: sendOtp, isPending: isEmailLoading } = useSendOTP()
@@ -60,9 +60,11 @@ export function SignUp() {
 
     setError(null)
     try {
-      const { otpId } = await sendOtp({ email: emailInput })
+      const { otpId, otpEncryptionTargetBundle } = await sendOtp({
+        email: emailInput,
+      })
       setEmail(emailInput)
-      setOtpId(otpId)
+      setOtpSession({ otpId, otpEncryptionTargetBundle })
       goToStep('email-verification')
     } catch (err) {
       setError(

--- a/packages/react-kit/src/auth/pages/Verifying.tsx
+++ b/packages/react-kit/src/auth/pages/Verifying.tsx
@@ -13,7 +13,7 @@ interface VerifyingProps {
 }
 
 export function Verifying({ otp, otpSource }: VerifyingProps) {
-  const { otpId, goToStep, config } = useAuth()
+  const { otpId, otpEncryptionTargetBundle, goToStep, config } = useAuth()
   const {
     mutate: verifyOtp,
     error: verificationError,
@@ -32,10 +32,24 @@ export function Verifying({ otp, otpSource }: VerifyingProps) {
 
   // Auto-verify when component mounts with OTP
   useEffect(() => {
-    if (!otpId || !otp || isVerificationLoading || verificationError) return
+    if (
+      !otpId ||
+      !otpEncryptionTargetBundle ||
+      !otp ||
+      isVerificationLoading ||
+      verificationError
+    )
+      return
 
-    verifyOtp({ otpId, code: otp })
-  }, [otpId, otp, isVerificationLoading, verificationError, verifyOtp])
+    verifyOtp({ otpId, code: otp, otpEncryptionTargetBundle })
+  }, [
+    otpId,
+    otpEncryptionTargetBundle,
+    otp,
+    isVerificationLoading,
+    verificationError,
+    verifyOtp,
+  ])
 
   return (
     <ScreenWrapper>

--- a/packages/react/src/actions.test.ts
+++ b/packages/react/src/actions.test.ts
@@ -271,16 +271,22 @@ describe('React Actions', () => {
       expect(authCall).not.toHaveProperty('emailCustomization')
     })
 
-    it('returns otpId from wallet auth', async () => {
+    it('returns otpId and otpEncryptionTargetBundle from wallet auth', async () => {
       const wallet = createMockWallet()
-      wallet.auth.mockResolvedValue({ otpId: 'otp-456' })
+      wallet.auth.mockResolvedValue({
+        otpId: 'otp-456',
+        otpEncryptionTargetBundle: 'bundle-from-auth',
+      })
       const store = createMockStore(wallet)
       const connector = createMockConnector(store)
       const config = createMockConfig(connector)
 
       const result = await sendOTP(config, { email: 'user@example.com' })
 
-      expect(result).toEqual({ otpId: 'otp-456' })
+      expect(result).toEqual({
+        otpId: 'otp-456',
+        otpEncryptionTargetBundle: 'bundle-from-auth',
+      })
     })
 
     it('includes email customization when provided', async () => {
@@ -323,13 +329,18 @@ describe('React Actions', () => {
       const connector = createMockConnector(store)
       const config = createMockConfig(connector)
 
-      await verifyOTP(config, { code: '123456', otpId: 'otp-123' })
+      await verifyOTP(config, {
+        code: '123456',
+        otpId: 'otp-123',
+        otpEncryptionTargetBundle: 'bundle-stub',
+      })
 
       expect(wallet.auth).toHaveBeenCalledWith({
         type: 'otp',
         mode: 'verifyOtp',
         otpId: 'otp-123',
         otpCode: '123456',
+        otpEncryptionTargetBundle: 'bundle-stub',
       })
     })
 
@@ -341,7 +352,11 @@ describe('React Actions', () => {
       const connector = createMockConnector(store)
       const config = createMockConfig(connector)
 
-      await verifyOTP(config, { code: '123456', otpId: 'otp-123' })
+      await verifyOTP(config, {
+        code: '123456',
+        otpId: 'otp-123',
+        otpEncryptionTargetBundle: 'bundle-stub',
+      })
 
       expect(store.getState().setEoaAccount).toHaveBeenCalledWith({
         address: '0xverified',
@@ -357,7 +372,11 @@ describe('React Actions', () => {
       const connector = createMockConnector(store)
       const config = createMockConfig(connector)
 
-      await verifyOTP(config, { code: '123456', otpId: 'otp-123' })
+      await verifyOTP(config, {
+        code: '123456',
+        otpId: 'otp-123',
+        otpEncryptionTargetBundle: 'bundle-stub',
+      })
 
       expect(wagmiConnect).toHaveBeenCalledWith(config, { connector })
     })
@@ -368,7 +387,11 @@ describe('React Actions', () => {
       const config = createMockConfig(connector)
 
       await expect(
-        verifyOTP(config, { code: '123456', otpId: 'otp-123' }),
+        verifyOTP(config, {
+          code: '123456',
+          otpId: 'otp-123',
+          otpEncryptionTargetBundle: 'bundle-stub',
+        }),
       ).rejects.toThrow('Wallet not initialized')
     })
   })

--- a/packages/react/src/actions.ts
+++ b/packages/react/src/actions.ts
@@ -218,7 +218,7 @@ export async function sendOTP(
     otpCodeCustomization?: { length: 6 | 7 | 8 | 9; alphanumeric: boolean }
     connector?: Connector
   },
-): Promise<{ otpId: string }> {
+): Promise<{ otpId: string; otpEncryptionTargetBundle: string }> {
   const connector = parameters.connector ?? getZeroDevConnector(config)
 
   // @ts-expect-error - getStore is a custom method
@@ -242,6 +242,7 @@ export async function sendOTP(
 
   return {
     otpId: result.otpId,
+    otpEncryptionTargetBundle: result.otpEncryptionTargetBundle,
   }
 }
 
@@ -252,7 +253,7 @@ export declare namespace sendOTP {
     otpCodeCustomization?: { length: 6 | 7 | 8 | 9; alphanumeric: boolean }
     connector?: Connector
   }
-  type ReturnType = { otpId: string }
+  type ReturnType = { otpId: string; otpEncryptionTargetBundle: string }
   type ErrorType = Error
 }
 
@@ -264,6 +265,8 @@ export async function verifyOTP(
   parameters: {
     code: string
     otpId: string
+    /** Encryption target bundle returned by the matching `sendOTP` call. */
+    otpEncryptionTargetBundle: string
     connector?: Connector
   },
 ): Promise<void> {
@@ -280,6 +283,7 @@ export async function verifyOTP(
     mode: 'verifyOtp',
     otpId: parameters.otpId,
     otpCode: parameters.code,
+    otpEncryptionTargetBundle: parameters.otpEncryptionTargetBundle,
   })
 
   const [session, eoaAccount] = await Promise.all([
@@ -298,6 +302,7 @@ export declare namespace verifyOTP {
   type Parameters = {
     code: string
     otpId: string
+    otpEncryptionTargetBundle: string
     connector?: Connector
   }
   type ReturnType = void
@@ -515,7 +520,7 @@ export async function sendMagicLink(
     otpCodeCustomization?: { length: 6 | 7 | 8 | 9; alphanumeric: boolean }
     connector?: Connector
   },
-): Promise<{ otpId: string }> {
+): Promise<{ otpId: string; otpEncryptionTargetBundle: string }> {
   const connector = parameters.connector ?? getZeroDevConnector(config)
 
   // @ts-expect-error - getStore is a custom method
@@ -536,6 +541,7 @@ export async function sendMagicLink(
 
   return {
     otpId: result.otpId,
+    otpEncryptionTargetBundle: result.otpEncryptionTargetBundle,
   }
 }
 
@@ -546,7 +552,7 @@ export declare namespace sendMagicLink {
     otpCodeCustomization?: { length: 6 | 7 | 8 | 9; alphanumeric: boolean }
     connector?: Connector
   }
-  type ReturnType = { otpId: string }
+  type ReturnType = { otpId: string; otpEncryptionTargetBundle: string }
   type ErrorType = Error
 }
 
@@ -558,6 +564,8 @@ export async function verifyMagicLink(
   parameters: {
     otpId: string
     code: string
+    /** Encryption target bundle returned by the matching `sendMagicLink` call. */
+    otpEncryptionTargetBundle: string
     connector?: Connector
   },
 ): Promise<void> {
@@ -574,6 +582,7 @@ export async function verifyMagicLink(
     mode: 'verify',
     otpId: parameters.otpId,
     code: parameters.code,
+    otpEncryptionTargetBundle: parameters.otpEncryptionTargetBundle,
   })
 
   const [session, eoaAccount] = await Promise.all([
@@ -592,6 +601,7 @@ export declare namespace verifyMagicLink {
   type Parameters = {
     otpId: string
     code: string
+    otpEncryptionTargetBundle: string
     connector?: Connector
   }
   type ReturnType = void

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 20.19.11
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@20.19.11)(happy-dom@20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.1))
+        version: 4.0.18(vitest@4.0.18(@types/node@20.19.11)(happy-dom@20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.1))
       happy-dom:
         specifier: ^20.6.0
         version: 20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -43,7 +43,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@20.19.11)(happy-dom@20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.1)
+        version: 4.0.18(@types/node@20.19.11)(happy-dom@20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.1)
 
   apps/react-example:
     dependencies:
@@ -99,6 +99,12 @@ importers:
 
   packages/core:
     dependencies:
+      '@noble/curves':
+        specifier: ^2.2.0
+        version: 2.2.0
+      '@noble/hashes':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@turnkey/http':
         specifier: ^3.12.1
         version: 3.12.1
@@ -118,6 +124,9 @@ importers:
         specifier: ^2.38.0
         version: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12)
     devDependencies:
+      '@hpke/core':
+        specifier: ^1.9.0
+        version: 1.9.0
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.11
@@ -150,7 +159,7 @@ importers:
         version: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12)
       wagmi:
         specifier: ^3.0.0
-        version: 3.0.0(0d45bb739e2023a45cfc5f67faf7c39b)
+        version: 3.0.0(fb8e05f5e5623f9a522b5788d20b1d95)
       zustand:
         specifier: ^5.0.3
         version: 5.0.8(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.4.0(react@19.2.0))
@@ -166,7 +175,7 @@ importers:
     dependencies:
       '@wagmi/core':
         specifier: ^2.22.0
-        version: 2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.2)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.0))(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        version: 2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.2)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@zerodev/wallet-core':
         specifier: workspace:*
         version: link:../core
@@ -187,7 +196,7 @@ importers:
         version: 2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.0))(@types/react@19.2.2)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       zustand:
         specifier: ^5.0.3
-        version: 5.0.8(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
+        version: 5.0.8(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.4.0(react@19.2.0))
     devDependencies:
       '@storybook/addon-a11y':
         specifier: ^10.3.3
@@ -285,7 +294,7 @@ importers:
         version: 4.7.0(vite@8.0.0(@types/node@20.19.11)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.1))
       jsdom:
         specifier: ^29.0.1
-        version: 29.0.1(@noble/hashes@1.8.0)
+        version: 29.0.1(@noble/hashes@2.2.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -1316,6 +1325,14 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@hpke/common@1.10.1':
+    resolution: {integrity: sha512-moJwhmtLtuxiUzzNp1jpfBfx8yefKoO9D/RCR9dmwrnc7qjJqId1rEtQz+lSlU5cabX8daToMSx/7HayXOiaFw==}
+    engines: {node: '>=16.0.0'}
+
+  '@hpke/core@1.9.0':
+    resolution: {integrity: sha512-pFxWl1nNJeQCSUFs7+GAblHvXBCjn9EPN65vdKlYQil2aURaRxfGMO6vBKGqm1YHTKwiAxJQNEI70PbSowMP9Q==}
+    engines: {node: '>=16.0.0'}
+
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
@@ -1534,6 +1551,10 @@ packages:
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/curves@2.2.0':
+    resolution: {integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==}
+    engines: {node: '>= 20.19.0'}
+
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
@@ -1549,6 +1570,10 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -8367,10 +8392,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valtio@1.13.2:
@@ -9436,6 +9463,32 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@base-org/account@2.4.0(@types/react@19.2.2)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)':
+    dependencies:
+      '@coinbase/cdp-sdk': 1.38.5(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@noble/hashes': 1.4.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.1
+      idb-keyval: 6.2.1
+      ox: 0.6.9(typescript@5.9.3)(zod@4.1.12)
+      preact: 10.24.2
+      viem: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12)
+      zustand: 5.0.3(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.4.0(react@19.2.0))
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
+      - utf-8-validate
+      - ws
+      - zod
+    optional: true
+
   '@base-org/account@2.4.0(@types/react@19.2.2)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
       '@coinbase/cdp-sdk': 1.38.5(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -9460,32 +9513,6 @@ snapshots:
       - utf-8-validate
       - ws
       - zod
-
-  '@base-org/account@2.4.0(@types/react@19.2.2)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)':
-    dependencies:
-      '@coinbase/cdp-sdk': 1.38.5(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@noble/hashes': 1.4.0
-      clsx: 1.2.1
-      eventemitter3: 5.0.1
-      idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@4.1.12)
-      preact: 10.24.2
-      viem: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12)
-      zustand: 5.0.3(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.4.0(react@19.2.0))
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - debug
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - react
-      - typescript
-      - use-sync-external-store
-      - utf-8-validate
-      - ws
-      - zod
-    optional: true
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -9701,6 +9728,30 @@ snapshots:
       '@clack/core': 0.3.5
       picocolors: 1.1.1
       sisteransi: 1.0.5
+
+  '@coinbase/cdp-sdk@1.38.5(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana-program/system': 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/token': 0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      abitype: 1.0.6(typescript@5.9.3)(zod@3.25.76)
+      axios: 1.13.2
+      axios-retry: 4.5.0(axios@1.13.2)
+      jose: 6.1.1
+      md5: 2.3.0
+      uncrypto: 0.1.3
+      viem: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+      - ws
+    optional: true
 
   '@coinbase/cdp-sdk@1.38.5(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
@@ -10002,9 +10053,9 @@ snapshots:
       ethereum-cryptography: 2.2.1
       micro-ftch: 0.3.1
 
-  '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
+  '@exodus/bytes@1.15.0(@noble/hashes@2.2.0)':
     optionalDependencies:
-      '@noble/hashes': 1.8.0
+      '@noble/hashes': 2.2.0
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -10053,6 +10104,12 @@ snapshots:
   '@hono/node-server@1.19.12(hono@4.10.4)':
     dependencies:
       hono: 4.10.4
+
+  '@hpke/common@1.10.1': {}
+
+  '@hpke/core@1.9.0':
+    dependencies:
+      '@hpke/common': 1.10.1
 
   '@iconify/types@2.0.0': {}
 
@@ -10454,6 +10511,10 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@noble/curves@2.2.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
   '@noble/hashes@1.4.0': {}
 
   '@noble/hashes@1.7.0': {}
@@ -10461,6 +10522,8 @@ snapshots:
   '@noble/hashes@1.7.1': {}
 
   '@noble/hashes@1.8.0': {}
+
+  '@noble/hashes@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -12253,9 +12316,19 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
+  '@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+    dependencies:
+      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+    optional: true
+
   '@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+
+  '@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+    dependencies:
+      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+    optional: true
 
   '@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
@@ -12389,6 +12462,33 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/accounts': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/addresses': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 3.0.3(typescript@5.9.3)
+      '@solana/functional': 3.0.3(typescript@5.9.3)
+      '@solana/instruction-plans': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/instructions': 3.0.3(typescript@5.9.3)
+      '@solana/keys': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/programs': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 3.0.3(typescript@5.9.3)
+      '@solana/rpc-spec-types': 3.0.3(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/signers': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/sysvars': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-confirmation': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+    optional: true
+
   '@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/accounts': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -12486,6 +12586,16 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/errors': 3.0.3(typescript@5.9.3)
+      '@solana/functional': 3.0.3(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 3.0.3(typescript@5.9.3)
+      '@solana/subscribable': 3.0.3(typescript@5.9.3)
+      typescript: 5.9.3
+      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optional: true
+
   '@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.9.3)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.9.3)
@@ -12502,6 +12612,25 @@ snapshots:
       '@solana/rpc-spec-types': 3.0.3(typescript@5.9.3)
       '@solana/subscribable': 3.0.3(typescript@5.9.3)
       typescript: 5.9.3
+
+  '@solana/rpc-subscriptions@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/errors': 3.0.3(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 3.0.3(typescript@5.9.3)
+      '@solana/functional': 3.0.3(typescript@5.9.3)
+      '@solana/promises': 3.0.3(typescript@5.9.3)
+      '@solana/rpc-spec-types': 3.0.3(typescript@5.9.3)
+      '@solana/rpc-subscriptions-api': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-subscriptions-channel-websocket': 3.0.3(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions-spec': 3.0.3(typescript@5.9.3)
+      '@solana/rpc-transformers': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/subscribable': 3.0.3(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+    optional: true
 
   '@solana/rpc-subscriptions@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
@@ -12595,6 +12724,24 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/transaction-confirmation@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/addresses': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-strings': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 3.0.3(typescript@5.9.3)
+      '@solana/keys': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/promises': 3.0.3(typescript@5.9.3)
+      '@solana/rpc': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+    optional: true
 
   '@solana/transaction-confirmation@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
@@ -13479,7 +13626,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@20.19.11)(happy-dom@20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.1))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@20.19.11)(happy-dom@20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.1))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -13491,7 +13638,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@20.19.11)(happy-dom@20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@20.19.11)(happy-dom@20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.1)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -13608,12 +13755,12 @@ snapshots:
       - ws
       - zod
 
-  '@wagmi/connectors@7.0.0(0598bfbb4f73a43f0ecabbd404870812)':
+  '@wagmi/connectors@7.0.0(908e69353500339eee5106ce7bf09d9a)':
     dependencies:
       '@wagmi/core': 3.0.0(@tanstack/query-core@5.90.20)(@types/react@19.2.2)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12))
       viem: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12)
     optionalDependencies:
-      '@base-org/account': 2.4.0(@types/react@19.2.2)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
+      '@base-org/account': 2.4.0(@types/react@19.2.2)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
       '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(zod@4.1.12)
       '@gemini-wallet/core': 0.3.2(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12))
       '@metamask/sdk': 0.33.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -13644,21 +13791,6 @@ snapshots:
       mipd: 0.0.7(typescript@5.9.3)
       viem: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12)
       zustand: 5.0.0(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.4.0(react@19.2.0))
-    optionalDependencies:
-      '@tanstack/query-core': 5.90.20
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-      - use-sync-external-store
-
-  '@wagmi/core@2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.2)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.0))(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
-    dependencies:
-      eventemitter3: 5.0.1
-      mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      zustand: 5.0.0(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
     optionalDependencies:
       '@tanstack/query-core': 5.90.20
       typescript: 5.9.3
@@ -15555,10 +15687,10 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
-  data-urls@7.0.0(@noble/hashes@1.8.0):
+  data-urls@7.0.0(@noble/hashes@2.2.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -16461,9 +16593,9 @@ snapshots:
 
   hono@4.10.4: {}
 
-  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -16811,17 +16943,17 @@ snapshots:
 
   jsc-safe-url@0.2.4: {}
 
-  jsdom@29.0.1(@noble/hashes@1.8.0):
+  jsdom@29.0.1(@noble/hashes@2.2.0):
     dependencies:
       '@asamuzakjp/css-color': 5.1.1
       '@asamuzakjp/dom-selector': 7.0.4
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
       css-tree: 3.2.1
-      data-urls: 7.0.0(@noble/hashes@1.8.0)
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.2.7
       parse5: 8.0.0
@@ -16832,7 +16964,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -18665,7 +18797,7 @@ snapshots:
       '@tanstack/react-query': 5.90.7(react@19.2.0)
       react: 19.2.0
       typescript: 5.9.3
-      wagmi: 3.0.0(0d45bb739e2023a45cfc5f67faf7c39b)
+      wagmi: 3.0.0(fb8e05f5e5623f9a522b5788d20b1d95)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -20254,7 +20386,7 @@ snapshots:
       terser: 5.46.1
       yaml: 2.8.1
 
-  vitest@4.0.18(@types/node@20.19.11)(happy-dom@20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.1):
+  vitest@4.0.18(@types/node@20.19.11)(happy-dom@20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@20.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.1))
@@ -20279,7 +20411,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.11
       happy-dom: 20.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      jsdom: 29.0.1(@noble/hashes@1.8.0)
+      jsdom: 29.0.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -20463,10 +20595,10 @@ snapshots:
       - ws
       - zod
 
-  wagmi@3.0.0(0d45bb739e2023a45cfc5f67faf7c39b):
+  wagmi@3.0.0(fb8e05f5e5623f9a522b5788d20b1d95):
     dependencies:
       '@tanstack/react-query': 5.90.7(react@19.2.0)
-      '@wagmi/connectors': 7.0.0(0598bfbb4f73a43f0ecabbd404870812)
+      '@wagmi/connectors': 7.0.0(908e69353500339eee5106ce7bf09d9a)
       '@wagmi/core': 3.0.0(@tanstack/query-core@5.90.20)(@types/react@19.2.2)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12))
       react: 19.2.0
       use-sync-external-store: 1.4.0(react@19.2.0)
@@ -20506,9 +20638,9 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1(@noble/hashes@1.8.0):
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
@@ -20664,12 +20796,6 @@ snapshots:
       react: 19.2.0
       use-sync-external-store: 1.4.0(react@19.2.0)
 
-  zustand@5.0.0(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0)):
-    optionalDependencies:
-      '@types/react': 19.2.2
-      react: 19.2.0
-      use-sync-external-store: 1.6.0(react@19.2.0)
-
   zustand@5.0.3(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.4.0(react@19.2.0)):
     optionalDependencies:
       '@types/react': 19.2.2
@@ -20681,11 +20807,5 @@ snapshots:
       '@types/react': 19.2.2
       react: 19.2.0
       use-sync-external-store: 1.4.0(react@19.2.0)
-
-  zustand@5.0.8(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0)):
-    optionalDependencies:
-      '@types/react': 19.2.2
-      react: 19.2.0
-      use-sync-external-store: 1.6.0(react@19.2.0)
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
demo-branch: sahil/encrypted-otp

## Summary

Wires the SDK to Turnkey's encrypted-OTP flow (`INIT_OTP_V3` / `VERIFY_OTP_V2`). The OTP code and client public key are now HPKE-sealed to a per-session enclave key before being sent to the auth proxy, so a compromised proxy can't substitute its own pubkey without knowing the OTP code.

Pairs with the doorway-kms `upgrade_turnkey` branch (tkhq/go-sdk@v0.17.0) and the demo's `sahil/encrypted-otp` branch.

## What changed

- **Inline HPKE seal** (`packages/core/src/utils/hpke.ts`) — RFC 9180 mode_base for DHKEM(P-256,HKDF-SHA256) / HKDF-SHA256 / AES-256-GCM. Round-trip tested against `@hpke/core`. Adds `@noble/curves` and `@noble/hashes` as direct deps; no kitchen-sink crypto library.
- **`encryptOtpAttempt`** wrapper — parses the signed encryption target bundle, verifies the ECDSA signature against a pinned TLS Fetcher key, then HPKE-seals `{otp_code, public_key}` to the enclave's ephemeral target key.
- **Wire shape**:
  - `/auth/init/otp` response: `{ otpId, otpEncryptionTargetBundle }`
  - Auth-proxy: `/v1/otp_verify` → `/v1/otp_verify_v2`, body `{ otpId, encryptedOtpBundle }`
- **Hook variables**: `useVerifyOTP` / `useVerifyMagicLink` now require `otpEncryptionTargetBundle`. `useSendOTP` / `useSendMagicLink` results expose it.
- **react-kit**: auth slice replaces `setOtpId` with `setOtpSession` (carries both `otpId` and the bundle).
- **e2e**: integration tests updated; new `otp-init-shape.test.ts` smoke covers wire layer without email; shared `helpers/otp-login.ts` dedups the login dance used by session-management / wallet-operations.
- **Test infra**: default temp-email base switched to `api.mail.tm` (mail.gw has been intermittently 502); `playwright.config` opts in to `ignoreHTTPSErrors` via `ALLOW_SELF_SIGNED_TLS=1`.

## Verified

Against a local backend on `upgrade_turnkey` with the demo on `sahil/encrypted-otp`:
- 715 unit tests
- 7 integration tests (otp-flow, magic-link-flow, session-management, wallet-operations, otp-init-shape)
- 9 browser tests (otp, magic-link, post-auth ×4, passkey ×3)

## Breaking changes

This is the first SDK version to require the encrypted-OTP backend. Consumers of `useSendOTP`/`useSendMagicLink` must thread the new `otpEncryptionTargetBundle` field through to `useVerifyOTP`/`useVerifyMagicLink`.