### PR TITLE
ci(e2e): point at in-monorepo apps/zerodev-signer-demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # E2E Test Environment Variables
-# Copy this file to .env.e2e and fill in the values
+# Copy this file to .env and fill in the values
 
 # Project ID to test against
 ZD_PROJECT_ID=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,24 +130,8 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     needs: [build]
     steps:
-      - name: Checkout SDK
+      - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Extract demo branch from PR body
-        id: demo-branch
-        if: github.event_name == 'pull_request'
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-        run: |
-          BRANCH=$(echo "$PR_BODY" | grep -oE 'demo-branch:[[:space:]]*[^[:space:]]+' | head -1 | sed 's/demo-branch:[[:space:]]*//')
-          echo "ref=${BRANCH:-main}" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout demo app
-        uses: actions/checkout@v4
-        with:
-          repository: zerodevapp/zerodev-signer-demo
-          ref: ${{ steps.demo-branch.outputs.ref || 'main' }}
-          path: zerodev-signer-demo
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -158,7 +142,7 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - name: Install SDK dependencies
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build SDK
@@ -167,20 +151,8 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 
-      - name: Point demo app to local SDK build
-        working-directory: zerodev-signer-demo
-        run: |
-          node -e "
-          const fs = require('fs');
-          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-          pkg.dependencies['@zerodev/wallet-core'] = 'file:../packages/core';
-          pkg.dependencies['@zerodev/wallet-react'] = 'file:../packages/react';
-          fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));
-          "
-          pnpm install --no-frozen-lockfile
-
       - name: Build and start demo app
-        working-directory: zerodev-signer-demo
+        working-directory: apps/zerodev-signer-demo
         run: |
           pnpm build
           pnpm start &

--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,8 @@ playwright-report/
 test-results/
 blob-report/
 
-# E2E env
-.env.e2e
+# E2E env (see .env.example for required vars)
+.env
 
 # Jetbrains IDEs
 .idea/

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ MIT
 
 - **Website:** [zerodev.app](https://zerodev.app)
 - **Documentation:** [docs.zerodev.app](https://docs.zerodev.app)
-- **Demo:** [Live Demo](https://zerodev-signer-demo.vercel.app/) | [Source](https://github.com/zerodevapp/zerodev-signer-demo)
+- **Demo:** [Live Demo](https://zerodev-signer-demo.vercel.app/) | [Source](./apps/zerodev-signer-demo)
 
 ## Packages
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url'
 import { defineConfig, devices } from '@playwright/test'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const demoAppDir = path.resolve(__dirname, '../../zerodev-signer-demo')
+const demoAppDir = path.resolve(__dirname, '../apps/zerodev-signer-demo')
 
 export default defineConfig({
   testDir: './browser',

--- a/e2e/vitest.integration.config.ts
+++ b/e2e/vitest.integration.config.ts
@@ -1,5 +1,25 @@
+import fs from 'node:fs'
 import path from 'node:path'
 import { defineConfig } from 'vitest/config'
+
+// Load `.env` from repo root (see `.env.example`) into process.env. Done
+// explicitly because vitest's Node test runner reads `process.env` directly
+// and doesn't auto-load dotenv files.
+const envPath = path.resolve(__dirname, '../.env')
+if (fs.existsSync(envPath)) {
+  for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const eq = trimmed.indexOf('=')
+    if (eq < 0) continue
+    const key = trimmed.slice(0, eq).trim()
+    const value = trimmed
+      .slice(eq + 1)
+      .trim()
+      .replace(/^['"]|['"]$/g, '')
+    if (process.env[key] === undefined) process.env[key] = value
+  }
+}
 
 export default defineConfig({
   resolve: {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -313,7 +313,7 @@ import type {
 
 ## React Integration
 
-For React apps, see the demo implementation at [zerodev-wallet-demo](https://github.com/zerodevapp/zerodev-signer-demo).
+For React apps, see the demo implementation at [`apps/zerodev-signer-demo`](../../apps/zerodev-signer-demo).
 
 Key patterns:
 - Use React Context for SDK instance


### PR DESCRIPTION
## Summary

The demo was moved into the SDK monorepo at `apps/zerodev-signer-demo` in #146, but CI + Playwright still pointed at the standalone `zerodevapp/zerodev-signer-demo` repo via an external checkout + `file:` link hack and a `demo-branch:` PR-body convention.

Now that `apps/zerodev-signer-demo` uses `workspace:*` for SDK deps, neither the cross-repo checkout nor the `file:` rewrite are needed: the demo always builds against local source.

Also wires up dotenv loading for integration tests (vitest's Node runner doesn't auto-load `.env` files), and renames `.env.e2e` → `.env` now that it lives next to the rest of the SDK config.

### Changes

- `e2e/playwright.config.ts`: `demoAppDir` → `../apps/zerodev-signer-demo`.
- `.github/workflows/ci.yml`: drop external repo checkout, drop `demo-branch:` parser, drop `package.json` `file:` rewrite; build + start the demo from `apps/zerodev-signer-demo` as part of the SDK install.
- `e2e/vitest.integration.config.ts`: load repo-root `.env` into `process.env` so `ZD_PROJECT_ID` etc. are picked up automatically (vitest's Node runner doesn't do this on its own).
- `.gitignore` + `.env.example`: `.env.e2e` → `.env`.

### Verified locally

- Browser e2e: 9/9 pass against staging (`pnpm test:e2e` with the demo running from `apps/zerodev-signer-demo`).
- Integration: 7/7 pass against staging (`pnpm test:integration`, with `ZD_PROJECT_ID` in `.env`).

### Follow-up

The standalone `zerodevapp/zerodev-signer-demo` repo can be archived after this lands. Vercel project should be migrated to deploy from `apps/zerodev-signer-demo` in this monorepo.