### PR TITLE
feat(react-kit): expand docs demo and fix embedded rendering

### DIFF
--- a/packages/react-kit/docs/components/ConnectButton.tsx
+++ b/packages/react-kit/docs/components/ConnectButton.tsx
@@ -27,6 +27,7 @@ export function ConnectButton() {
             borderRadius: 6,
             border: '1px solid #ddd',
             background: 'white',
+            color: '#111',
             fontSize: 12,
             cursor: 'pointer',
           }}

--- a/packages/react-kit/docs/components/SignatureRequest/Demo.tsx
+++ b/packages/react-kit/docs/components/SignatureRequest/Demo.tsx
@@ -1,12 +1,48 @@
-import { AuthFlow, SignatureRequest } from '@zerodev/wallet-react-kit'
-import { parseEther } from 'viem'
-import { useAccount, useSendTransaction } from 'wagmi'
+import {
+  AuthFlow,
+  SignatureRequest,
+  usePendingRequest,
+} from '@zerodev/wallet-react-kit'
+import { encodeFunctionData, erc20Abi, parseEther } from 'viem'
+import {
+  useAccount,
+  useDisconnect,
+  useSendCalls,
+  useSendTransaction,
+  useSignMessage,
+  useSignTypedData,
+} from 'wagmi'
 import { ConnectButton } from '../ConnectButton'
