### PR TITLE
feat(react-kit): wallet selection screen for external connectors

### DIFF
--- a/apps/react-example/src/wagmi.ts
+++ b/apps/react-example/src/wagmi.ts
@@ -11,7 +11,7 @@ export const wagmiConfig = createConfig({
       config: {
         auth: {
           magicLinkBaseUrl: 'http://localhost:3000/verify',
-          enabledMethods: ['email', 'google', 'passkey'],
+          enabledMethods: ['email', 'google', 'passkey', 'injected-wallet'],
           // emailAuthMethod: 'otp', // set email auth method, 'magicLink' or 'otp', default is 'magicLink'
           termsAndConditionsUrl: 'https://www.example.com',
           privacyPolicyUrl: 'https://www.example.com',

--- a/packages/react-kit/src/auth/index.test.tsx
+++ b/packages/react-kit/src/auth/index.test.tsx
@@ -33,6 +33,12 @@ vi.mock('./pages/ErrorScreen', () => ({
   ErrorScreen: () => <div data-testid="error">Error Page</div>,
 }))
 
+vi.mock('./pages/WalletSelection', () => ({
+  WalletSelection: () => (
+    <div data-testid="wallet-selection">WalletSelection Page</div>
+  ),
+}))
+
 vi.mock('../shared/components/StatusView', () => ({
   StatusView: ({
     title,
@@ -135,13 +141,7 @@ describe('AuthFlow', () => {
     mockStep = 'wallet-selection'
     render(<AuthFlow />)
 
-    expect(screen.getByTestId('status-view')).toBeDefined()
-    expect(screen.getByTestId('status-title').textContent).toBe(
-      'Select your wallet',
-    )
-    expect(screen.getByTestId('status-content').textContent).toBe(
-      'Please select a wallet to continue.',
-    )
+    expect(screen.getByTestId('wallet-selection')).toBeDefined()
   })
 
   it('renders authenticated state as null', () => {

--- a/packages/react-kit/src/auth/index.tsx
+++ b/packages/react-kit/src/auth/index.tsx
@@ -6,6 +6,7 @@ import { ErrorScreen } from './pages/ErrorScreen'
 import { OtpInput } from './pages/OtpInput'
 import { SignUp } from './pages/SignUp'
 import { Verifying } from './pages/Verifying'
+import { WalletSelection } from './pages/WalletSelection'
 
 function hasMagicLinkCodeInUrl(): boolean {
   if (typeof window === 'undefined') return false
@@ -16,14 +17,6 @@ function OAuthCallback() {
   return (
     <StatusView imageName="loading" title="Authenticating...">
       Please wait while we complete the OAuth authentication.
-    </StatusView>
-  )
-}
-
-function WalletSelection() {
-  return (
-    <StatusView imageName="loading" title="Select your wallet">
-      Please select a wallet to continue.
     </StatusView>
   )
 }

--- a/packages/react-kit/src/auth/pages/WalletSelection.tsx
+++ b/packages/react-kit/src/auth/pages/WalletSelection.tsx
@@ -1,0 +1,62 @@
+import { useConnect } from 'wagmi'
+import { AppLogo } from '../../shared/components/AppLogo'
+import { ListItem } from '../../shared/components/ListItem'
+import { ScreenWrapper } from '../../shared/components/ScreenWrapper'
+import { Text } from '../../shared/components/Text'
+import { useAuth } from '../hooks/useAuth'
+
+export function WalletSelection() {
+  const { goToStep } = useAuth()
+  const { connect, connectors, isPending } = useConnect()
+
+  const externalConnectors = connectors.filter((c) => c.id !== 'zerodev-wallet')
+
+  const handleSelect = (connector: (typeof connectors)[number]) => {
+    connect(
+      { connector },
+      {
+        onSuccess: () => {
+          goToStep('initializing')
+        },
+      },
+    )
+  }
+
+  return (
+    <ScreenWrapper>
+      {({ paddingTop }) => (
+        <div
+          style={{ paddingTop: `${paddingTop}px` }}
+          className="flex flex-1 flex-col h-full"
+        >
+          <div className="flex-1 flex flex-col gap-8 justify-center">
+            <Text className="text-h2 text-center">Select your wallet</Text>
+
+            <div className="flex flex-col gap-2">
+              {externalConnectors.length === 0 ? (
+                <Text className="text-center">
+                  No wallets detected. Install a browser wallet extension to
+                  continue.
+                </Text>
+              ) : (
+                externalConnectors.map((connector) => (
+                  <ListItem
+                    key={connector.uid}
+                    title={connector.name}
+                    iconName="walletOutline"
+                    {...(connector.icon ? { imageUri: connector.icon } : {})}
+                    disabled={isPending}
+                    onClick={() => handleSelect(connector)}
+                    className="rounded-3xl"
+                  />
+                ))
+              )}
+            </div>
+          </div>
+
+          <AppLogo className="self-center pt-4 pb-6" />
+        </div>
+      )}
+    </ScreenWrapper>
+  )
+}


### PR DESCRIPTION
closes FS-2157

## Summary

  - Wires up the previously-placeholder `wallet-selection` step into a real screen. When a consumer enables `'injected-wallet'` and the user clicks "Choose a wallet instead" in `<SignUp />`, they now see a list of every wagmi connector except the kit (`zerodev-wallet`).
  - Selecting a connector calls wagmi's `connect()`. On success the kit's auth state resets to `'initializing'`, so `<AuthFlow />` unmounts and the user is now connected via the external wallet from wagmi's perspective — the kit's own connect flow yields.
  - Uses EIP-6963 connector metadata directly: `connector.name` for the title, `connector.icon` for the wallet's logo, with a `walletOutline` fallback for connectors that don't expose one.
  - Empty state copy when no connectors are detected — prompts the user to install a browser wallet extension.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
