### PR TITLE
chore(react-kit): API and docs polish

### DIFF
--- a/apps/react-example/src/wagmi.ts
+++ b/apps/react-example/src/wagmi.ts
@@ -1,11 +1,11 @@
-import { zeroDevKitWallet } from '@zerodev/wallet-react-kit'
+import { zeroDevWallet } from '@zerodev/wallet-react-kit'
 import { createConfig, http } from 'wagmi'
 import { sepolia } from 'wagmi/chains'
 
 export const wagmiConfig = createConfig({
   chains: [sepolia],
   connectors: [
-    zeroDevKitWallet({
+    zeroDevWallet({
       projectId: import.meta.env.VITE_ZERODEV_PROJECT_ID,
       chains: [sepolia],
       config: {

--- a/packages/react-kit/docs/components/WalletProvider.tsx
+++ b/packages/react-kit/docs/components/WalletProvider.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { zeroDevKitWallet } from '@zerodev/wallet-react-kit'
+import { zeroDevWallet } from '@zerodev/wallet-react-kit'
 import { type ReactNode, useState } from 'react'
 import { createConfig, http, WagmiProvider } from 'wagmi'
 import { sepolia } from 'wagmi/chains'
@@ -7,7 +7,7 @@ import { sepolia } from 'wagmi/chains'
 const config = createConfig({
   chains: [sepolia],
   connectors: [
-    zeroDevKitWallet({
+    zeroDevWallet({
       projectId: import.meta.env.VITE_ZERODEV_PROJECT_ID,
       chains: [sepolia],
       config: {

--- a/packages/react-kit/docs/pages/index.mdx
+++ b/packages/react-kit/docs/pages/index.mdx
@@ -9,13 +9,13 @@ pnpm add @zerodev/wallet-react-kit
 ```
 
 ```tsx
-import { zeroDevKitWallet, SignatureRequest } from '@zerodev/wallet-react-kit'
+import { zeroDevWallet, SignatureRequest } from '@zerodev/wallet-react-kit'
 import { createConfig } from 'wagmi'
 import { sepolia } from 'wagmi/chains'
 
 const config = createConfig({
   connectors: [
-    zeroDevKitWallet({
+    zeroDevWallet({
       projectId: 'your-project-id',
       chains: [sepolia],
     }),

--- a/packages/react-kit/docs/pages/react-kit/configuration.mdx
+++ b/packages/react-kit/docs/pages/react-kit/configuration.mdx
@@ -5,9 +5,9 @@ The kit connector accepts all base `zeroDevWallet` params plus an optional `conf
 ## Basic
 
 ```tsx
-import { zeroDevKitWallet } from '@zerodev/wallet-react-kit'
+import { zeroDevWallet } from '@zerodev/wallet-react-kit'
 
-zeroDevKitWallet({
+zeroDevWallet({
   projectId: 'your-project-id',
   chains: [sepolia],
 })
@@ -17,10 +17,10 @@ Signing confirmation is enabled by default (`prompt` mode). No extra config need
 
 ## Auth
 
-Configure the [authentication flow](/react-kit/features/authentication). To display the auth UI, mount the [`<AuthFlow />`](/react-kit/features/authentication) component in your app.
+Configure how users sign in. To display the auth UI, mount the [`<AuthFlow />`](/react-kit/features/authentication) component in your app.
 
 ```tsx
-zeroDevKitWallet({
+zeroDevWallet({
   projectId: '...',
   chains: [sepolia],
   config: {
@@ -45,14 +45,12 @@ zeroDevKitWallet({
 | `onSuccess` | `() => void` | Called when authentication completes successfully. |
 | `onError` | `(error: unknown) => void` | Called when authentication fails. |
 
-Full reference: [Authentication](/react-kit/features/authentication).
-
 ## Signing
 
 Control whether transactions and signing requests show a confirmation UI. To display the confirmation UI, mount the [`<SignatureRequest />`](/react-kit/features/transaction-signing) component in your app.
 
 ```tsx
-zeroDevKitWallet({
+zeroDevWallet({
   projectId: '...',
   chains: [sepolia],
   config: {
@@ -75,7 +73,7 @@ zeroDevKitWallet({
 Set `mode: 'background'` to disable the signing gate entirely. Transactions execute immediately without confirmation UI.
 
 ```tsx
-zeroDevKitWallet({
+zeroDevWallet({
   projectId: '...',
   chains: [sepolia],
   config: {

--- a/packages/react-kit/docs/pages/react-kit/features/authentication.mdx
+++ b/packages/react-kit/docs/pages/react-kit/features/authentication.mdx
@@ -2,10 +2,9 @@ import AuthFlowExample from '../../../components/AuthFlow'
 
 # Authentication
 
-Sign users in with email OTP, Google, or passkey. The `<AuthFlow />`
+Sign user in with email, Google, passkey, and more. The `<AuthFlow />`
 component sits in your tree and renders the right auth screen for the
-current step — sign-up, email verification, OTP entry, OAuth callback,
-or passkey prompt.
+current step.
 
 ## Import
 
@@ -18,9 +17,9 @@ import { AuthFlow } from '@zerodev/wallet-react-kit'
 Pass an `auth` block to the connector to enable authentication:
 
 ```tsx
-import { zeroDevKitWallet } from '@zerodev/wallet-react-kit'
+import { zeroDevWallet } from '@zerodev/wallet-react-kit'
 
-zeroDevKitWallet({
+zeroDevWallet({
   projectId: '...',
   chains: [sepolia],
   config: {
@@ -49,31 +48,36 @@ zeroDevKitWallet({
 | `onSuccess` | `() => void` | Called when authentication completes successfully. |
 | `onError` | `(error: unknown) => void` | Called when authentication fails. |
 
-If you set neither `termsAndConditionsUrl` nor `privacyPolicyUrl`, the
-agreement checkbox is hidden entirely and the user can proceed without
-any consent step.
-
 ## Usage
 
 Mount the component once, anywhere in your tree. It renders the active
 auth screen when the user is signing in and renders nothing otherwise.
+Trigger the flow with wagmi's `useConnect`:
 
 ```tsx
 import { AuthFlow } from '@zerodev/wallet-react-kit'
+import { useConnect } from 'wagmi'
 
 function App() {
+  const { connect, connectors } = useConnect()
+
   return (
     <>
-      <YourApp />
+      <button
+        type="button"
+        onClick={() => connect({ connector: connectors[0] })}
+      >
+        Connect
+      </button>
       <AuthFlow />
     </>
   )
 }
 ```
 
-The flow starts when `eth_requestAccounts` is called (e.g. via wagmi's
-`useConnect`) and completes when the user is authenticated, at which
-point `onSuccess` fires.
+`connect()` triggers `eth_requestAccounts` under the hood, which kicks
+off the auth flow. The flow completes when the user is authenticated,
+at which point `onSuccess` fires.
 
 To build a custom auth UI instead of using `<AuthFlow />`, read state
 directly with the [`useAuth`](/react-kit/hooks/use-auth) hook.

--- a/packages/react-kit/docs/pages/react-kit/features/transaction-signing.mdx
+++ b/packages/react-kit/docs/pages/react-kit/features/transaction-signing.mdx
@@ -13,6 +13,30 @@ before the underlying call proceeds.
 import { SignatureRequest } from '@zerodev/wallet-react-kit'
 ```
 
+## Configure transaction signing
+
+Signing confirmation is on by default — no config required. Pass a
+`signing` block to the connector if you want to customize the behavior:
+
+```tsx
+import { zeroDevWallet } from '@zerodev/wallet-react-kit'
+
+zeroDevWallet({
+  projectId: '...',
+  chains: [sepolia],
+  config: {
+    signing: {
+      mode: 'prompt',
+    },
+  },
+})
+```
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `mode` | `"prompt"` or `"background"` | `"prompt"` | `prompt` shows the confirmation UI. `background` skips it and lets calls go through immediately. |
+| `methods` | `RequestMethod[]` | `eth_sendTransaction`, `wallet_sendTransaction`, `wallet_sendCalls`, `personal_sign`, `eth_signTypedData_v4` | Which RPC methods trigger the confirmation UI. |
+
 ## Usage
 
 Mount the component once, anywhere in your tree. When a signing call

--- a/packages/react-kit/docs/pages/react-kit/getting-started.mdx
+++ b/packages/react-kit/docs/pages/react-kit/getting-started.mdx
@@ -1,9 +1,14 @@
 # Getting Started
 
+`@zerodev/wallet-react-kit` is the React UI layer for the ZeroDev
+Wallet SDK. It ships an enhanced wagmi connector and drop-in components
+for the most common wallet flows, built on wagmi so it slots into a
+standard wagmi setup.
+
 ## Installation
 
 ```bash
-pnpm add @zerodev/wallet-react-kit
+pnpm add @zerodev/wallet-react-kit wagmi viem @tanstack/react-query
 ```
 
 ## Setup
@@ -11,14 +16,14 @@ pnpm add @zerodev/wallet-react-kit
 ### 1. Create a wagmi config with the kit connector
 
 ```tsx
-import { zeroDevKitWallet } from '@zerodev/wallet-react-kit'
+import { zeroDevWallet } from '@zerodev/wallet-react-kit'
 import { createConfig, http } from 'wagmi'
 import { sepolia } from 'wagmi/chains'
 
 export const config = createConfig({
   chains: [sepolia],
   connectors: [
-    zeroDevKitWallet({
+    zeroDevWallet({
       projectId: 'your-project-id',
       chains: [sepolia],
     }),

--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -54,6 +54,7 @@
     "web3"
   ],
   "peerDependencies": {
+    "@tanstack/react-query": "^5.0.0",
     "@wagmi/core": "^2.22.0",
     "@zerodev/wallet-core": "workspace:*",
     "@zerodev/wallet-react": "workspace:*",

--- a/packages/react-kit/src/auth/hooks/useAuth.test.ts
+++ b/packages/react-kit/src/auth/hooks/useAuth.test.ts
@@ -39,7 +39,7 @@ describe('useAuth', () => {
     mockConfig.connectors = []
 
     expect(() => renderHook(() => useAuth())).toThrow(
-      'useAuth must be used with zeroDevKitWallet connector',
+      'useAuth must be used with zeroDevWallet connector',
     )
 
     // Restore
@@ -51,7 +51,7 @@ describe('useAuth', () => {
     mockConfig.connectors = [badConnector as any]
 
     expect(() => renderHook(() => useAuth())).toThrow(
-      'useAuth must be used with zeroDevKitWallet connector',
+      'useAuth must be used with zeroDevWallet connector',
     )
 
     // Restore

--- a/packages/react-kit/src/auth/hooks/useAuth.ts
+++ b/packages/react-kit/src/auth/hooks/useAuth.ts
@@ -16,7 +16,7 @@ export function useAuth() {
   const store = getKitStore(config)
 
   if (!store) {
-    throw new Error('useAuth must be used with zeroDevKitWallet connector')
+    throw new Error('useAuth must be used with zeroDevWallet connector')
   }
 
   const step = useStore(store, (state) => state.auth.step)

--- a/packages/react-kit/src/connector.test.ts
+++ b/packages/react-kit/src/connector.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { ZeroDevKitConnectorParams } from './connector'
-import { zeroDevKitWallet } from './connector'
+import { zeroDevWallet } from './connector'
 import type { createStore } from './store'
 
 type Provider = {
@@ -51,7 +51,7 @@ function createKitConnector(
     chains: [],
     ...overrides,
   }
-  const factory = zeroDevKitWallet(params)
+  const factory = zeroDevWallet(params)
   return factory({} as never) as unknown as KitConnector
 }
 

--- a/packages/react-kit/src/connector.ts
+++ b/packages/react-kit/src/connector.ts
@@ -3,7 +3,7 @@ import type {
   ZeroDevProvider,
   ZeroDevWalletConnectorParams,
 } from '@zerodev/wallet-react'
-import { zeroDevWallet } from '@zerodev/wallet-react'
+import { zeroDevWallet as baseZeroDevWallet } from '@zerodev/wallet-react'
 import type { AuthConfig } from './auth/types'
 import { createStore } from './store.js'
 import type { Request, RequestMethod } from './types.js'
@@ -43,10 +43,10 @@ function requireUserConfirmation(
   })
 }
 
-export function zeroDevKitWallet(
+export function zeroDevWallet(
   params: ZeroDevKitConnectorParams,
 ): CreateConnectorFn {
-  const baseFactory = zeroDevWallet(params)
+  const baseFactory = baseZeroDevWallet(params)
   const store = createStore()
 
   // Initialize auth config if provided

--- a/packages/react-kit/src/index.ts
+++ b/packages/react-kit/src/index.ts
@@ -14,7 +14,7 @@ export type {
   ZeroDevKitConfig,
   ZeroDevKitConnectorParams,
 } from './connector.js'
-export { zeroDevKitWallet } from './connector.js'
+export { zeroDevWallet } from './connector.js'
 
 // Signing
 export type { SignatureRequestProps } from './signing'


### PR DESCRIPTION
- Rename the kit's connector export from `zeroDevKitWallet` to `zeroDevWallet`. Removes the "Kit" qualifier — the package is the connector, no other connector to disambiguate against. The base `zeroDevWallet` from `@zerodev/wallet-react` is imported as `baseZeroDevWallet` inside `connector.ts` to handle the name collision.
- Declare `@tanstack/react-query` as a `peerDependency`. It was already required at runtime via `useGasEstimate`, but was missing from `peerDependencies`, so consumers got no install-time warning and only discovered the dependency when `Error: No QueryClient set` started throwing on `<SignatureRequest />` mount.
- Getting Started gets a one-paragraph intro and an install command that lists the real peer deps consumers need (`wagmi`, `viem`, `@tanstack/react-query`). Previously it just installed the kit, leaving the rest implicit.
- Auth and Signing config sections in the docs now share the same shape — short intro pointing at the relevant component, config snippet, properties table. Authentication's description was tightened (no more enumerating the internal step names) and its Usage example now shows wiring with wagmi's `useConnect` so the trigger isn't left implicit. The transaction-signing page gained a parallel "Configure transaction signing" section that was missing.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
