### PR TITLE
feat(react-kit): configurable T&C and privacy policy URLs in auth

### DIFF
--- a/apps/react-example/src/wagmi.ts
+++ b/apps/react-example/src/wagmi.ts
@@ -13,6 +13,8 @@ export const wagmiConfig = createConfig({
           magicLinkBaseUrl: 'http://localhost:3000/verify',
           enabledMethods: ['email', 'google', 'passkey'],
           // emailAuthMethod: 'otp', // set email auth method, 'magicLink' or 'otp', default is 'magicLink'
+          termsAndConditionsUrl: 'https://www.example.com',
+          privacyPolicyUrl: 'https://www.example.com',
           onSuccess: () => {
             // handle successful authentication
           },

--- a/packages/react-kit/docs/pages/react-kit/configuration.mdx
+++ b/packages/react-kit/docs/pages/react-kit/configuration.mdx
@@ -15,6 +15,38 @@ zeroDevKitWallet({
 
 Signing confirmation is enabled by default (`prompt` mode). No extra config needed.
 
+## Auth
+
+Configure the [authentication flow](/react-kit/features/authentication). To display the auth UI, mount the [`<AuthFlow />`](/react-kit/features/authentication) component in your app.
+
+```tsx
+zeroDevKitWallet({
+  projectId: '...',
+  chains: [sepolia],
+  config: {
+    auth: {
+      magicLinkBaseUrl: 'https://yourdomain.com/auth/verify',
+      enabledMethods: ['email', 'google', 'passkey'],
+      termsAndConditionsUrl: 'https://yourdomain.com/terms',
+      privacyPolicyUrl: 'https://yourdomain.com/privacy',
+    },
+  },
+})
+```
+
+### `config.auth`
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `magicLinkBaseUrl` | `string` | The URL the magic link points to. |
+| `enabledMethods` | `AuthMethod[]` | Which methods to offer: `'email'`, `'google'`, `'passkey'`, `'injected-wallet'`. |
+| `termsAndConditionsUrl` | `string` (optional) | Your terms and conditions URL. When set (alone or with `privacyPolicyUrl`), the auth UI shows a required agreement checkbox. |
+| `privacyPolicyUrl` | `string` (optional) | Your privacy policy URL. When set (alone or with `termsAndConditionsUrl`), the auth UI shows a required agreement checkbox. |
+| `onSuccess` | `() => void` | Called when authentication completes successfully. |
+| `onError` | `(error: unknown) => void` | Called when authentication fails. |
+
+Full reference: [Authentication](/react-kit/features/authentication).
+
 ## Signing
 
 Control whether transactions and signing requests show a confirmation UI. To display the confirmation UI, mount the [`<SignatureRequest />`](/react-kit/features/transaction-signing) component in your app.

--- a/packages/react-kit/docs/pages/react-kit/features/authentication.mdx
+++ b/packages/react-kit/docs/pages/react-kit/features/authentication.mdx
@@ -27,6 +27,8 @@ zeroDevKitWallet({
     auth: {
       magicLinkBaseUrl: 'https://yourdomain.com/auth/verify',
       enabledMethods: ['email', 'google', 'passkey'],
+      termsAndConditionsUrl: 'https://yourdomain.com/terms',
+      privacyPolicyUrl: 'https://yourdomain.com/privacy',
       onSuccess: () => {
         // user is authenticated
       },
@@ -42,8 +44,14 @@ zeroDevKitWallet({
 | --- | --- | --- |
 | `magicLinkBaseUrl` | `string` | The URL the magic link points to. Your app should call the verification handler at this path. |
 | `enabledMethods` | `AuthMethod[]` | Which methods to offer: `'email'`, `'google'`, `'passkey'`, `'injected-wallet'`. |
+| `termsAndConditionsUrl` | `string` (optional) | URL for your terms and conditions page. When set (alone or with `privacyPolicyUrl`), the auth UI shows a required agreement checkbox before the user can continue. |
+| `privacyPolicyUrl` | `string` (optional) | URL for your privacy policy page. When set (alone or with `termsAndConditionsUrl`), the auth UI shows a required agreement checkbox before the user can continue. |
 | `onSuccess` | `() => void` | Called when authentication completes successfully. |
 | `onError` | `(error: unknown) => void` | Called when authentication fails. |
+
+If you set neither `termsAndConditionsUrl` nor `privacyPolicyUrl`, the
+agreement checkbox is hidden entirely and the user can proceed without
+any consent step.
 
 ## Usage
 

--- a/packages/react-kit/src/auth/pages/SignUp.tsx
+++ b/packages/react-kit/src/auth/pages/SignUp.tsx
@@ -48,8 +48,13 @@ export function SignUp() {
 
   const [error, setError] = useState<string | null>(null)
   const anyPending = isGoogleLoading || isEmailLoading
+  const requiresAgreement = !!(
+    config?.termsAndConditionsUrl || config?.privacyPolicyUrl
+  )
+  const canContinue = !requiresAgreement || agreedToTerms
 
   const handleGoogleAuth = async () => {
+    if (!canContinue) return
     setError(null)
     try {
       await authenticateOAuth({ provider: 'google' })
@@ -62,11 +67,12 @@ export function SignUp() {
   }
 
   const handleTwitterAuth = () => {
+    if (!canContinue) return
     alert('Twitter authentication coming soon')
   }
 
   const handleEmailSubmit = async () => {
-    if (!emailInput || anyPending) return
+    if (!emailInput || anyPending || !canContinue) return
 
     setError(null)
     try {
@@ -120,14 +126,14 @@ export function SignUp() {
                     iconName="google"
                     title="Google"
                     className="flex-1 rounded-3xl"
-                    disabled={anyPending}
+                    disabled={anyPending || !canContinue}
                     onClick={handleGoogleAuth}
                   />
                   <ListItem
                     iconName="xTwitter"
                     title="X.com"
                     className="flex-1 rounded-3xl"
-                    disabled={anyPending}
+                    disabled={anyPending || !canContinue}
                     onClick={handleTwitterAuth}
                   />
                 </div>
@@ -142,12 +148,17 @@ export function SignUp() {
                   disabled={anyPending}
                   variant="listItemStyle"
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter' && emailInput && !anyPending) {
+                    if (
+                      e.key === 'Enter' &&
+                      emailInput &&
+                      !anyPending &&
+                      canContinue
+                    ) {
                       handleEmailSubmit()
                     }
                   }}
                 >
-                  {emailInput && !anyPending ? (
+                  {emailInput && !anyPending && canContinue ? (
                     <button
                       type="button"
                       className="w-13 h-13 rounded-2xl bg-greyScale/[3%] flex items-center justify-center hover:bg-greyScale/[5%] transition-colors cursor-pointer"
@@ -166,7 +177,7 @@ export function SignUp() {
               {/* <ListItem
                 iconName="walletOutline"
                 title="Choose a wallet instead"
-                disabled={anyPending}
+                disabled={anyPending || !canContinue}
                 onClick={handleChooseWallet}
                 chevron
                 className="rounded-3xl"
@@ -174,6 +185,8 @@ export function SignUp() {
             </div>
           </div>
           <SignUpFooter
+            termsAndConditionsUrl={config?.termsAndConditionsUrl}
+            privacyPolicyUrl={config?.privacyPolicyUrl}
             agreedToTerms={agreedToTerms}
             setAgreedToTerms={setAgreedToTerms}
           />

--- a/packages/react-kit/src/auth/types.ts
+++ b/packages/react-kit/src/auth/types.ts
@@ -18,6 +18,8 @@ export interface AuthConfig {
   magicLinkBaseUrl: string
   enabledMethods: AuthMethod[]
   emailAuthMethod?: EmailAuthMethod
+  termsAndConditionsUrl?: string
+  privacyPolicyUrl?: string
   onSuccess?: () => void
   onError?: (error: unknown) => void
 }

--- a/packages/react-kit/src/shared/components/SignUpFooter/SignUpFooter.stories.tsx
+++ b/packages/react-kit/src/shared/components/SignUpFooter/SignUpFooter.stories.tsx
@@ -3,6 +3,9 @@ import { useState } from 'react'
 
 import { SignUpFooter } from '.'
 
+const TERMS_URL = 'https://example.com/terms'
+const PRIVACY_URL = 'https://example.com/privacy'
+
 const meta = {
   title: 'Shared/SignUpFooter',
   component: SignUpFooter,
@@ -18,80 +21,61 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Unchecked: Story = {
+function Wrap(props: React.ComponentProps<typeof SignUpFooter>) {
+  const [agreed, setAgreed] = useState(props.agreedToTerms)
+  return (
+    <div className="w-96 p-6 bg-white rounded-lg">
+      <SignUpFooter
+        {...props}
+        agreedToTerms={agreed}
+        setAgreedToTerms={setAgreed}
+      />
+    </div>
+  )
+}
+
+export const BothLinks: Story = {
   args: {
     agreedToTerms: false,
     setAgreedToTerms: () => {},
+    termsAndConditionsUrl: TERMS_URL,
+    privacyPolicyUrl: PRIVACY_URL,
   },
-  render: () => {
-    const [agreed, setAgreed] = useState(false)
-    return (
-      <div className="w-96 p-6 bg-white rounded-lg">
-        <SignUpFooter agreedToTerms={agreed} setAgreedToTerms={setAgreed} />
-      </div>
-    )
-  },
+  render: (args) => <Wrap {...args} />,
 }
 
 export const Checked: Story = {
   args: {
     agreedToTerms: true,
     setAgreedToTerms: () => {},
+    termsAndConditionsUrl: TERMS_URL,
+    privacyPolicyUrl: PRIVACY_URL,
   },
-  render: () => {
-    const [agreed, setAgreed] = useState(true)
-    return (
-      <div className="w-96 p-6 bg-white rounded-lg">
-        <SignUpFooter agreedToTerms={agreed} setAgreedToTerms={setAgreed} />
-      </div>
-    )
-  },
+  render: (args) => <Wrap {...args} />,
 }
 
-export const InSignUpForm: Story = {
+export const OnlyTerms: Story = {
+  args: {
+    agreedToTerms: false,
+    setAgreedToTerms: () => {},
+    termsAndConditionsUrl: TERMS_URL,
+  },
+  render: (args) => <Wrap {...args} />,
+}
+
+export const OnlyPrivacy: Story = {
+  args: {
+    agreedToTerms: false,
+    setAgreedToTerms: () => {},
+    privacyPolicyUrl: PRIVACY_URL,
+  },
+  render: (args) => <Wrap {...args} />,
+}
+
+export const NoAgreement: Story = {
   args: {
     agreedToTerms: false,
     setAgreedToTerms: () => {},
   },
-  render: () => {
-    const [agreed, setAgreed] = useState(false)
-    const [email, setEmail] = useState('')
-    const [password, setPassword] = useState('')
-
-    return (
-      <div className="w-96 p-6 bg-white rounded-lg shadow-lg">
-        <h2 className="text-2xl font-bold text-gray-900 mb-6 text-center">
-          Create Account
-        </h2>
-        <div className="flex flex-col gap-4 mb-6">
-          <input
-            type="email"
-            placeholder="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className="px-4 py-3 rounded-lg border border-gray-300"
-          />
-          <input
-            type="password"
-            placeholder="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className="px-4 py-3 rounded-lg border border-gray-300"
-          />
-          <button
-            type="button"
-            disabled={!agreed}
-            className={`px-4 py-3 rounded-lg font-medium transition-colors ${
-              agreed
-                ? 'bg-blue-500 text-white hover:bg-blue-600 cursor-pointer'
-                : 'bg-gray-300 text-gray-500 cursor-not-allowed'
-            }`}
-          >
-            Sign Up
-          </button>
-        </div>
-        <SignUpFooter agreedToTerms={agreed} setAgreedToTerms={setAgreed} />
-      </div>
-    )
-  },
+  render: (args) => <Wrap {...args} />,
 }

--- a/packages/react-kit/src/shared/components/SignUpFooter/SignUpFooter.test.tsx
+++ b/packages/react-kit/src/shared/components/SignUpFooter/SignUpFooter.test.tsx
@@ -1,121 +1,136 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-// Mock the AppLogo component
 vi.mock('../AppLogo', () => ({
   AppLogo: () => <div data-testid="app-logo">App Logo</div>,
 }))
 
 import { SignUpFooter } from './index'
 
+const TERMS_URL = 'https://example.com/terms'
+const PRIVACY_URL = 'https://example.com/privacy'
+
 afterEach(() => {
   cleanup()
 })
 
 describe('SignUpFooter', () => {
-  describe('rendering', () => {
-    it('renders the checkbox', () => {
-      const mockSetAgreed = vi.fn()
-      render(
-        <SignUpFooter agreedToTerms={false} setAgreedToTerms={mockSetAgreed} />,
-      )
-
-      const checkbox = screen.getByRole('checkbox')
-      expect(checkbox).toBeDefined()
-    })
-
-    it('renders the terms and conditions text', () => {
-      const mockSetAgreed = vi.fn()
-      render(
-        <SignUpFooter agreedToTerms={false} setAgreedToTerms={mockSetAgreed} />,
-      )
-
-      expect(screen.getByText(/I agree to the/i)).toBeDefined()
-      expect(screen.getByText('Terms & Conditions')).toBeDefined()
-      expect(screen.getByText('Privacy Policy')).toBeDefined()
-    })
-
-    it('renders the AppLogo', () => {
-      const mockSetAgreed = vi.fn()
-      render(
-        <SignUpFooter agreedToTerms={false} setAgreedToTerms={mockSetAgreed} />,
-      )
+  describe('without legal URLs', () => {
+    it('renders only the AppLogo when neither URL is provided', () => {
+      render(<SignUpFooter agreedToTerms={false} setAgreedToTerms={vi.fn()} />)
 
       expect(screen.getByTestId('app-logo')).toBeDefined()
+      expect(screen.queryByRole('checkbox')).toBeNull()
+      expect(screen.queryByText(/I agree to the/i)).toBeNull()
+    })
+  })
+
+  describe('with both URLs', () => {
+    it('renders checkbox and both links', () => {
+      render(
+        <SignUpFooter
+          agreedToTerms={false}
+          setAgreedToTerms={vi.fn()}
+          termsAndConditionsUrl={TERMS_URL}
+          privacyPolicyUrl={PRIVACY_URL}
+        />,
+      )
+
+      expect(screen.getByRole('checkbox')).toBeDefined()
+      expect(screen.getByText(/I agree to the/i)).toBeDefined()
+
+      const tc = screen.getByText('Terms & Conditions') as HTMLAnchorElement
+      const pp = screen.getByText('Privacy Policy') as HTMLAnchorElement
+      expect(tc.getAttribute('href')).toBe(TERMS_URL)
+      expect(pp.getAttribute('href')).toBe(PRIVACY_URL)
+    })
+
+    it('joins the two links with " and "', () => {
+      const { container } = render(
+        <SignUpFooter
+          agreedToTerms={false}
+          setAgreedToTerms={vi.fn()}
+          termsAndConditionsUrl={TERMS_URL}
+          privacyPolicyUrl={PRIVACY_URL}
+        />,
+      )
+      expect(container.textContent).toContain(
+        'I agree to the Terms & Conditions and Privacy Policy',
+      )
+    })
+  })
+
+  describe('with only Terms & Conditions URL', () => {
+    it('renders checkbox and only T&C link', () => {
+      render(
+        <SignUpFooter
+          agreedToTerms={false}
+          setAgreedToTerms={vi.fn()}
+          termsAndConditionsUrl={TERMS_URL}
+        />,
+      )
+
+      expect(screen.getByRole('checkbox')).toBeDefined()
+      expect(screen.getByText('Terms & Conditions')).toBeDefined()
+      expect(screen.queryByText('Privacy Policy')).toBeNull()
+    })
+  })
+
+  describe('with only Privacy Policy URL', () => {
+    it('renders checkbox and only Privacy link', () => {
+      render(
+        <SignUpFooter
+          agreedToTerms={false}
+          setAgreedToTerms={vi.fn()}
+          privacyPolicyUrl={PRIVACY_URL}
+        />,
+      )
+
+      expect(screen.getByRole('checkbox')).toBeDefined()
+      expect(screen.getByText('Privacy Policy')).toBeDefined()
+      expect(screen.queryByText('Terms & Conditions')).toBeNull()
     })
   })
 
   describe('checkbox state', () => {
-    it('renders checkbox as unchecked when agreedToTerms is false', () => {
-      const mockSetAgreed = vi.fn()
+    it('reflects agreedToTerms=false', () => {
       render(
-        <SignUpFooter agreedToTerms={false} setAgreedToTerms={mockSetAgreed} />,
+        <SignUpFooter
+          agreedToTerms={false}
+          setAgreedToTerms={vi.fn()}
+          termsAndConditionsUrl={TERMS_URL}
+        />,
       )
-
-      const checkbox = screen.getByRole('checkbox') as HTMLInputElement
-      expect(checkbox.checked).toBe(false)
+      expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(
+        false,
+      )
     })
 
-    it('renders checkbox as checked when agreedToTerms is true', () => {
-      const mockSetAgreed = vi.fn()
+    it('reflects agreedToTerms=true', () => {
       render(
-        <SignUpFooter agreedToTerms={true} setAgreedToTerms={mockSetAgreed} />,
+        <SignUpFooter
+          agreedToTerms={true}
+          setAgreedToTerms={vi.fn()}
+          termsAndConditionsUrl={TERMS_URL}
+        />,
       )
-
-      const checkbox = screen.getByRole('checkbox') as HTMLInputElement
-      expect(checkbox.checked).toBe(true)
+      expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(
+        true,
+      )
     })
 
-    it('calls setAgreedToTerms with true when checkbox is clicked while unchecked', () => {
+    it('calls setAgreedToTerms when toggled', () => {
       const mockSetAgreed = vi.fn()
       render(
-        <SignUpFooter agreedToTerms={false} setAgreedToTerms={mockSetAgreed} />,
+        <SignUpFooter
+          agreedToTerms={false}
+          setAgreedToTerms={mockSetAgreed}
+          termsAndConditionsUrl={TERMS_URL}
+        />,
       )
 
-      const checkbox = screen.getByRole('checkbox')
-      fireEvent.click(checkbox)
-
+      fireEvent.click(screen.getByRole('checkbox'))
       expect(mockSetAgreed).toHaveBeenCalledWith(true)
-    })
-
-    it('calls setAgreedToTerms with false when checkbox is clicked while checked', () => {
-      const mockSetAgreed = vi.fn()
-      render(
-        <SignUpFooter agreedToTerms={true} setAgreedToTerms={mockSetAgreed} />,
-      )
-
-      const checkbox = screen.getByRole('checkbox')
-      fireEvent.click(checkbox)
-
-      expect(mockSetAgreed).toHaveBeenCalledWith(false)
-    })
-  })
-
-  describe('layout', () => {
-    it('renders with correct container classes', () => {
-      const mockSetAgreed = vi.fn()
-      const { container } = render(
-        <SignUpFooter agreedToTerms={false} setAgreedToTerms={mockSetAgreed} />,
-      )
-
-      const wrapper = container.firstChild as HTMLElement
-      expect(wrapper.className).toContain('flex')
-      expect(wrapper.className).toContain('flex-col')
-      expect(wrapper.className).toContain('items-center')
-      expect(wrapper.className).toContain('gap-5')
-    })
-
-    it('renders checkbox row with correct layout classes', () => {
-      const mockSetAgreed = vi.fn()
-      const { container } = render(
-        <SignUpFooter agreedToTerms={false} setAgreedToTerms={mockSetAgreed} />,
-      )
-
-      // Get the inner div (checkbox row), not the container
-      const checkboxRow = container.querySelector('.flex.flex-row')
-      expect(checkboxRow).toBeDefined()
-      expect(checkboxRow?.className).toContain('items-center')
-      expect(checkboxRow?.className).toContain('gap-2')
     })
   })
 })

--- a/packages/react-kit/src/shared/components/SignUpFooter/index.tsx
+++ b/packages/react-kit/src/shared/components/SignUpFooter/index.tsx
@@ -2,44 +2,56 @@ import { AppLogo } from '../AppLogo'
 import { Text } from '../Text'
 
 export function SignUpFooter({
+  termsAndConditionsUrl,
+  privacyPolicyUrl,
   agreedToTerms,
   setAgreedToTerms,
 }: {
+  termsAndConditionsUrl?: string | undefined
+  privacyPolicyUrl?: string | undefined
   agreedToTerms: boolean
   setAgreedToTerms: (agreed: boolean) => void
 }) {
+  const showAgreement = !!(termsAndConditionsUrl || privacyPolicyUrl)
+
   return (
     <div className="flex flex-col items-center gap-5">
-      <div className="flex flex-row items-center gap-2">
-        <input
-          type="checkbox"
-          checked={agreedToTerms}
-          onChange={(e) => setAgreedToTerms(e.target.checked)}
-          className="cursor-pointer"
-        />
-        <Text className="flex-1">
-          I agree to the{' '}
-          <Text
-            as="a"
-            href="https://zerodev.app/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline"
-          >
-            Terms & Conditions
-          </Text>{' '}
-          and{' '}
-          <Text
-            as="a"
-            href="https://zerodev.app/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline"
-          >
-            Privacy Policy
+      {showAgreement && (
+        <div className="flex flex-row items-center gap-2">
+          <input
+            type="checkbox"
+            checked={agreedToTerms}
+            onChange={(e) => setAgreedToTerms(e.target.checked)}
+            className="cursor-pointer"
+          />
+          <Text className="flex-1">
+            I agree to the{' '}
+            {termsAndConditionsUrl && (
+              <Text
+                as="a"
+                href={termsAndConditionsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                Terms & Conditions
+              </Text>
+            )}
+            {termsAndConditionsUrl && privacyPolicyUrl && ' and '}
+            {privacyPolicyUrl && (
+              <Text
+                as="a"
+                href={privacyPolicyUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                Privacy Policy
+              </Text>
+            )}
           </Text>
-        </Text>
-      </div>
+        </div>
+      )}
       <AppLogo />
     </div>
   )


### PR DESCRIPTION
closes FS-2146

## Summary

  - Consumers ship under their own brand and can't surface their own legal copy through the kit today — the auth UI links to `https://zerodev.app/`. Adds optional `termsAndConditionsUrl` and `privacyPolicyUrl` to `AuthConfig`.
  - `SignUpFooter` adapts to whatever's set: both → "I agree to the Terms & Conditions and Privacy Policy", one → only that one, neither → checkbox + agreement text hidden entirely. Hardcoded ZeroDev links removed.
  - When at least one URL is set, the checkbox becomes a real gate. Google, Twitter, email submit, and wallet-selection entry points are all disabled (and their handlers refuse to run) until the user checks it. Previously the checkbox was decorative.
  - Docs (`configuration.mdx`, `features/authentication.mdx`) and the demo app's `wagmi.ts` updated to surface the new fields.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
