### PR TITLE
feat(react-kit): SignatureRequest custom classname

### DIFF
--- a/packages/react-kit/src/shared/components/ScreenWrapper/index.tsx
+++ b/packages/react-kit/src/shared/components/ScreenWrapper/index.tsx
@@ -1,3 +1,5 @@
+import type { CSSProperties } from 'react'
+import { cn } from '../../utils/common'
 import { MultiRadialBackground } from './MultiRadialBackground'
 
 interface ChildrenProps {
@@ -11,14 +13,24 @@ const BOTTOM_TAB_MARGIN = 20
 
 export function ScreenWrapper({
   children,
+  className,
+  style,
 }: {
   children: (props: ChildrenProps) => React.ReactNode
+  className?: string | undefined
+  style?: CSSProperties | undefined
 }) {
   const paddingBottom = BOTTOM_TAB_HEIGHT + BOTTOM_TAB_MARGIN + 10
   const paddingTop = TOP_NAV_HEIGHT + 20
 
   return (
-    <div className="flex-1 flex flex-col relative overflow-hidden h-full">
+    <div
+      className={cn(
+        'flex-1 flex flex-col relative overflow-hidden h-full',
+        className,
+      )}
+      style={style}
+    >
       <MultiRadialBackground />
       <div className="flex-1 bg-offWhite/85 m-1.5 px-4 overflow-hidden rounded-[30px] relative">
         {children({ paddingTop, paddingBottom })}

--- a/packages/react-kit/src/signing/index.tsx
+++ b/packages/react-kit/src/signing/index.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import { ScreenWrapper } from '../shared/components/ScreenWrapper'
 import type { PendingRequest, Request } from '../types.js'
 import { renderRequestContent } from './components/renderRequestContent.js'
@@ -10,19 +10,24 @@ type RenderPropArgs = {
   reject: () => void
 }
 
+type StyleProps = {
+  className?: string | undefined
+  style?: CSSProperties | undefined
+}
+
 export type SignatureRequestProps =
-  | {
+  | (StyleProps & {
       request?: never
       onConfirm?: never
       onReject?: never
       children?: (args: RenderPropArgs) => ReactNode
-    }
-  | {
+    })
+  | (StyleProps & {
       request: Request
       onConfirm: () => void
       onReject: () => void
       children?: never
-    }
+    })
 
 export function SignatureRequest(props: SignatureRequestProps = {}) {
   if (props.request) {
@@ -31,11 +36,16 @@ export function SignatureRequest(props: SignatureRequestProps = {}) {
         request={props.request}
         onConfirm={props.onConfirm}
         onReject={props.onReject}
+        className={props.className}
+        style={props.style}
       />
     )
   }
   return (
-    <UncontrolledSignatureRequest>
+    <UncontrolledSignatureRequest
+      className={props.className}
+      style={props.style}
+    >
       {props.children}
     </UncontrolledSignatureRequest>
   )
@@ -45,13 +55,15 @@ function ControlledSignatureRequest({
   request,
   onConfirm,
   onReject,
+  className,
+  style,
 }: {
   request: Request
   onConfirm: () => void
   onReject: () => void
-}) {
+} & StyleProps) {
   return (
-    <ScreenWrapper>
+    <ScreenWrapper className={className} style={style}>
       {({ paddingTop }) => (
         <div style={{ paddingTop }}>
           {renderRequestContent(request, onConfirm, onReject)}
@@ -63,9 +75,11 @@ function ControlledSignatureRequest({
 
 function UncontrolledSignatureRequest({
   children,
+  className,
+  style,
 }: {
   children: ((args: RenderPropArgs) => ReactNode) | undefined
-}) {
+} & StyleProps) {
   const { pendingRequest, pendingRequests, confirm, reject } =
     usePendingRequest()
 
@@ -75,7 +89,7 @@ function UncontrolledSignatureRequest({
 
   if (!pendingRequest) return null
   return (
-    <ScreenWrapper>
+    <ScreenWrapper className={className} style={style}>
       {() => (
         <div className="h-full flex flex-col" style={{ paddingTop: 20 }}>
           {renderRequestContent(pendingRequest, confirm, reject)}


### PR DESCRIPTION
Closes [FS-2111](https://linear.app/offchain-labs/issue/FS-2111/allow-devs-to-pass-custom-classname-to-signaturerequest)

### Summary

This PR adds custom `className` and `style` props to `SignatureRequest`

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
