### PR TITLE
release(core/react): @zerodev/wallet-core@0.0.1-alpha.19 and @zerodev/wallet-react@0.0.1-alpha.21

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -24,12 +24,14 @@
     "lucky-corners-sneeze",
     "neat-apples-repair",
     "neat-birds-count",
+    "oauth-login-url",
     "plenty-glasses-wear",
     "rare-buttons-rescue",
     "shaggy-ants-lay",
     "shy-chefs-behave",
     "thin-trees-grow",
     "warm-files-post",
+    "wicked-banks-wait",
     "wise-shrimps-show"
   ]
 }

--- a/.changeset/wicked-banks-wait.md
+++ b/.changeset/wicked-banks-wait.md
@@ -1,0 +1,10 @@
+---
+"@zerodev/wallet-core": patch
+"@zerodev/wallet-react": patch
+---
+
+fix(react): switch OAuth flow to fetch + verify the Google login URL client-side (audit finding TOB-KMS-1).
+
+The SDK now calls `GET /oauth/google/login-url` to fetch the Google OAuth authorization URL, verifies the URL host is `accounts.google.com` and that its `nonce` query parameter equals `sha256(utf8_bytes_of(pub_key_hex))`, and only then opens the popup. A malicious or compromised backend can no longer substitute its own session pubkey at the Turnkey OIDC step.
+
+Requires backend on `afilios/dpl-477-implement-login-url-endpoint` or later. No public API change to `authenticateOAuth` / `useAuthenticateOAuth`. Removed exports: `buildBackendOAuthUrl`. Added exports: `fetchGoogleLoginUrl`, `verifyGoogleLoginUrl`, `generateOAuthNonce` (encoding fixed to match backend).

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @zerodev/wallet-core
 
+## 0.0.1-alpha.19
+
+### Patch Changes
+
+- fix(react): switch OAuth flow to fetch + verify the Google login URL client-side (audit finding TOB-KMS-1).
+
+  The SDK now calls `GET /oauth/google/login-url` to fetch the Google OAuth authorization URL, verifies the URL host is `accounts.google.com` and that its `nonce` query parameter equals `sha256(utf8_bytes_of(pub_key_hex))`, and only then opens the popup. A malicious or compromised backend can no longer substitute its own session pubkey at the Turnkey OIDC step.
+
+  Requires backend on `afilios/dpl-477-implement-login-url-endpoint` or later. No public API change to `authenticateOAuth` / `useAuthenticateOAuth`. Removed exports: `buildBackendOAuthUrl`. Added exports: `fetchGoogleLoginUrl`, `verifyGoogleLoginUrl`, `generateOAuthNonce` (encoding fixed to match backend).
+
 ## 0.0.1-alpha.18
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-core",
-  "version": "0.0.1-alpha.18",
+  "version": "0.0.1-alpha.19",
   "description": "ZeroDev Wallet SDK built on Turnkey",
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @zerodev/wallet-react
 
+## 0.0.1-alpha.21
+
+### Patch Changes
+
+- fix(react): switch OAuth flow to fetch + verify the Google login URL client-side (audit finding TOB-KMS-1).
+
+  The SDK now calls `GET /oauth/google/login-url` to fetch the Google OAuth authorization URL, verifies the URL host is `accounts.google.com` and that its `nonce` query parameter equals `sha256(utf8_bytes_of(pub_key_hex))`, and only then opens the popup. A malicious or compromised backend can no longer substitute its own session pubkey at the Turnkey OIDC step.
+
+  Requires backend on `afilios/dpl-477-implement-login-url-endpoint` or later. No public API change to `authenticateOAuth` / `useAuthenticateOAuth`. Removed exports: `buildBackendOAuthUrl`. Added exports: `fetchGoogleLoginUrl`, `verifyGoogleLoginUrl`, `generateOAuthNonce` (encoding fixed to match backend).
+
+- fix(react): switch OAuth flow to fetch + verify the Google login URL client-side (audit finding TOB-KMS-1).
+
+  The SDK now calls `GET /oauth/google/login-url` to fetch the Google OAuth authorization URL, verifies the URL host is `accounts.google.com` and that its `nonce` query parameter equals `sha256(utf8_bytes_of(pub_key_hex))`, and only then opens the popup. A malicious or compromised backend can no longer substitute its own session pubkey at the Turnkey OIDC step.
+
+  Requires backend on `afilios/dpl-477-implement-login-url-endpoint` or later. No public API change to `authenticateOAuth` / `useAuthenticateOAuth`. Removed exports: `buildBackendOAuthUrl`. Added exports: `fetchGoogleLoginUrl`, `verifyGoogleLoginUrl`, `generateOAuthNonce` (encoding fixed to match backend).
+
+- Updated dependencies
+  - @zerodev/wallet-core@0.0.1-alpha.19
+
 ## 0.0.1-alpha.20
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-react",
-  "version": "0.0.1-alpha.20",
+  "version": "0.0.1-alpha.21",
   "description": "React hooks for ZeroDev Wallet SDK",
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",


### PR DESCRIPTION
## Summary

Release bumps:
- `@zerodev/wallet-core`: `0.0.1-alpha.18` → `0.0.1-alpha.19`
- `@zerodev/wallet-react`: `0.0.1-alpha.20` → `0.0.1-alpha.21`

Includes the OAuth `login-url` + nonce-verify fix from #155 (audit finding TOB-KMS-1, [DPL-478](https://linear.app/offchain-labs/issue/DPL-478)). Requires backend on `afilios/dpl-477-implement-login-url-endpoint` or later (already merged to main).