### PR TITLE
feat(react-kit): add `magicLink` and set auth method

### DIFF
--- a/apps/react-example/src/wagmi.ts
+++ b/apps/react-example/src/wagmi.ts
@@ -10,7 +10,7 @@ export const wagmiConfig = createConfig({
       chains: [sepolia],
       config: {
         auth: {
-          magicLinkBaseUrl: 'https://yourdomain.com/auth/verify',
+          magicLinkBaseUrl: 'http://localhost:3000/verify',
           enabledMethods: ['email', 'google', 'passkey'],
           onSuccess: () => {
             // handle successful authentication

--- a/apps/react-example/src/wagmi.ts
+++ b/apps/react-example/src/wagmi.ts
@@ -12,6 +12,7 @@ export const wagmiConfig = createConfig({
         auth: {
           magicLinkBaseUrl: 'http://localhost:3000/verify',
           enabledMethods: ['email', 'google', 'passkey'],
+          // emailAuthMethod: 'otp', // set email auth method, 'magicLink' or 'otp', default is 'magicLink'
           onSuccess: () => {
             // handle successful authentication
           },

--- a/packages/react-kit/src/auth/authStoreSlice.ts
+++ b/packages/react-kit/src/auth/authStoreSlice.ts
@@ -1,6 +1,47 @@
 import type { StateCreator } from 'zustand'
 import type { AuthConfig, AuthMethod, AuthStep } from './types'
 
+const OTP_SESSION_STORAGE_KEY = 'zerodev:auth:otpSession'
+
+type StoredOtpSession = {
+  otpId: string
+  otpEncryptionTargetBundle: string
+}
+
+function readStoredOtpSession(): StoredOtpSession | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.localStorage.getItem(OTP_SESSION_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as StoredOtpSession
+    if (!parsed?.otpId || !parsed?.otpEncryptionTargetBundle) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function writeStoredOtpSession(session: StoredOtpSession): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(
+      OTP_SESSION_STORAGE_KEY,
+      JSON.stringify(session),
+    )
+  } catch {
+    // ignore
+  }
+}
+
+function clearStoredOtpSession(): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.removeItem(OTP_SESSION_STORAGE_KEY)
+  } catch {
+    // ignore
+  }
+}
+
 export interface AuthStoreSlice {
   auth: {
     // State
@@ -20,6 +61,8 @@ export interface AuthStoreSlice {
       otpId: string
       otpEncryptionTargetBundle: string
     }) => void
+    /** Clear the persisted OTP session after a successful verify. */
+    clearOtpSession: () => void
     config: AuthConfig | null
 
     // Actions
@@ -48,11 +91,16 @@ export const createAuthStoreSlice: StateCreator<
 
     // Actions
     initialize: (config: AuthConfig) => {
+      const stored = readStoredOtpSession()
       set((state) => ({
         auth: {
           ...state.auth,
           config,
           enabledMethods: config.enabledMethods,
+          ...(stored && {
+            otpId: stored.otpId,
+            otpEncryptionTargetBundle: stored.otpEncryptionTargetBundle,
+          }),
         },
       }))
     },
@@ -81,6 +129,7 @@ export const createAuthStoreSlice: StateCreator<
     },
 
     reset: () => {
+      clearStoredOtpSession()
       set((state) => ({
         auth: {
           ...state.auth,
@@ -103,11 +152,23 @@ export const createAuthStoreSlice: StateCreator<
     },
 
     setOtpSession: ({ otpId, otpEncryptionTargetBundle }) => {
+      writeStoredOtpSession({ otpId, otpEncryptionTargetBundle })
       set((state) => ({
         auth: {
           ...state.auth,
           otpId,
           otpEncryptionTargetBundle,
+        },
+      }))
+    },
+
+    clearOtpSession: () => {
+      clearStoredOtpSession()
+      set((state) => ({
+        auth: {
+          ...state.auth,
+          otpId: null,
+          otpEncryptionTargetBundle: null,
         },
       }))
     },

--- a/packages/react-kit/src/auth/hooks/useAuth.ts
+++ b/packages/react-kit/src/auth/hooks/useAuth.ts
@@ -41,5 +41,6 @@ export function useAuth() {
     reset: store.getState().auth.reset,
     setEmail: store.getState().auth.setEmail,
     setOtpSession: store.getState().auth.setOtpSession,
+    clearOtpSession: store.getState().auth.clearOtpSession,
   }
 }

--- a/packages/react-kit/src/auth/index.tsx
+++ b/packages/react-kit/src/auth/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { StatusView } from '../shared/components/StatusView'
 import { useAuth } from './hooks/useAuth'
 import { EmailVerification } from './pages/EmailVerification'
@@ -5,6 +6,11 @@ import { ErrorScreen } from './pages/ErrorScreen'
 import { OtpInput } from './pages/OtpInput'
 import { SignUp } from './pages/SignUp'
 import { Verifying } from './pages/Verifying'
+
+function hasMagicLinkCodeInUrl(): boolean {
+  if (typeof window === 'undefined') return false
+  return new URLSearchParams(window.location.search).has('code')
+}
 
 function OAuthCallback() {
   return (
@@ -23,7 +29,13 @@ function WalletSelection() {
 }
 
 export function AuthFlow() {
-  const { step } = useAuth()
+  const { step, goToStep } = useAuth()
+
+  useEffect(() => {
+    if (step === 'initializing' && hasMagicLinkCodeInUrl()) {
+      goToStep('verifying-otp')
+    }
+  }, [step, goToStep])
 
   switch (step) {
     case 'initializing':

--- a/packages/react-kit/src/auth/pages/EmailVerification.tsx
+++ b/packages/react-kit/src/auth/pages/EmailVerification.tsx
@@ -1,4 +1,4 @@
-import { useSendOTP } from '@zerodev/wallet-react'
+import { useSendMagicLink } from '@zerodev/wallet-react'
 import { useEffect, useState } from 'react'
 import { AppLogo } from '../../shared/components/AppLogo'
 import { ScreenWrapper } from '../../shared/components/ScreenWrapper'
@@ -7,11 +7,12 @@ import { Text } from '../../shared/components/Text'
 import { useAuth } from '../hooks/useAuth'
 
 export function EmailVerification() {
-  const { email, setOtpSession, goToStep } = useAuth()
-  const { mutateAsync: sendOtp, isPending: isSendOtpPending } = useSendOTP()
+  const { email, setOtpSession, config } = useAuth()
+  const { mutateAsync: sendMagicLink, isPending: isSendPending } =
+    useSendMagicLink()
 
   const [secondsLeftUntilResend, setSecondsLeftUntilResend] = useState(60)
-  const canResend = secondsLeftUntilResend <= 0 && !isSendOtpPending
+  const canResend = secondsLeftUntilResend <= 0 && !isSendPending
 
   useEffect(() => {
     if (secondsLeftUntilResend <= 0) return
@@ -25,15 +26,18 @@ export function EmailVerification() {
     }
   }, [secondsLeftUntilResend])
 
-  const handleResendOtp = async () => {
+  const handleResend = async () => {
     if (!email || !canResend) return
 
     try {
-      const { otpId, otpEncryptionTargetBundle } = await sendOtp({ email })
+      const { otpId, otpEncryptionTargetBundle } = await sendMagicLink({
+        email,
+        redirectURL: config?.magicLinkBaseUrl ?? '',
+      })
       setOtpSession({ otpId, otpEncryptionTargetBundle })
       setSecondsLeftUntilResend(60)
     } catch {
-      // Error sending OTP
+      // Error resending magic link
     }
   }
 
@@ -59,22 +63,12 @@ export function EmailVerification() {
               <button
                 type="button"
                 disabled={!canResend}
-                onClick={handleResendOtp}
+                onClick={handleResend}
                 className="cursor-pointer underline disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {canResend
                   ? 'Resend'
                   : `Resend in ${secondsLeftUntilResend} ${secondsLeftUntilResend === 1 ? 'second' : 'seconds'}`}
-              </button>
-            </Text>
-            <Text className="text-center">
-              Or{' '}
-              <button
-                type="button"
-                onClick={() => goToStep('otp-input')}
-                className="cursor-pointer underline"
-              >
-                sign in manually instead
               </button>
             </Text>
           </div>

--- a/packages/react-kit/src/auth/pages/OtpInput.tsx
+++ b/packages/react-kit/src/auth/pages/OtpInput.tsx
@@ -13,6 +13,7 @@ export function OtpInput() {
     otpId,
     otpEncryptionTargetBundle,
     setOtpSession,
+    clearOtpSession,
     goToStep,
     config,
   } = useAuth()
@@ -43,6 +44,7 @@ export function OtpInput() {
         code: otp.trim(),
         otpEncryptionTargetBundle,
       })
+      clearOtpSession()
       goToStep('authenticated')
       config?.onSuccess?.()
     } catch (err) {

--- a/packages/react-kit/src/auth/pages/SignUp.tsx
+++ b/packages/react-kit/src/auth/pages/SignUp.tsx
@@ -1,4 +1,8 @@
-import { useAuthenticateOAuth, useSendOTP } from '@zerodev/wallet-react'
+import {
+  useAuthenticateOAuth,
+  useSendMagicLink,
+  useSendOTP,
+} from '@zerodev/wallet-react'
 import { useState } from 'react'
 
 import { Icon } from '../../shared/components/Icon'
@@ -22,7 +26,11 @@ export function SignUp() {
   const { goToStep, setEmail, setOtpSession, config } = useAuth()
   const [agreedToTerms, setAgreedToTerms] = useState(false)
   const [emailInput, setEmailInput] = useState('')
-  const { mutateAsync: sendOtp, isPending: isEmailLoading } = useSendOTP()
+  const useOtp = config?.emailAuthMethod === 'otp'
+  const { mutateAsync: sendOtp, isPending: isSendOtpPending } = useSendOTP()
+  const { mutateAsync: sendMagicLink, isPending: isSendMagicLinkPending } =
+    useSendMagicLink()
+  const isEmailLoading = useOtp ? isSendOtpPending : isSendMagicLinkPending
   const { mutateAsync: authenticateOAuth, isPending: isGoogleLoading } =
     useAuthenticateOAuth({
       mutation: {
@@ -60,12 +68,15 @@ export function SignUp() {
 
     setError(null)
     try {
-      const { otpId, otpEncryptionTargetBundle } = await sendOtp({
-        email: emailInput,
-      })
+      const { otpId, otpEncryptionTargetBundle } = useOtp
+        ? await sendOtp({ email: emailInput })
+        : await sendMagicLink({
+            email: emailInput,
+            redirectURL: config?.magicLinkBaseUrl ?? '',
+          })
       setEmail(emailInput)
       setOtpSession({ otpId, otpEncryptionTargetBundle })
-      goToStep('email-verification')
+      goToStep(useOtp ? 'otp-input' : 'email-verification')
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'Failed to send verification code',

--- a/packages/react-kit/src/auth/pages/SignUp.tsx
+++ b/packages/react-kit/src/auth/pages/SignUp.tsx
@@ -26,11 +26,13 @@ export function SignUp() {
   const { goToStep, setEmail, setOtpSession, config } = useAuth()
   const [agreedToTerms, setAgreedToTerms] = useState(false)
   const [emailInput, setEmailInput] = useState('')
-  const useOtp = config?.emailAuthMethod === 'otp'
+  const shouldUseOtp = config?.emailAuthMethod === 'otp'
   const { mutateAsync: sendOtp, isPending: isSendOtpPending } = useSendOTP()
   const { mutateAsync: sendMagicLink, isPending: isSendMagicLinkPending } =
     useSendMagicLink()
-  const isEmailLoading = useOtp ? isSendOtpPending : isSendMagicLinkPending
+  const isEmailLoading = shouldUseOtp
+    ? isSendOtpPending
+    : isSendMagicLinkPending
   const { mutateAsync: authenticateOAuth, isPending: isGoogleLoading } =
     useAuthenticateOAuth({
       mutation: {
@@ -68,7 +70,7 @@ export function SignUp() {
 
     setError(null)
     try {
-      const { otpId, otpEncryptionTargetBundle } = useOtp
+      const { otpId, otpEncryptionTargetBundle } = shouldUseOtp
         ? await sendOtp({ email: emailInput })
         : await sendMagicLink({
             email: emailInput,
@@ -76,7 +78,7 @@ export function SignUp() {
           })
       setEmail(emailInput)
       setOtpSession({ otpId, otpEncryptionTargetBundle })
-      goToStep(useOtp ? 'otp-input' : 'email-verification')
+      goToStep(shouldUseOtp ? 'otp-input' : 'email-verification')
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'Failed to send verification code',

--- a/packages/react-kit/src/auth/pages/Verifying.tsx
+++ b/packages/react-kit/src/auth/pages/Verifying.tsx
@@ -1,5 +1,5 @@
 import { useVerifyMagicLink } from '@zerodev/wallet-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { AppLogo } from '../../shared/components/AppLogo'
 import { Button } from '../../shared/components/Button'
 import { ScreenWrapper } from '../../shared/components/ScreenWrapper'
@@ -13,8 +13,17 @@ function getCodeFromUrl(): string | null {
 }
 
 export function Verifying() {
-  const { otpId, otpEncryptionTargetBundle, goToStep, config } = useAuth()
+  const {
+    otpId,
+    otpEncryptionTargetBundle,
+    goToStep,
+    clearOtpSession,
+    config,
+  } = useAuth()
   const [code] = useState<string | null>(getCodeFromUrl)
+
+  // ref to prevent useEffect firing twice in dev's StrictMode
+  const hasVerifiedRef = useRef(false)
   const {
     mutate: verifyMagicLink,
     error: verificationError,
@@ -22,6 +31,7 @@ export function Verifying() {
   } = useVerifyMagicLink({
     mutation: {
       onSuccess: async () => {
+        clearOtpSession()
         goToStep('authenticated')
         config?.onSuccess?.()
       },
@@ -32,24 +42,12 @@ export function Verifying() {
   })
 
   useEffect(() => {
-    if (
-      !otpId ||
-      !otpEncryptionTargetBundle ||
-      !code ||
-      isVerificationLoading ||
-      verificationError
-    )
+    if (hasVerifiedRef.current || !otpId || !otpEncryptionTargetBundle || !code)
       return
 
+    hasVerifiedRef.current = true
     verifyMagicLink({ otpId, code, otpEncryptionTargetBundle })
-  }, [
-    otpId,
-    otpEncryptionTargetBundle,
-    code,
-    isVerificationLoading,
-    verificationError,
-    verifyMagicLink,
-  ])
+  }, [otpId, otpEncryptionTargetBundle, code, verifyMagicLink])
 
   return (
     <ScreenWrapper>

--- a/packages/react-kit/src/auth/pages/Verifying.tsx
+++ b/packages/react-kit/src/auth/pages/Verifying.tsx
@@ -1,5 +1,5 @@
-import { useVerifyOTP } from '@zerodev/wallet-react'
-import { useEffect } from 'react'
+import { useVerifyMagicLink } from '@zerodev/wallet-react'
+import { useEffect, useState } from 'react'
 import { AppLogo } from '../../shared/components/AppLogo'
 import { Button } from '../../shared/components/Button'
 import { ScreenWrapper } from '../../shared/components/ScreenWrapper'
@@ -7,18 +7,19 @@ import { StatusView } from '../../shared/components/StatusView'
 import { Text } from '../../shared/components/Text'
 import { useAuth } from '../hooks/useAuth'
 
-interface VerifyingProps {
-  otp?: string
-  otpSource?: 'input' | 'link'
+function getCodeFromUrl(): string | null {
+  if (typeof window === 'undefined') return null
+  return new URLSearchParams(window.location.search).get('code')
 }
 
-export function Verifying({ otp, otpSource }: VerifyingProps) {
+export function Verifying() {
   const { otpId, otpEncryptionTargetBundle, goToStep, config } = useAuth()
+  const [code] = useState<string | null>(getCodeFromUrl)
   const {
-    mutate: verifyOtp,
+    mutate: verifyMagicLink,
     error: verificationError,
     isPending: isVerificationLoading,
-  } = useVerifyOTP({
+  } = useVerifyMagicLink({
     mutation: {
       onSuccess: async () => {
         goToStep('authenticated')
@@ -30,25 +31,24 @@ export function Verifying({ otp, otpSource }: VerifyingProps) {
     },
   })
 
-  // Auto-verify when component mounts with OTP
   useEffect(() => {
     if (
       !otpId ||
       !otpEncryptionTargetBundle ||
-      !otp ||
+      !code ||
       isVerificationLoading ||
       verificationError
     )
       return
 
-    verifyOtp({ otpId, code: otp, otpEncryptionTargetBundle })
+    verifyMagicLink({ otpId, code, otpEncryptionTargetBundle })
   }, [
     otpId,
     otpEncryptionTargetBundle,
-    otp,
+    code,
     isVerificationLoading,
     verificationError,
-    verifyOtp,
+    verifyMagicLink,
   ])
 
   return (
@@ -61,7 +61,7 @@ export function Verifying({ otp, otpSource }: VerifyingProps) {
             </StatusView>
           )}
 
-          {!otp && !isVerificationLoading && (
+          {!code && !isVerificationLoading && (
             <StatusView imageName="error" title="Invalid Link">
               <Text>
                 This verification link is invalid or incomplete.
@@ -79,20 +79,11 @@ export function Verifying({ otp, otpSource }: VerifyingProps) {
                   timeout, an expired link, or a cancelled request.
                 </Text>
               </StatusView>
-              <div className="flex flex-col gap-1">
-                {otpSource === 'input' && (
-                  <Button
-                    action="primary"
-                    text="Try again"
-                    onClick={() => goToStep('otp-input')}
-                  />
-                )}
-                <Button
-                  action={otpSource === 'input' ? 'secondary' : 'primary'}
-                  onClick={() => goToStep('sign-up')}
-                  text="Choose another sign-in method"
-                />
-              </div>
+              <Button
+                action="primary"
+                onClick={() => goToStep('sign-up')}
+                text="Choose another sign-in method"
+              />
             </>
           )}
 

--- a/packages/react-kit/src/auth/types.ts
+++ b/packages/react-kit/src/auth/types.ts
@@ -12,9 +12,12 @@ export type AuthStep =
   | 'authenticated'
   | 'error'
 
+export type EmailAuthMethod = 'magicLink' | 'otp'
+
 export interface AuthConfig {
   magicLinkBaseUrl: string
   enabledMethods: AuthMethod[]
+  emailAuthMethod?: EmailAuthMethod
   onSuccess?: () => void
   onError?: (error: unknown) => void
 }


### PR DESCRIPTION
Closes [FS-2132](https://linear.app/offchain-labs/issue/FS-2132/separate-otp-and-magic-link-flows)

### Summary

- This PR adds magic link flow
- Separates OTP and magic link flows. It adds `emailAuthMethod` as an auth config option, where the default is magic link

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
