### PR TITLE
feat(react-kit): loading skeletons across signing pages

### DIFF
--- a/packages/react-kit/src/signing/SignatureRequest.test.tsx
+++ b/packages/react-kit/src/signing/SignatureRequest.test.tsx
@@ -18,6 +18,14 @@ vi.mock('wagmi', () => ({
   useConfig: () => mockConfig,
 }))
 
+vi.mock('./hooks/useGasEstimate', () => ({
+  useGasEstimate: () => ({
+    data: 1000n,
+    isFetching: false,
+    isError: false,
+  }),
+}))
+
 import { SignatureRequest } from './index'
 
 function createMockPendingRequest(

--- a/packages/react-kit/src/signing/components/DataRow/DataRow.stories.tsx
+++ b/packages/react-kit/src/signing/components/DataRow/DataRow.stories.tsx
@@ -72,5 +72,5 @@ export const WithCustomValue: Story = {
 }
 
 export const Skeleton: StoryObj<typeof DataRowSkeleton> = {
-  render: () => <DataRowSkeleton label="networkFee" />,
+  render: () => <DataRowSkeleton />,
 }

--- a/packages/react-kit/src/signing/components/DataRow/DataRow.stories.tsx
+++ b/packages/react-kit/src/signing/components/DataRow/DataRow.stories.tsx
@@ -72,5 +72,5 @@ export const WithCustomValue: Story = {
 }
 
 export const Skeleton: StoryObj<typeof DataRowSkeleton> = {
-  render: () => <DataRowSkeleton />,
+  render: () => <DataRowSkeleton label="networkFee" />,
 }

--- a/packages/react-kit/src/signing/components/DataRow/index.tsx
+++ b/packages/react-kit/src/signing/components/DataRow/index.tsx
@@ -45,14 +45,19 @@ export function DataRow({
 
 interface DataRowSkeletonProps {
   className?: string
+  label?: string
 }
 
-export function DataRowSkeleton({ className }: DataRowSkeletonProps) {
+export function DataRowSkeleton({ className, label }: DataRowSkeletonProps) {
   return (
     <div
       className={cn('flex flex-row items-center justify-between', className)}
     >
-      <div className="w-20 h-3 rounded-lg bg-offWhite/50 animate-pulse" />
+      {label ? (
+        <Text>{camelCaseToTitle(label)}</Text>
+      ) : (
+        <div className="w-24 h-3 rounded-lg bg-offWhite/50 animate-pulse" />
+      )}
       <div className="w-24 h-3 rounded-lg bg-offWhite/50 animate-pulse" />
     </div>
   )

--- a/packages/react-kit/src/signing/components/SigningLayout/SigningLayout.test.tsx
+++ b/packages/react-kit/src/signing/components/SigningLayout/SigningLayout.test.tsx
@@ -1,0 +1,83 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../shared/components/Icon', async () => {
+  const React = await import('react')
+
+  const MockIcon = ({
+    name,
+    ...props
+  }: { name: string } & React.SVGProps<SVGSVGElement>) =>
+    React.createElement('svg', { 'data-testid': `icon-${name}`, ...props })
+
+  return {
+    Icon: MockIcon,
+    icons: {},
+  }
+})
+
+import { SigningLayout } from './index'
+
+afterEach(() => {
+  cleanup()
+})
+
+function getButton(label: string): HTMLButtonElement {
+  return screen.getByText(label).closest('button') as HTMLButtonElement
+}
+
+describe('SigningLayout', () => {
+  describe('default state', () => {
+    it('renders children and enables Confirm', () => {
+      render(
+        <SigningLayout onConfirm={vi.fn()} onReject={vi.fn()}>
+          <div data-testid="page-body">page content</div>
+        </SigningLayout>,
+      )
+
+      expect(screen.getByTestId('page-body')).toBeDefined()
+      expect(getButton('Confirm').disabled).toBe(false)
+      expect(getButton('Reject').disabled).toBe(false)
+    })
+  })
+
+  describe('disabled prop', () => {
+    it('disables Confirm while Reject stays enabled', () => {
+      render(
+        <SigningLayout disabled onConfirm={vi.fn()} onReject={vi.fn()}>
+          <div>body</div>
+        </SigningLayout>,
+      )
+
+      expect(getButton('Confirm').disabled).toBe(true)
+      expect(getButton('Reject').disabled).toBe(false)
+    })
+  })
+
+  describe('error prop', () => {
+    it('renders an AlertView with the error message and disables Confirm', () => {
+      const error = new Error('boom')
+      render(
+        <SigningLayout error={error} onConfirm={vi.fn()} onReject={vi.fn()}>
+          <div>body</div>
+        </SigningLayout>,
+      )
+
+      expect(screen.getByText('Unable to process transaction')).toBeDefined()
+      expect(screen.getByText('boom')).toBeDefined()
+      expect(getButton('Confirm').disabled).toBe(true)
+      expect(getButton('Reject').disabled).toBe(false)
+    })
+
+    it('maps insufficient funds errors to a friendly title', () => {
+      const error = new Error('insufficient funds for gas')
+      render(
+        <SigningLayout error={error} onConfirm={vi.fn()} onReject={vi.fn()}>
+          <div>body</div>
+        </SigningLayout>,
+      )
+
+      expect(screen.getByText('Insufficient funds')).toBeDefined()
+    })
+  })
+})

--- a/packages/react-kit/src/signing/components/SigningPageSkeleton/SigningPageSkeleton.stories.tsx
+++ b/packages/react-kit/src/signing/components/SigningPageSkeleton/SigningPageSkeleton.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { SigningPageSkeleton } from '.'
+
+const meta = {
+  title: 'Signing/SigningPageSkeleton',
+  component: SigningPageSkeleton,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{ width: 400 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof SigningPageSkeleton>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/packages/react-kit/src/signing/components/SigningPageSkeleton/index.tsx
+++ b/packages/react-kit/src/signing/components/SigningPageSkeleton/index.tsx
@@ -1,0 +1,33 @@
+import { Wrapper } from '../../../shared/components/Wrapper'
+import { cn } from '../../../shared/utils/common'
+import { DataRowSkeleton } from '../DataRow'
+
+function SkeletonBar({ className }: { className?: string }) {
+  return (
+    <div className={cn('rounded-lg bg-offWhite/50 animate-pulse', className)} />
+  )
+}
+
+function SkeletonCard() {
+  return (
+    <Wrapper className="rounded-xl p-4 w-full flex flex-col gap-3">
+      <div className="flex flex-row items-center gap-3">
+        <SkeletonBar className="w-12 h-12 rounded-2xl" />
+        <div className="flex flex-col gap-2 flex-1">
+          <SkeletonBar className="w-1/2 h-4" />
+          <SkeletonBar className="w-1/3 h-3" />
+        </div>
+      </div>
+    </Wrapper>
+  )
+}
+
+export function SigningPageSkeleton() {
+  return (
+    <div className="flex flex-col gap-2">
+      <SkeletonCard />
+      <SkeletonCard />
+      <DataRowSkeleton />
+    </div>
+  )
+}

--- a/packages/react-kit/src/signing/hooks/useGasEstimate.ts
+++ b/packages/react-kit/src/signing/hooks/useGasEstimate.ts
@@ -5,18 +5,22 @@ import type { ZeroDevWalletState } from '@zerodev/wallet-react'
 import type { Address, Hex } from 'viem'
 import { useChainId, useConfig } from 'wagmi'
 
-type UseGasEstimateParams = {
+export type UseGasEstimateCall = {
   to: Address
-  value?: Hex
-  data?: Hex
+  value?: Hex | undefined
+  data?: Hex | undefined
 }
 
-export function useGasEstimate({ to, value, data }: UseGasEstimateParams) {
+type UseGasEstimateParams = {
+  calls: UseGasEstimateCall[]
+}
+
+export function useGasEstimate({ calls }: UseGasEstimateParams) {
   const config = useConfig()
   const chainId = useChainId()
 
   return useQuery({
-    queryKey: ['userop-gas-estimate', chainId, to, value, data],
+    queryKey: ['userop-gas-estimate', chainId, calls],
     refetchInterval: 12_000,
     retry: false,
     queryFn: async (): Promise<bigint | null> => {
@@ -38,13 +42,11 @@ export function useGasEstimate({ to, value, data }: UseGasEstimateParams) {
       // misleading.
       const userOp = await kernelClient.prepareUserOperation({
         account,
-        calls: [
-          {
-            to,
-            value: value ? BigInt(value) : 0n,
-            data: data ?? '0x',
-          },
-        ],
+        calls: calls.map((c) => ({
+          to: c.to,
+          value: c.value ? BigInt(c.value) : 0n,
+          data: c.data ?? '0x',
+        })),
       })
       const totalGas =
         userOp.preVerificationGas +

--- a/packages/react-kit/src/signing/pages/BatchCalls.tsx
+++ b/packages/react-kit/src/signing/pages/BatchCalls.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import {
   type Address,
   erc20Abi,
@@ -5,16 +6,19 @@ import {
   formatUnits,
   type Hex,
   maxUint256,
+  zeroAddress,
 } from 'viem'
-import { useReadContract } from 'wagmi'
+import { useReadContracts } from 'wagmi'
 
 import { Text } from '../../shared/components/Text'
 import { shortenHex } from '../../shared/utils/common'
 import type { BatchCall } from '../../types.js'
-import { DataRow } from '../components/DataRow'
+import { DataRow, DataRowSkeleton } from '../components/DataRow'
 import { DetailsContainer } from '../components/DetailsContainer'
 import { SigningLayout } from '../components/SigningLayout'
+import { SigningPageSkeleton } from '../components/SigningPageSkeleton'
 import { TxDetailsItem } from '../components/TxDetailsItem'
+import { useGasEstimate } from '../hooks/useGasEstimate'
 import {
   decodeCollectionApproval,
   isCollectionApproval,
@@ -22,9 +26,16 @@ import {
 import { decodeErc20Approval, isErc20Approval } from '../utils/erc20Approval.js'
 import { decodeErc20Transfer, isErc20Transfer } from '../utils/erc20Transfer.js'
 import { isEthTransfer } from '../utils/ethTransfer.js'
+import { formatGasFee } from '../utils/formatGasFee'
 
-const GAS_FEE = '0.00008 ETH ($0.28)'
 const EXECUTION_TIME = '≈ 1 sec'
+
+type TokenInfo = {
+  symbol?: string | undefined
+  decimals?: number | undefined
+}
+
+type TokenInfoMap = Map<Address, TokenInfo>
 
 interface BatchCallsProps {
   calls: BatchCall[]
@@ -54,27 +65,17 @@ function EthTransferItem({
 }
 
 function Erc20TransferItem({
-  contract,
   to,
   amount,
   index,
+  tokenInfo,
 }: {
-  contract: Address
   to: Address
   amount: bigint
   index: number
+  tokenInfo: TokenInfo
 }) {
-  const { data: symbol } = useReadContract({
-    address: contract,
-    abi: erc20Abi,
-    functionName: 'symbol',
-  })
-  const { data: decimals } = useReadContract({
-    address: contract,
-    abi: erc20Abi,
-    functionName: 'decimals',
-  })
-
+  const { symbol, decimals } = tokenInfo
   const formatted =
     decimals != null ? formatUnits(amount, decimals) : String(amount)
   const symbolStr = symbol ?? ''
@@ -92,27 +93,17 @@ function Erc20TransferItem({
 }
 
 function Erc20ApprovalItem({
-  contract,
   spender,
   amount,
   index,
+  tokenInfo,
 }: {
-  contract: Address
   spender: Address
   amount: bigint
   index: number
+  tokenInfo: TokenInfo
 }) {
-  const { data: symbol } = useReadContract({
-    address: contract,
-    abi: erc20Abi,
-    functionName: 'symbol',
-  })
-  const { data: decimals } = useReadContract({
-    address: contract,
-    abi: erc20Abi,
-    functionName: 'decimals',
-  })
-
+  const { symbol, decimals } = tokenInfo
   const isUnlimited = amount === maxUint256
   const allowance = isUnlimited
     ? 'Unlimited'
@@ -167,7 +158,15 @@ function UnknownCallItem({ call, index }: { call: BatchCall; index: number }) {
   return <TxDetailsItem title="Unknown Message" index={index} data={data} />
 }
 
-function CallItem({ call, index }: { call: BatchCall; index: number }) {
+function CallItem({
+  call,
+  index,
+  tokenInfoMap,
+}: {
+  call: BatchCall
+  index: number
+  tokenInfoMap: TokenInfoMap
+}) {
   const tx = call as Parameters<typeof isEthTransfer>[0]
 
   if (isEthTransfer(tx)) {
@@ -183,12 +182,13 @@ function CallItem({ call, index }: { call: BatchCall; index: number }) {
   if (isErc20Transfer(tx)) {
     const decoded = decodeErc20Transfer(tx)
     if (decoded) {
+      const contract = call.to as Address
       return (
         <Erc20TransferItem
-          contract={call.to as Address}
           to={decoded.to}
           amount={decoded.amount}
           index={index}
+          tokenInfo={tokenInfoMap.get(contract) ?? {}}
         />
       )
     }
@@ -197,12 +197,13 @@ function CallItem({ call, index }: { call: BatchCall; index: number }) {
   if (isErc20Approval(tx)) {
     const decoded = decodeErc20Approval(tx)
     if (decoded) {
+      const contract = call.to as Address
       return (
         <Erc20ApprovalItem
-          contract={call.to as Address}
           spender={decoded.spender}
           amount={decoded.amount}
           index={index}
+          tokenInfo={tokenInfoMap.get(contract) ?? {}}
         />
       )
     }
@@ -225,9 +226,84 @@ function CallItem({ call, index }: { call: BatchCall; index: number }) {
   return <UnknownCallItem call={call} index={index} />
 }
 
+function getErc20Addresses(calls: BatchCall[]): Address[] {
+  const addresses = new Set<Address>()
+  for (const call of calls) {
+    if (!call.to) continue
+    const tx = call as Parameters<typeof isEthTransfer>[0]
+    if (isErc20Transfer(tx) || isErc20Approval(tx)) {
+      addresses.add(call.to as Address)
+    }
+  }
+  return [...addresses]
+}
+
 export function BatchCalls({ calls, confirm, reject }: BatchCallsProps) {
+  const erc20Addresses = useMemo(() => getErc20Addresses(calls), [calls])
+
+  const erc20Reads = useMemo(
+    () =>
+      erc20Addresses.flatMap((address) => [
+        {
+          address,
+          abi: erc20Abi,
+          functionName: 'symbol' as const,
+        },
+        {
+          address,
+          abi: erc20Abi,
+          functionName: 'decimals' as const,
+        },
+      ]),
+    [erc20Addresses],
+  )
+
+  const { data: tokenResults, isLoading: tokensLoading } = useReadContracts({
+    contracts: erc20Reads,
+    query: { enabled: erc20Reads.length > 0 },
+  })
+
+  const tokenInfoMap = useMemo<TokenInfoMap>(() => {
+    const map: TokenInfoMap = new Map()
+    erc20Addresses.forEach((address, i) => {
+      const symbolResult = tokenResults?.[i * 2]
+      const decimalsResult = tokenResults?.[i * 2 + 1]
+      map.set(address, {
+        symbol: symbolResult?.result as string | undefined,
+        decimals: decimalsResult?.result as number | undefined,
+      })
+    })
+    return map
+  }, [erc20Addresses, tokenResults])
+
+  const {
+    data: gasEstimate,
+    isFetching: gasFetching,
+    isError: gasError,
+  } = useGasEstimate({
+    calls: calls.map((c) => ({
+      to: (c.to ?? zeroAddress) as Address,
+      value: c.value as Hex | undefined,
+      data: c.data as Hex | undefined,
+    })),
+  })
+
+  if (tokensLoading) {
+    return (
+      <SigningLayout onConfirm={confirm} onReject={reject} disabled>
+        <SigningPageSkeleton />
+      </SigningLayout>
+    )
+  }
+
+  const confirmDisabled = gasFetching || gasEstimate == null
+
   return (
-    <SigningLayout onConfirm={confirm} onReject={reject}>
+    <SigningLayout
+      onConfirm={confirm}
+      onReject={reject}
+      disabled={confirmDisabled}
+    >
       <div className="flex flex-col gap-2 pt-4">
         <div className="flex flex-col items-center justify-center gap-2 pb-2">
           <Text className="text-h2">Confirm Transaction</Text>
@@ -242,12 +318,23 @@ export function BatchCalls({ calls, confirm, reject }: BatchCallsProps) {
                 key={`${call.to ?? 'unknown'}-${i}`}
                 call={call}
                 index={i + 1}
+                tokenInfoMap={tokenInfoMap}
               />
             ))}
           </div>
         </DetailsContainer>
         <DetailsContainer title="Estimated Gas Fee" iconName="lightingFill">
-          <DataRow label="Fee" value={GAS_FEE} iconName="gasStation" />
+          {gasError ? (
+            <DataRow label="Fee" value="Error" iconName="gasStation" />
+          ) : gasEstimate != null ? (
+            <DataRow
+              label="Fee"
+              value={formatGasFee(gasEstimate)}
+              iconName="gasStation"
+            />
+          ) : (
+            <DataRowSkeleton />
+          )}
           <DataRow
             label="Total execution time"
             value={EXECUTION_TIME}

--- a/packages/react-kit/src/signing/pages/BatchCalls.tsx
+++ b/packages/react-kit/src/signing/pages/BatchCalls.tsx
@@ -333,7 +333,7 @@ export function BatchCalls({ calls, confirm, reject }: BatchCallsProps) {
               iconName="gasStation"
             />
           ) : (
-            <DataRowSkeleton />
+            <DataRowSkeleton label="Fee" />
           )}
           <DataRow
             label="Total execution time"

--- a/packages/react-kit/src/signing/pages/CollectionApproval.tsx
+++ b/packages/react-kit/src/signing/pages/CollectionApproval.tsx
@@ -119,7 +119,7 @@ export function CollectionApproval({
               iconName="gasStation"
             />
           ) : (
-            <DataRowSkeleton />
+            <DataRowSkeleton label="Network fee" />
           )}
         </div>
       </div>

--- a/packages/react-kit/src/signing/pages/CollectionApproval.tsx
+++ b/packages/react-kit/src/signing/pages/CollectionApproval.tsx
@@ -4,9 +4,10 @@ import { useReadContract } from 'wagmi'
 import { Text } from '../../shared/components/Text'
 import { shortenHex } from '../../shared/utils/common'
 import { ArrowCardPair } from '../components/ArrowCardPair'
-import { DataRow } from '../components/DataRow'
+import { DataRow, DataRowSkeleton } from '../components/DataRow'
 import { InfoCard } from '../components/InfoCard'
 import { SigningLayout } from '../components/SigningLayout'
+import { SigningPageSkeleton } from '../components/SigningPageSkeleton'
 import { useGasEstimate } from '../hooks/useGasEstimate'
 import { formatGasFee } from '../utils/formatGasFee'
 
@@ -53,12 +54,15 @@ export function CollectionApproval({
     isFetching: gasFetching,
     isError: gasError,
   } = useGasEstimate({
-    to: contract,
-    data,
+    calls: [{ to: contract, data }],
   })
 
   if (isLoading) {
-    return <Text>Loading collection details...</Text>
+    return (
+      <SigningLayout onConfirm={confirm} onReject={reject} disabled>
+        <SigningPageSkeleton />
+      </SigningLayout>
+    )
   }
 
   const collectionName = name || 'Unknown collection'
@@ -106,17 +110,17 @@ export function CollectionApproval({
               />
             }
           />
-          <DataRow
-            label="Network fee"
-            value={
-              gasError
-                ? 'Error'
-                : gasEstimate != null && !gasFetching
-                  ? formatGasFee(gasEstimate)
-                  : 'Estimating...'
-            }
-            iconName="gasStation"
-          />
+          {gasError ? (
+            <DataRow label="Network fee" value="Error" iconName="gasStation" />
+          ) : gasEstimate != null ? (
+            <DataRow
+              label="Network fee"
+              value={formatGasFee(gasEstimate)}
+              iconName="gasStation"
+            />
+          ) : (
+            <DataRowSkeleton />
+          )}
         </div>
       </div>
     </SigningLayout>

--- a/packages/react-kit/src/signing/pages/Erc20Approval.tsx
+++ b/packages/react-kit/src/signing/pages/Erc20Approval.tsx
@@ -122,7 +122,7 @@ export function Erc20Approval({
               iconName="gasStation"
             />
           ) : (
-            <DataRowSkeleton />
+            <DataRowSkeleton label="Network fee" />
           )}
         </div>
       </div>

--- a/packages/react-kit/src/signing/pages/Erc20Approval.tsx
+++ b/packages/react-kit/src/signing/pages/Erc20Approval.tsx
@@ -4,9 +4,10 @@ import { useReadContract } from 'wagmi'
 import { Text } from '../../shared/components/Text'
 import { shortenHex } from '../../shared/utils/common'
 import { ArrowCardPair } from '../components/ArrowCardPair'
-import { DataRow } from '../components/DataRow'
+import { DataRow, DataRowSkeleton } from '../components/DataRow'
 import { InfoCard } from '../components/InfoCard'
 import { SigningLayout } from '../components/SigningLayout'
+import { SigningPageSkeleton } from '../components/SigningPageSkeleton'
 import { useGasEstimate } from '../hooks/useGasEstimate'
 import { formatGasFee } from '../utils/formatGasFee'
 
@@ -49,18 +50,29 @@ export function Erc20Approval({
     isFetching: gasFetching,
     isError: gasError,
   } = useGasEstimate({
-    to: contract,
-    data,
+    calls: [{ to: contract, data }],
   })
 
   const isLoading = symbolLoading || decimalsLoading
 
   if (isLoading) {
-    return <Text>Loading token details...</Text>
+    return (
+      <SigningLayout onConfirm={confirm} onReject={reject} disabled>
+        <SigningPageSkeleton />
+      </SigningLayout>
+    )
   }
 
   if (!decimals || !symbol) {
-    return <Text>Failed to load token details.</Text>
+    return (
+      <SigningLayout
+        onConfirm={confirm}
+        onReject={reject}
+        error={new Error('Failed to load token details')}
+      >
+        <div />
+      </SigningLayout>
+    )
   }
 
   const isUnlimited = amount === maxUint256
@@ -101,17 +113,17 @@ export function Erc20Approval({
               />
             }
           />
-          <DataRow
-            label="Network fee"
-            value={
-              gasError
-                ? 'Error'
-                : gasEstimate != null && !gasFetching
-                  ? formatGasFee(gasEstimate)
-                  : 'Estimating...'
-            }
-            iconName="gasStation"
-          />
+          {gasError ? (
+            <DataRow label="Network fee" value="Error" iconName="gasStation" />
+          ) : gasEstimate != null ? (
+            <DataRow
+              label="Network fee"
+              value={formatGasFee(gasEstimate)}
+              iconName="gasStation"
+            />
+          ) : (
+            <DataRowSkeleton />
+          )}
         </div>
       </div>
     </SigningLayout>

--- a/packages/react-kit/src/signing/pages/Erc20Transfer.tsx
+++ b/packages/react-kit/src/signing/pages/Erc20Transfer.tsx
@@ -117,7 +117,7 @@ export function Erc20Transfer({
               iconName="gasStation"
             />
           ) : (
-            <DataRowSkeleton />
+            <DataRowSkeleton label="Network fee" />
           )}
         </div>
       </div>

--- a/packages/react-kit/src/signing/pages/Erc20Transfer.tsx
+++ b/packages/react-kit/src/signing/pages/Erc20Transfer.tsx
@@ -3,9 +3,10 @@ import { useReadContract } from 'wagmi'
 
 import { Text } from '../../shared/components/Text'
 import { ArrowCardPair } from '../components/ArrowCardPair'
-import { DataRow } from '../components/DataRow'
+import { DataRow, DataRowSkeleton } from '../components/DataRow'
 import { InfoCard } from '../components/InfoCard'
 import { SigningLayout } from '../components/SigningLayout'
+import { SigningPageSkeleton } from '../components/SigningPageSkeleton'
 import { useGasEstimate } from '../hooks/useGasEstimate'
 import { formatGasFee } from '../utils/formatGasFee'
 
@@ -48,18 +49,29 @@ export function Erc20Transfer({
     isFetching: gasFetching,
     isError: gasError,
   } = useGasEstimate({
-    to: contract,
-    data,
+    calls: [{ to: contract, data }],
   })
 
   const isLoading = symbolLoading || decimalsLoading
 
   if (isLoading) {
-    return <Text>Loading token details...</Text>
+    return (
+      <SigningLayout onConfirm={confirm} onReject={reject} disabled>
+        <SigningPageSkeleton />
+      </SigningLayout>
+    )
   }
 
   if (!decimals || !symbol) {
-    return <Text>Failed to load token details.</Text>
+    return (
+      <SigningLayout
+        onConfirm={confirm}
+        onReject={reject}
+        error={new Error('Failed to load token details')}
+      >
+        <div />
+      </SigningLayout>
+    )
   }
 
   const formattedAmount = formatUnits(amount, decimals)
@@ -96,17 +108,17 @@ export function Erc20Transfer({
               />
             }
           />
-          <DataRow
-            label="Network fee"
-            value={
-              gasError
-                ? 'Error'
-                : gasEstimate != null && !gasFetching
-                  ? formatGasFee(gasEstimate)
-                  : 'Estimating...'
-            }
-            iconName="gasStation"
-          />
+          {gasError ? (
+            <DataRow label="Network fee" value="Error" iconName="gasStation" />
+          ) : gasEstimate != null ? (
+            <DataRow
+              label="Network fee"
+              value={formatGasFee(gasEstimate)}
+              iconName="gasStation"
+            />
+          ) : (
+            <DataRowSkeleton />
+          )}
         </div>
       </div>
     </SigningLayout>

--- a/packages/react-kit/src/signing/pages/EthTransfer.tsx
+++ b/packages/react-kit/src/signing/pages/EthTransfer.tsx
@@ -71,7 +71,7 @@ export function EthTransfer({ to, value, confirm, reject }: EthTransferProps) {
               iconName="gasStation"
             />
           ) : (
-            <DataRowSkeleton />
+            <DataRowSkeleton label="Network fee" />
           )}
         </div>
       </div>

--- a/packages/react-kit/src/signing/pages/EthTransfer.tsx
+++ b/packages/react-kit/src/signing/pages/EthTransfer.tsx
@@ -2,7 +2,7 @@ import { type Address, formatEther, type Hex } from 'viem'
 
 import { Text } from '../../shared/components/Text'
 import { ArrowCardPair } from '../components/ArrowCardPair'
-import { DataRow } from '../components/DataRow'
+import { DataRow, DataRowSkeleton } from '../components/DataRow'
 import { InfoCard } from '../components/InfoCard'
 import { SigningLayout } from '../components/SigningLayout'
 import { useGasEstimate } from '../hooks/useGasEstimate'
@@ -27,7 +27,7 @@ export function EthTransfer({ to, value, confirm, reject }: EthTransferProps) {
     data: gasEstimate,
     isFetching,
     isError,
-  } = useGasEstimate({ to, value })
+  } = useGasEstimate({ calls: [{ to, value }] })
 
   const confirmDisabled = isFetching || gasEstimate == null
 
@@ -62,17 +62,17 @@ export function EthTransfer({ to, value, confirm, reject }: EthTransferProps) {
               />
             }
           />
-          <DataRow
-            label="Network fee"
-            value={
-              isError
-                ? 'Error'
-                : gasEstimate != null && !isFetching
-                  ? formatGasFee(gasEstimate)
-                  : 'Estimating...'
-            }
-            iconName="gasStation"
-          />
+          {isError ? (
+            <DataRow label="Network fee" value="Error" iconName="gasStation" />
+          ) : gasEstimate != null ? (
+            <DataRow
+              label="Network fee"
+              value={formatGasFee(gasEstimate)}
+              iconName="gasStation"
+            />
+          ) : (
+            <DataRowSkeleton />
+          )}
         </div>
       </div>
     </SigningLayout>

--- a/packages/react-kit/src/signing/pages/GenericRequest.tsx
+++ b/packages/react-kit/src/signing/pages/GenericRequest.tsx
@@ -120,7 +120,7 @@ function GenericSendTransaction({
               iconName="gasStation"
             />
           ) : (
-            <DataRowSkeleton />
+            <DataRowSkeleton label="Fee" />
           )}
           <DataRow
             label="Total execution time"

--- a/packages/react-kit/src/signing/pages/GenericRequest.tsx
+++ b/packages/react-kit/src/signing/pages/GenericRequest.tsx
@@ -1,11 +1,20 @@
-import { formatEther, type Hex, hexToBigInt, toHex } from 'viem'
+import {
+  type Address,
+  formatEther,
+  type Hex,
+  hexToBigInt,
+  toHex,
+  zeroAddress,
+} from 'viem'
 
 import { Text } from '../../shared/components/Text'
 import { shortenHex } from '../../shared/utils/common'
 import type { Request } from '../../types.js'
-import { DataRow } from '../components/DataRow'
+import { DataRow, DataRowSkeleton } from '../components/DataRow'
 import { DetailsContainer } from '../components/DetailsContainer'
 import { SigningLayout } from '../components/SigningLayout'
+import { useGasEstimate } from '../hooks/useGasEstimate'
+import { formatGasFee } from '../utils/formatGasFee'
 
 interface GenericRequestProps {
   request: Request
@@ -40,10 +49,51 @@ export function GenericRequest({
     )
   }
 
-  const [{ data = '0x', to, value = toHex(0) }] = request.params
+  return (
+    <GenericSendTransaction
+      params={request.params}
+      confirm={confirm}
+      reject={reject}
+    />
+  )
+}
+
+function GenericSendTransaction({
+  params,
+  confirm,
+  reject,
+}: {
+  params: Extract<
+    Request,
+    { method: 'eth_sendTransaction' | 'wallet_sendTransaction' }
+  >['params']
+  confirm: () => void
+  reject: () => void
+}) {
+  const [{ data = '0x', to, value = toHex(0) }] = params
+
+  const {
+    data: gasEstimate,
+    isFetching: gasFetching,
+    isError: gasError,
+  } = useGasEstimate({
+    calls: [
+      {
+        to: (to ?? zeroAddress) as Address,
+        value: value as Hex,
+        data: data as Hex,
+      },
+    ],
+  })
+
+  const confirmDisabled = gasFetching || gasEstimate == null
 
   return (
-    <SigningLayout onConfirm={confirm} onReject={reject}>
+    <SigningLayout
+      onConfirm={confirm}
+      onReject={reject}
+      disabled={confirmDisabled}
+    >
       <div className="flex flex-col gap-2 pt-4">
         <div className="flex flex-col items-center justify-center gap-2 pb-2">
           <Text className="text-h2">Confirm Transaction</Text>
@@ -61,11 +111,17 @@ export function GenericRequest({
           <DataRow label="Data" value={shortenHex(data as Hex)} />
         </DetailsContainer>
         <DetailsContainer title="Estimated Gas Fee" iconName="lightingFill">
-          <DataRow
-            label="Fee"
-            value="0.00008 ETH ($0.28)"
-            iconName="gasStation"
-          />
+          {gasError ? (
+            <DataRow label="Fee" value="Error" iconName="gasStation" />
+          ) : gasEstimate != null ? (
+            <DataRow
+              label="Fee"
+              value={formatGasFee(gasEstimate)}
+              iconName="gasStation"
+            />
+          ) : (
+            <DataRowSkeleton />
+          )}
           <DataRow
             label="Total execution time"
             value="≈ 1 sec"


### PR DESCRIPTION
## Summary

  - Signing pages previously bailed to bare text (`"Loading token details..."`, `"Estimating..."`) while async data resolved. Now they render a generic `<SigningPageSkeleton />` inside the signing chrome — Reject stays usable, Confirm is disabled, page chrome stays consistent. The skeleton's shape (two card placeholders + a single fee-row skeleton) matches the actual page surface so the swap doesn't snap to a different layout.
  - Gas-only refreshes get a narrow `<DataRowSkeleton />` swap on just the fee row, not the whole page. Gas refetches periodically — flashing the full page skeleton on each refresh would be jarring, so the page-loading condition explicitly excludes gas.
  - `BatchCalls` and `GenericRequest` were displaying hardcoded fee strings (`"0.00008 ETH ($0.28)"`) regardless of network conditions — placeholder values that would mislead consumers. Both now call `useGasEstimate` against the real userop. The hook itself was refactored to take `calls: UseGasEstimateCall[]` (matching what the kernel client consumes) so batch and single-call pages share the same code path.
  - In `BatchCalls`, hoisted the per-item ERC-20 `useReadContract` calls out of the child components and into a single `useReadContracts` at the parent. The page now waits for all token metadata before rendering items, instead of each child decoding-and-flickering in sequence as its queries land.
  - Error fallback consistency: pages that previously bailed to bare `<Text>Failed to load token details</Text>` now wrap that in `<SigningLayout error=...>` so the user can still Reject — no more dead-end screens.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
