### PR TITLE
release(core/react): @zerodev/wallet-core@0.0.1-alpha.18 and @zerodev/wallet-react@0.0.1-alpha.20

### DIFF
--- a/.changeset/humble-worlds-fry.md
+++ b/.changeset/humble-worlds-fry.md
@@ -1,0 +1,18 @@
+---
+"@zerodev/wallet-core": patch
+"@zerodev/wallet-react": patch
+---
+
+feat(otp): switch to encrypted OTP flow (Turnkey `INIT_OTP_V3` / `VERIFY_OTP_V2`)
+
+The OTP code and client public key are now HPKE-sealed to a per-session enclave key before being sent to the auth proxy. A compromised proxy can no longer substitute its own public key without knowing the OTP.
+
+**Breaking changes** (alpha):
+
+- `registerWithOTP` now returns `{ otpId, otpEncryptionTargetBundle }`. Pass `otpEncryptionTargetBundle` verbatim to the verify step.
+- `useSendOTP` / `useSendMagicLink` results include `otpEncryptionTargetBundle`.
+- `useVerifyOTP` / `useVerifyMagicLink` variables now require `otpEncryptionTargetBundle`.
+- `AuthParams` `otp.verifyOtp` and `magicLink.verify` variants require `otpEncryptionTargetBundle`.
+- Auth-proxy endpoint `/v1/otp_verify` → `/v1/otp_verify_v2`; request body switched from `{otpId, otpCode, public_key}` to `{otpId, encryptedOtpBundle}`.
+
+Requires the doorway-kms backend running on the `upgrade_turnkey` branch (or later release that adopts `tkhq/go-sdk@v0.17.0`).

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -18,6 +18,7 @@
     "gentle-adults-talk",
     "giant-garlics-make",
     "humble-sheep-kiss",
+    "humble-worlds-fry",
     "khaki-ways-listen",
     "loud-jobs-cheat",
     "lucky-corners-sneeze",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @zerodev/wallet-core
 
+## 0.0.1-alpha.18
+
+### Patch Changes
+
+- feat(otp): switch to encrypted OTP flow (Turnkey `INIT_OTP_V3` / `VERIFY_OTP_V2`)
+
+  The OTP code and client public key are now HPKE-sealed to a per-session enclave key before being sent to the auth proxy. A compromised proxy can no longer substitute its own public key without knowing the OTP.
+
+  **Breaking changes** (alpha):
+
+  - `registerWithOTP` now returns `{ otpId, otpEncryptionTargetBundle }`. Pass `otpEncryptionTargetBundle` verbatim to the verify step.
+  - `useSendOTP` / `useSendMagicLink` results include `otpEncryptionTargetBundle`.
+  - `useVerifyOTP` / `useVerifyMagicLink` variables now require `otpEncryptionTargetBundle`.
+  - `AuthParams` `otp.verifyOtp` and `magicLink.verify` variants require `otpEncryptionTargetBundle`.
+  - Auth-proxy endpoint `/v1/otp_verify` → `/v1/otp_verify_v2`; request body switched from `{otpId, otpCode, public_key}` to `{otpId, encryptedOtpBundle}`.
+
+  Requires the doorway-kms backend running on the `upgrade_turnkey` branch (or later release that adopts `tkhq/go-sdk@v0.17.0`).
+
 ## 0.0.1-alpha.17
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-core",
-  "version": "0.0.1-alpha.17",
+  "version": "0.0.1-alpha.18",
   "description": "ZeroDev Wallet SDK built on Turnkey",
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @zerodev/wallet-react
 
+## 0.0.1-alpha.20
+
+### Patch Changes
+
+- feat(otp): switch to encrypted OTP flow (Turnkey `INIT_OTP_V3` / `VERIFY_OTP_V2`)
+
+  The OTP code and client public key are now HPKE-sealed to a per-session enclave key before being sent to the auth proxy. A compromised proxy can no longer substitute its own public key without knowing the OTP.
+
+  **Breaking changes** (alpha):
+
+  - `registerWithOTP` now returns `{ otpId, otpEncryptionTargetBundle }`. Pass `otpEncryptionTargetBundle` verbatim to the verify step.
+  - `useSendOTP` / `useSendMagicLink` results include `otpEncryptionTargetBundle`.
+  - `useVerifyOTP` / `useVerifyMagicLink` variables now require `otpEncryptionTargetBundle`.
+  - `AuthParams` `otp.verifyOtp` and `magicLink.verify` variants require `otpEncryptionTargetBundle`.
+  - Auth-proxy endpoint `/v1/otp_verify` → `/v1/otp_verify_v2`; request body switched from `{otpId, otpCode, public_key}` to `{otpId, encryptedOtpBundle}`.
+
+  Requires the doorway-kms backend running on the `upgrade_turnkey` branch (or later release that adopts `tkhq/go-sdk@v0.17.0`).
+
+- Updated dependencies
+  - @zerodev/wallet-core@0.0.1-alpha.18
+
 ## 0.0.1-alpha.19
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-react",
-  "version": "0.0.1-alpha.19",
+  "version": "0.0.1-alpha.20",
   "description": "React hooks for ZeroDev Wallet SDK",
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",


### PR DESCRIPTION
Encrypted OTP rollout (#145).