+
+const USDC_SEPOLIA = '0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8'
+
+const buttonStyle = {
+  width: '100%',
+  padding: '10px 16px',
+  borderRadius: 8,
+  border: 'none',
+  background: '#2563eb',
+  color: 'white',
+  fontSize: 13,
+  fontWeight: 600,
+  cursor: 'pointer',
+} as const
 
 export default function SignatureRequestDemo() {
   const { isConnected, address } = useAccount()
-  const { sendTransaction, isPending, isSuccess, isError, error, data } =
+  const { disconnect } = useDisconnect()
+  const { sendTransaction, isSuccess, isError, error, data } =
     useSendTransaction()
+  const {
+    signMessage,
+    data: signature,
+    isSuccess: signSuccess,
+    isError: signError,
+    error: signMessageError,
+  } = useSignMessage()
+  const { signTypedData } = useSignTypedData()
+  const { sendCalls } = useSendCalls()
+  const { pendingRequests } = usePendingRequest()
 
   if (!isConnected) {
     return (
@@ -20,29 +56,197 @@ export default function SignatureRequestDemo() {
     )
   }
 
+  const queued = pendingRequests.length > 0
+
   return (
     <div>
-      <button
-        type="button"
-        onClick={() =>
-          sendTransaction({ to: address!, value: parseEther('0'), data: '0x' })
-        }
-        disabled={isPending}
+      <div
         style={{
-          width: '100%',
-          padding: '10px 16px',
-          borderRadius: 8,
-          border: 'none',
-          background: '#111',
-          color: 'white',
-          fontSize: 14,
-          fontWeight: 600,
-          cursor: isPending ? 'not-allowed' : 'pointer',
-          opacity: isPending ? 0.6 : 1,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 12,
+          gap: 8,
         }}
       >
-        {isPending ? 'Awaiting confirmation...' : 'Send Transaction (0 ETH)'}
-      </button>
+        <span style={{ fontSize: 12, color: '#666', wordBreak: 'break-all' }}>
+          {address}
+        </span>
+        <button
+          type="button"
+          onClick={() => disconnect()}
+          style={{
+            padding: '4px 10px',
+            borderRadius: 6,
+            border: '1px solid #ddd',
+            background: 'white',
+            color: '#111',
+            fontSize: 12,
+            cursor: 'pointer',
+            flexShrink: 0,
+          }}
+        >
+          Disconnect
+        </button>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <button
+          type="button"
+          style={buttonStyle}
+          onClick={() =>
+            sendTransaction({ to: address!, value: parseEther('0.01') })
+          }
+        >
+          {queued ? 'Queue ETH transfer' : 'Send ETH'}
+        </button>
+
+        <button
+          type="button"
+          style={buttonStyle}
+          onClick={() =>
+            sendTransaction({
+              to: USDC_SEPOLIA,
+              data: encodeFunctionData({
+                abi: erc20Abi,
+                functionName: 'transfer',
+                args: [address!, 1000000n],
+              }),
+            })
+          }
+        >
+          {queued ? 'Queue ERC-20 transfer' : 'Send ERC-20'}
+        </button>
+
+        <button
+          type="button"
+          style={buttonStyle}
+          onClick={() =>
+            sendTransaction({
+              to: USDC_SEPOLIA,
+              data: encodeFunctionData({
+                abi: erc20Abi,
+                functionName: 'approve',
+                args: [address!, 1000000n],
+              }),
+            })
+          }
+        >
+          {queued ? 'Queue ERC-20 approval' : 'Approve ERC-20'}
+        </button>
+
+        <button
+          type="button"
+          style={buttonStyle}
+          onClick={() =>
+            sendTransaction({
+              // Not an NFT — reusing USDC because it has a name() function,
+              // so the decoded UI loads fast. The setApprovalForAll calldata is the same regardless.
+              to: USDC_SEPOLIA,
+              data: encodeFunctionData({
+                abi: [
+                  {
+                    type: 'function',
+                    name: 'setApprovalForAll',
+                    inputs: [
+                      { name: 'operator', type: 'address' },
+                      { name: 'approved', type: 'bool' },
+                    ],
+                    outputs: [],
+                    stateMutability: 'nonpayable',
+                  },
+                ],
+                functionName: 'setApprovalForAll',
+                args: [address!, true],
+              }),
+            })
+          }
+        >
+          {queued ? 'Queue collection approval' : 'Collection Approval'}
+        </button>
+
+        <button
+          type="button"
+          style={buttonStyle}
+          onClick={() => signMessage({ message: 'Hello from ZeroDev!' })}
+        >
+          {queued ? 'Queue message signature' : 'Sign Message'}
+        </button>
+
+        <button
+          type="button"
+          style={buttonStyle}
+          onClick={() =>
+            signTypedData({
+              domain: {
+                name: 'Example DApp',
+                version: '1',
+                chainId: 11155111,
+                verifyingContract: USDC_SEPOLIA,
+              },
+              types: {
+                Person: [
+                  { name: 'name', type: 'string' },
+                  { name: 'wallets', type: 'address[]' },
+                ],
+                Mail: [
+                  { name: 'from', type: 'Person' },
+                  { name: 'to', type: 'Person[]' },
+                  { name: 'contents', type: 'string' },
+                ],
+              },
+              primaryType: 'Mail',
+              message: {
+                from: {
+                  name: 'Alice',
+                  wallets: [
+                    '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+                    '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
+                  ],
+                },
+                to: [
+                  {
+                    name: 'Bob',
+                    wallets: [
+                      '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+                      '0xB0B0000000000000000000000000000000000000',
+                    ],
+                  },
+                  {
+                    name: 'Charlie',
+                    wallets: ['0xC0FFEE0000000000000000000000000000000000'],
+                  },
+                ],
+                contents: 'Hello from ZeroDev!',
+              },
+            })
+          }
+        >
+          {queued ? 'Queue typed data signature' : 'Sign Typed Data'}
+        </button>
+
+        <button
+          type="button"
+          style={buttonStyle}
+          onClick={() =>
+            sendCalls({
+              calls: [
+                { to: address!, value: parseEther('0.01') },
+                {
+                  to: USDC_SEPOLIA,
+                  data: encodeFunctionData({
+                    abi: erc20Abi,
+                    functionName: 'transfer',
+                    args: [address!, 1000000n],
+                  }),
+                },
+              ],
+            })
+          }
+        >
+          {queued ? 'Queue batch calls' : 'Batch Calls'}
+        </button>
+      </div>
 
       {isSuccess && (
         <p style={{ color: '#16a34a', fontSize: 13, marginTop: 8 }}>
@@ -57,7 +261,29 @@ export default function SignatureRequestDemo() {
         </p>
       )}
 
-      <SignatureRequest />
+      {signSuccess && (
+        <p
+          style={{
+            color: '#16a34a',
+            fontSize: 13,
+            marginTop: 8,
+            wordBreak: 'break-all',
+          }}
+        >
+          sig: {signature}
+        </p>
+      )}
+      {signError && (
+        <p style={{ color: '#dc2626', fontSize: 13, marginTop: 8 }}>
+          {signMessageError?.message?.includes('User rejected')
+            ? 'Rejected by user'
+            : signMessageError?.message}
+        </p>
+      )}
+
+      <div style={{ marginTop: 16 }}>
+        <SignatureRequest />
+      </div>
     </div>
   )
 }

--- a/packages/react-kit/docs/components/WalletProvider.tsx
+++ b/packages/react-kit/docs/components/WalletProvider.tsx
@@ -12,7 +12,7 @@ const config = createConfig({
       chains: [sepolia],
       config: {
         auth: {
-          magicLinkBaseUrl: 'https://yourdomain.com/auth/verify',
+          magicLinkBaseUrl: 'http://localhost:5173/verify',
           enabledMethods: ['email', 'google', 'passkey'],
         },
       },

--- a/packages/react-kit/src/auth/pages/EmailVerification.tsx
+++ b/packages/react-kit/src/auth/pages/EmailVerification.tsx
@@ -73,7 +73,7 @@ export function EmailVerification() {
             </Text>
           </div>
 
-          <AppLogo className="absolute self-center bottom-6" />
+          <AppLogo className="self-center pb-6" />
         </div>
       )}
     </ScreenWrapper>

--- a/packages/react-kit/src/auth/pages/EmailVerification.tsx
+++ b/packages/react-kit/src/auth/pages/EmailVerification.tsx
@@ -46,34 +46,36 @@ export function EmailVerification() {
       {({ paddingTop }) => (
         <div
           style={{ paddingTop: `${paddingTop}px` }}
-          className="flex flex-1 flex-col gap-8 justify-center h-full"
+          className="flex flex-1 flex-col h-full"
         >
-          <StatusView
-            imageName="send"
-            title={'Check your email!\n An Email is On Its Way'}
-          >
-            We've sent a magic link to{' '}
-            <Text className="text-solarOrange inline">{email}</Text>
-            {'\n'}Please open the email and click the link to log in.
-          </StatusView>
+          <div className="flex-1 flex flex-col gap-8 justify-center">
+            <StatusView
+              imageName="send"
+              title={'Check your email!\n An Email is On Its Way'}
+            >
+              We've sent a magic link to{' '}
+              <Text className="text-solarOrange inline">{email}</Text>
+              {'\n'}Please open the email and click the link to log in.
+            </StatusView>
 
-          <div className="flex flex-col gap-1">
-            <Text className="text-center">
-              Did not get an email?{' '}
-              <button
-                type="button"
-                disabled={!canResend}
-                onClick={handleResend}
-                className="cursor-pointer underline disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {canResend
-                  ? 'Resend'
-                  : `Resend in ${secondsLeftUntilResend} ${secondsLeftUntilResend === 1 ? 'second' : 'seconds'}`}
-              </button>
-            </Text>
+            <div className="flex flex-col gap-1">
+              <Text className="text-center">
+                Did not get an email?{' '}
+                <button
+                  type="button"
+                  disabled={!canResend}
+                  onClick={handleResend}
+                  className="cursor-pointer underline disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {canResend
+                    ? 'Resend'
+                    : `Resend in ${secondsLeftUntilResend} ${secondsLeftUntilResend === 1 ? 'second' : 'seconds'}`}
+                </button>
+              </Text>
+            </div>
           </div>
 
-          <AppLogo className="self-center pb-6" />
+          <AppLogo className="self-center pt-4 pb-6" />
         </div>
       )}
     </ScreenWrapper>

--- a/packages/react-kit/src/auth/pages/ErrorScreen.tsx
+++ b/packages/react-kit/src/auth/pages/ErrorScreen.tsx
@@ -23,28 +23,30 @@ export function ErrorScreen({
   return (
     <ScreenWrapper>
       {() => (
-        <div className="flex flex-1 flex-col gap-8 items-center justify-center h-full">
-          <StatusView imageName="error" title={title}>
-            <Text>{message}</Text>
-          </StatusView>
+        <div className="flex flex-1 flex-col h-full">
+          <div className="flex-1 flex flex-col gap-8 items-center justify-center">
+            <StatusView imageName="error" title={title}>
+              <Text>{message}</Text>
+            </StatusView>
 
-          <div className="flex flex-col gap-1">
-            {showRetry && (
-              <Button action="primary" text="Try again" onClick={goBack} />
-            )}
-            {showChooseAnother && (
-              <Button
-                action={showRetry ? 'secondary' : 'primary'}
-                onClick={() => goToStep('sign-up')}
-                text="Choose another sign-in method"
-              />
-            )}
-            {!showRetry && !showChooseAnother && (
-              <Button action="primary" text="Start over" onClick={reset} />
-            )}
+            <div className="flex flex-col gap-1">
+              {showRetry && (
+                <Button action="primary" text="Try again" onClick={goBack} />
+              )}
+              {showChooseAnother && (
+                <Button
+                  action={showRetry ? 'secondary' : 'primary'}
+                  onClick={() => goToStep('sign-up')}
+                  text="Choose another sign-in method"
+                />
+              )}
+              {!showRetry && !showChooseAnother && (
+                <Button action="primary" text="Start over" onClick={reset} />
+              )}
+            </div>
           </div>
 
-          <AppLogo className="self-center pb-6" />
+          <AppLogo className="self-center pt-4 pb-6" />
         </div>
       )}
     </ScreenWrapper>

--- a/packages/react-kit/src/auth/pages/ErrorScreen.tsx
+++ b/packages/react-kit/src/auth/pages/ErrorScreen.tsx
@@ -44,7 +44,7 @@ export function ErrorScreen({
             )}
           </div>
 
-          <AppLogo className="absolute self-center bottom-6" />
+          <AppLogo className="self-center pb-6" />
         </div>
       )}
     </ScreenWrapper>

--- a/packages/react-kit/src/auth/pages/OtpInput.tsx
+++ b/packages/react-kit/src/auth/pages/OtpInput.tsx
@@ -79,46 +79,50 @@ export function OtpInput() {
   return (
     <ScreenWrapper>
       {() => (
-        <div className="flex flex-1 flex-col gap-8 py-6 justify-center items-center h-full">
-          <div className="flex flex-col gap-4">
-            <Text className="text-h2 text-center">Enter verification code</Text>
-            <Text className="text-center">
-              Enter the code from the email we sent to{' '}
-              <Text className="text-solarOrange">{email}</Text>
-            </Text>
+        <div className="flex flex-1 flex-col h-full pt-6">
+          <div className="flex-1 flex flex-col gap-8 justify-center items-center">
+            <div className="flex flex-col gap-4">
+              <Text className="text-h2 text-center">
+                Enter verification code
+              </Text>
+              <Text className="text-center">
+                Enter the code from the email we sent to{' '}
+                <Text className="text-solarOrange">{email}</Text>
+              </Text>
+            </div>
+
+            <CodeInput
+              onComplete={handleComplete}
+              onChange={() => setError(false)}
+              disabled={isPending}
+              error={error}
+              autoFocus
+            />
+
+            <Button
+              text="Confirm code"
+              onClick={handleVerify}
+              disabled={!otp.trim() || isPending}
+            />
+
+            <div className="flex flex-col gap-1">
+              <Text className="text-center">
+                Did not get an email?{' '}
+                <button
+                  type="button"
+                  disabled={!canResend}
+                  onClick={handleResend}
+                  className="cursor-pointer underline disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {canResend
+                    ? 'Resend'
+                    : `Resend in ${secondsUntilResend} ${secondsUntilResend === 1 ? 'second' : 'seconds'}`}
+                </button>
+              </Text>
+            </div>
           </div>
 
-          <CodeInput
-            onComplete={handleComplete}
-            onChange={() => setError(false)}
-            disabled={isPending}
-            error={error}
-            autoFocus
-          />
-
-          <Button
-            text="Confirm code"
-            onClick={handleVerify}
-            disabled={!otp.trim() || isPending}
-          />
-
-          <div className="flex flex-col gap-1">
-            <Text className="text-center">
-              Did not get an email?{' '}
-              <button
-                type="button"
-                disabled={!canResend}
-                onClick={handleResend}
-                className="cursor-pointer underline disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {canResend
-                  ? 'Resend'
-                  : `Resend in ${secondsUntilResend} ${secondsUntilResend === 1 ? 'second' : 'seconds'}`}
-              </button>
-            </Text>
-          </div>
-
-          <AppLogo className="self-center" />
+          <AppLogo className="self-center pt-4 pb-6" />
         </div>
       )}
     </ScreenWrapper>

--- a/packages/react-kit/src/auth/pages/OtpInput.tsx
+++ b/packages/react-kit/src/auth/pages/OtpInput.tsx
@@ -79,7 +79,7 @@ export function OtpInput() {
   return (
     <ScreenWrapper>
       {() => (
-        <div className="flex flex-1 flex-col gap-8 justify-center items-center h-full">
+        <div className="flex flex-1 flex-col gap-8 py-6 justify-center items-center h-full">
           <div className="flex flex-col gap-4">
             <Text className="text-h2 text-center">Enter verification code</Text>
             <Text className="text-center">
@@ -118,7 +118,7 @@ export function OtpInput() {
             </Text>
           </div>
 
-          <AppLogo className="absolute self-center bottom-6" />
+          <AppLogo className="self-center" />
         </div>
       )}
     </ScreenWrapper>

--- a/packages/react-kit/src/auth/pages/SignUp.tsx
+++ b/packages/react-kit/src/auth/pages/SignUp.tsx
@@ -86,10 +86,6 @@ export function SignUp() {
     }
   }
 
-  const handleChooseWallet = () => {
-    goToStep('wallet-selection')
-  }
-
   if (error) {
     return (
       <div className="flex items-center justify-center min-h-screen">
@@ -167,14 +163,14 @@ export function SignUp() {
                 </Input>
               </div>
               <OrView />
-              <ListItem
+              {/* <ListItem
                 iconName="walletOutline"
                 title="Choose a wallet instead"
                 disabled={anyPending}
                 onClick={handleChooseWallet}
                 chevron
                 className="rounded-3xl"
-              />
+              /> */}
             </div>
           </div>
           <SignUpFooter

--- a/packages/react-kit/src/auth/pages/Verifying.tsx
+++ b/packages/react-kit/src/auth/pages/Verifying.tsx
@@ -52,40 +52,45 @@ export function Verifying() {
   return (
     <ScreenWrapper>
       {() => (
-        <div className="flex flex-1 flex-col gap-8 items-center justify-center h-full">
-          {isVerificationLoading && (
-            <StatusView imageName="loading" title="Verifying Your Email">
-              <Text>Please wait while we securely connect your wallet.</Text>
-            </StatusView>
-          )}
+        <div className="flex flex-1 flex-col h-full">
+          <div className="flex-1 flex flex-col gap-8 items-center justify-center">
+            {isVerificationLoading && (
+              <StatusView imageName="loading" title="Verifying Your Email">
+                <Text>Please wait while we securely connect your wallet.</Text>
+              </StatusView>
+            )}
 
-          {!code && !isVerificationLoading && (
-            <StatusView imageName="error" title="Invalid Link">
-              <Text>
-                This verification link is invalid or incomplete.
-                <br />
-                Please check your email and try again with the correct link.
-              </Text>
-            </StatusView>
-          )}
-
-          {verificationError != null && (
-            <>
-              <StatusView imageName="error" title="Oops, something went wrong">
+            {!code && !isVerificationLoading && (
+              <StatusView imageName="error" title="Invalid Link">
                 <Text>
-                  We couldn't complete the sign-in process. This could be due to
-                  timeout, an expired link, or a cancelled request.
+                  This verification link is invalid or incomplete.
+                  <br />
+                  Please check your email and try again with the correct link.
                 </Text>
               </StatusView>
-              <Button
-                action="primary"
-                onClick={() => goToStep('sign-up')}
-                text="Choose another sign-in method"
-              />
-            </>
-          )}
+            )}
 
-          <AppLogo className="self-center pb-6" />
+            {verificationError != null && (
+              <>
+                <StatusView
+                  imageName="error"
+                  title="Oops, something went wrong"
+                >
+                  <Text>
+                    We couldn't complete the sign-in process. This could be due
+                    to timeout, an expired link, or a cancelled request.
+                  </Text>
+                </StatusView>
+                <Button
+                  action="primary"
+                  onClick={() => goToStep('sign-up')}
+                  text="Choose another sign-in method"
+                />
+              </>
+            )}
+          </div>
+
+          <AppLogo className="self-center pt-4 pb-6" />
         </div>
       )}
     </ScreenWrapper>

--- a/packages/react-kit/src/auth/pages/Verifying.tsx
+++ b/packages/react-kit/src/auth/pages/Verifying.tsx
@@ -85,7 +85,7 @@ export function Verifying() {
             </>
           )}
 
-          <AppLogo className="absolute self-center bottom-6" />
+          <AppLogo className="self-center pb-6" />
         </div>
       )}
     </ScreenWrapper>

--- a/packages/react-kit/src/shared/components/ScreenWrapper/MultiRadialBackground.tsx
+++ b/packages/react-kit/src/shared/components/ScreenWrapper/MultiRadialBackground.tsx
@@ -65,7 +65,7 @@ export function MultiRadialBackground() {
   ]
 
   return (
-    <div className="absolute inset-0 -z-20 rounded-[36px] pointer-events-none">
+    <div className="absolute inset-0 z-0 rounded-[36px] pointer-events-none">
       <svg
         width="100%"
         height="100%"

--- a/packages/react-kit/src/shared/components/ScreenWrapper/index.tsx
+++ b/packages/react-kit/src/shared/components/ScreenWrapper/index.tsx
@@ -26,7 +26,7 @@ export function ScreenWrapper({
   return (
     <div
       className={cn(
-        'flex-1 flex flex-col relative overflow-hidden h-full max-w-[500px] rounded-[30px]',
+        'flex-1 flex flex-col relative overflow-hidden h-full w-[500px] rounded-[34px]',
         className,
       )}
       style={style}

--- a/packages/react-kit/src/shared/components/ScreenWrapper/index.tsx
+++ b/packages/react-kit/src/shared/components/ScreenWrapper/index.tsx
@@ -26,7 +26,7 @@ export function ScreenWrapper({
   return (
     <div
       className={cn(
-        'flex-1 flex flex-col relative overflow-hidden h-full',
+        'flex-1 flex flex-col relative overflow-hidden h-full max-w-[500px] rounded-[30px]',
         className,
       )}
       style={style}


### PR DESCRIPTION
closes fs-2142

  - Expand the docs `<SignatureRequest />` live demo to mirror `apps/react-example`'s button set: ETH/ERC-20 send, ERC-20 approve, collection approval, sign message, sign typed data, batch calls.
  - Fix `ScreenWrapper` rendering in non-fullscreen embeds (the kind of host layout the docs use, but also any consumer dropping the kit into a panel rather than a phone-frame parent):
    - `MultiRadialBackground` `-z-20` → `z-0`. The negative z-index escaped `ScreenWrapper`'s non-stacking-context parent and pushed the gradient SVG behind unrelated page chrome.
    - Added `max-w-[500px] rounded-[30px]` to `ScreenWrapper` so the panel keeps phone-frame proportions in wide hosts.
    - `<AppLogo>` on auth pages: `absolute bottom-6` → flow positioning, since absolute positioning ignored the new max-width and overlapped content.
  - Hide the "Choose a wallet instead" entry on `SignUp` (commented, not deleted) — the `wallet-selection` step still renders a placeholder, so the entry was a dead end.
  - Fix disconnect button text in the docs (was inheriting white from vocs's page color).

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
