### PR TITLE
feat(react-kit): magic link docs

### DIFF
--- a/packages/react-kit/docs/pages/verify.mdx
+++ b/packages/react-kit/docs/pages/verify.mdx
@@ -1,0 +1,19 @@
+import AuthFlowExample from '../components/AuthFlow'
+
+# Magic Link Authentication
+
+<AuthFlowExample />
+
+<a
+  href="/react-kit/features/authentication"
+  style={{
+    display: 'inline-block',
+    marginTop: 24,
+    padding: '8px 16px',
+    border: '1px solid #e5e7eb',
+    borderRadius: 8,
+    textDecoration: 'none',
+  }}
+>
+  ← Back to Authentication docs
+</a>


### PR DESCRIPTION
Closes [FS-2145](https://linear.app/offchain-labs/issue/FS-2145/add-redirect-page-for-magic-link-sign-in-to-docs)

### Summary

This PR adds support for magic link in docs