### PR TITLE
feat(react-kit): DataRow loading skeleton

### DIFF
--- a/packages/react-kit/src/signing/components/DataRow/DataRow.stories.tsx
+++ b/packages/react-kit/src/signing/components/DataRow/DataRow.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { icons } from '../../../shared/components/Icon'
 import { Text } from '../../../shared/components/Text'
-import { DataRow } from '.'
+import { DataRow, DataRowSkeleton } from '.'
 
 const iconNames = Object.keys(icons)
 
@@ -69,4 +69,8 @@ export const WithCustomValue: Story = {
     label: 'status',
     value: <Text className="text-solarOrange">Pending</Text>,
   },
+}
+
+export const Skeleton: StoryObj<typeof DataRowSkeleton> = {
+  render: () => <DataRowSkeleton />,
 }

--- a/packages/react-kit/src/signing/components/DataRow/index.tsx
+++ b/packages/react-kit/src/signing/components/DataRow/index.tsx
@@ -42,3 +42,18 @@ export function DataRow({
     </div>
   )
 }
+
+interface DataRowSkeletonProps {
+  className?: string
+}
+
+export function DataRowSkeleton({ className }: DataRowSkeletonProps) {
+  return (
+    <div
+      className={cn('flex flex-row items-center justify-between', className)}
+    >
+      <div className="w-20 h-3 rounded-lg bg-offWhite/50 animate-pulse" />
+      <div className="w-24 h-3 rounded-lg bg-offWhite/50 animate-pulse" />
+    </div>
+  )
+}


### PR DESCRIPTION
Closes [FS-2121](https://linear.app/offchain-labs/issue/FS-2121/add-loading-skeleton-to-datarow)

### Summary

This PR implements DataRow loading skeleton


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
