### PR TITLE
build(react-kit): externalize @tanstack/react-query

### DIFF
--- a/packages/react-kit/vite.config.ts
+++ b/packages/react-kit/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
         '@zerodev/wallet-core',
         '@zerodev/wallet-react',
         '@wagmi/core',
+        '@tanstack/react-query',
         'viem',
         'wagmi',
         'zustand',


### PR DESCRIPTION
  - React Query was being bundled into the kit's `dist/index.mjs` because it wasn't listed in `vite.config.ts`'s rollup `external`. That ships the kit with its *own* copy of react-query — including the module-level context singleton. Consumers wrapping the app with their own `<QueryClientProvider>` write to a different context, and the kit's bundled `useQuery` (e.g. via `useGasEstimate`) never sees it. Result: every consumer hits `Error: No QueryClient set, use QueryClientProvider to set one` the moment `<SignatureRequest />` mounts and a gas estimate fires.
  - Treating react-query as external follows the same pattern as `react`, `wagmi`, `viem`, `zustand` etc. already in the list: consumer-resolved at runtime, single shared instance, context contract works.
  - Side benefit: `dist/index.mjs` is ~30KB smaller now since react-query isn't duplicated into the bundle.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
