### PR TITLE
fix(react-kit): highlight terms and check email

### DIFF
--- a/packages/react-kit/src/auth/pages/SignUp.tsx
+++ b/packages/react-kit/src/auth/pages/SignUp.tsx
@@ -14,6 +14,7 @@ import { OrView } from '../../shared/components/OrView'
 import { ScreenWrapper } from '../../shared/components/ScreenWrapper'
 import { SignUpFooter } from '../../shared/components/SignUpFooter'
 import { Text } from '../../shared/components/Text'
+import { isValidEmailAddress } from '../../shared/utils/common'
 import { useAuth } from '../hooks/useAuth'
 
 // Helper to check if error is due to user closing OAuth window
@@ -24,25 +25,7 @@ function isOAuthWindowClosedError(message: string): boolean {
   )
 }
 
-// Debug-only override: render both magic-link and OTP buttons so QA can
-// exercise either path regardless of `config.emailAuthMethod`. Toggle by
-// appending `?renderBothEmailButtons=true` to the URL.
-function shouldShowBothEmailButtons(): boolean {
-  if (typeof window === 'undefined') return false
-  return (
-    new URLSearchParams(window.location.search).get(
-      'renderBothEmailButtons',
-    ) === 'true'
-  )
-}
-
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-function isValidEmailAddress(email: string): boolean {
-  return EMAIL_REGEX.test(email.trim())
-}
-
 export function SignUp() {
-  const showBothEmailButtons = shouldShowBothEmailButtons()
   const { goToStep, setEmail, setOtpSession, config, enabledMethods } =
     useAuth()
   const [agreedToTerms, setAgreedToTerms] = useState(false)
@@ -52,7 +35,9 @@ export function SignUp() {
   const { mutateAsync: sendOtp, isPending: isSendOtpPending } = useSendOTP()
   const { mutateAsync: sendMagicLink, isPending: isSendMagicLinkPending } =
     useSendMagicLink()
-  const isEmailLoading = isSendOtpPending || isSendMagicLinkPending
+  const isEmailLoading = shouldUseOtp
+    ? isSendOtpPending
+    : isSendMagicLinkPending
 
   const [error, setError] = useState<string | null>(null)
 
@@ -107,19 +92,6 @@ export function SignUp() {
   )
   const canContinue = !requiresAgreement || agreedToTerms
 
-  // Shared pre-check for the email-based auth handlers. Returns false if the
-  // submission shouldn't proceed; also flips `highlightAgreement` on so the
-  // SignUpFooter renders a red border around the terms checkbox.
-  const checkEmailGuard = (): boolean => {
-    if (!emailInput || anyPending) return false
-    if (!isValidEmailAddress(emailInput)) return false
-    if (!canContinue) {
-      setHighlightAgreement(true)
-      return false
-    }
-    return true
-  }
-
   const handleRegisterPasskey = () => {
     if (anyPending || !canContinue) return
     setError(null)
@@ -149,42 +121,31 @@ export function SignUp() {
     goToStep('wallet-selection')
   }
 
-  const handleSendOtp = async () => {
-    if (!checkEmailGuard()) return
+  const handleEmailSubmit = async () => {
+    if (!emailInput || anyPending) return
+    if (!isValidEmailAddress(emailInput)) return
+    if (!canContinue) {
+      setHighlightAgreement(true)
+      return
+    }
+
     setError(null)
     try {
-      const { otpId, otpEncryptionTargetBundle } = await sendOtp({
-        email: emailInput,
-      })
+      const { otpId, otpEncryptionTargetBundle } = shouldUseOtp
+        ? await sendOtp({ email: emailInput })
+        : await sendMagicLink({
+            email: emailInput,
+            redirectURL: config?.magicLinkBaseUrl ?? '',
+          })
       setEmail(emailInput)
       setOtpSession({ otpId, otpEncryptionTargetBundle })
-      goToStep('otp-input')
+      goToStep(shouldUseOtp ? 'otp-input' : 'email-verification')
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'Failed to send verification code',
       )
     }
   }
-
-  const handleSendMagicLink = async () => {
-    if (!checkEmailGuard()) return
-    setError(null)
-    try {
-      const { otpId, otpEncryptionTargetBundle } = await sendMagicLink({
-        email: emailInput,
-        redirectURL: config?.magicLinkBaseUrl ?? '',
-      })
-      setEmail(emailInput)
-      setOtpSession({ otpId, otpEncryptionTargetBundle })
-      goToStep('email-verification')
-    } catch (err) {
-      setError(
-        err instanceof Error ? err.message : 'Failed to send verification code',
-      )
-    }
-  }
-
-  const handleEmailSubmit = shouldUseOtp ? handleSendOtp : handleSendMagicLink
 
   if (error) {
     return (
@@ -247,80 +208,41 @@ export function SignUp() {
                 />
               )}
               {enabledMethods.includes('email') && (
-                <>
-                  <Input
-                    iconName="email"
-                    placeholder="Enter your email..."
-                    value={emailInput}
-                    onChange={(e) => setEmailInput(e.target.value)}
-                    type="email"
-                    autoCapitalize="none"
-                    autoComplete="email"
-                    disabled={anyPending}
-                    variant="listItemStyle"
-                    className="rounded-3xl"
-                    onKeyDown={(e) => {
-                      if (
-                        e.key === 'Enter' &&
-                        emailInput &&
-                        !anyPending &&
-                        !showBothEmailButtons
-                      ) {
-                        handleEmailSubmit()
-                      }
-                    }}
-                  >
-                    {!showBothEmailButtons &&
-                      (emailInput && !anyPending ? (
-                        <button
-                          type="button"
-                          className={`w-13 h-13 rounded-2xl bg-greyScale/[3%] flex items-center justify-center transition-colors ${
-                            isValidEmailAddress(emailInput) && canContinue
-                              ? 'cursor-pointer hover:bg-greyScale/[5%]'
-                              : 'cursor-not-allowed opacity-50'
-                          }`}
-                          onClick={handleEmailSubmit}
-                        >
-                          <Icon
-                            name="chevronRight"
-                            className="text-greyScale"
-                          />
-                        </button>
-                      ) : isEmailLoading ? (
-                        <div className="w-13 h-13 flex items-center justify-center">
-                          <div className="w-5 h-5 border-2 border-solarOrange border-t-transparent rounded-full animate-spin" />
-                        </div>
-                      ) : null)}
-                  </Input>
-                  {showBothEmailButtons && (
-                    <>
-                      <Button
-                        action="secondaryNeutral"
-                        text="Continue with email magic link"
-                        iconName="email"
-                        trailIcon
-                        disabled={
-                          !emailInput ||
-                          anyPending ||
-                          !isValidEmailAddress(emailInput)
-                        }
-                        onClick={handleSendMagicLink}
-                      />
-                      <Button
-                        action="secondaryNeutral"
-                        text="Continue with email OTP code"
-                        iconName="email"
-                        trailIcon
-                        disabled={
-                          !emailInput ||
-                          anyPending ||
-                          !isValidEmailAddress(emailInput)
-                        }
-                        onClick={handleSendOtp}
-                      />
-                    </>
-                  )}
-                </>
+                <Input
+                  iconName="email"
+                  placeholder="Enter your email..."
+                  value={emailInput}
+                  onChange={(e) => setEmailInput(e.target.value)}
+                  type="email"
+                  autoCapitalize="none"
+                  autoComplete="email"
+                  disabled={anyPending}
+                  variant="listItemStyle"
+                  className="rounded-3xl"
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && emailInput && !anyPending) {
+                      handleEmailSubmit()
+                    }
+                  }}
+                >
+                  {emailInput && !anyPending ? (
+                    <button
+                      type="button"
+                      className={`w-13 h-13 rounded-2xl bg-greyScale/[3%] flex items-center justify-center transition-colors ${
+                        isValidEmailAddress(emailInput) && canContinue
+                          ? 'cursor-pointer hover:bg-greyScale/[5%]'
+                          : 'cursor-not-allowed opacity-50'
+                      }`}
+                      onClick={handleEmailSubmit}
+                    >
+                      <Icon name="chevronRight" className="text-greyScale" />
+                    </button>
+                  ) : isEmailLoading ? (
+                    <div className="w-13 h-13 flex items-center justify-center">
+                      <div className="w-5 h-5 border-2 border-solarOrange border-t-transparent rounded-full animate-spin" />
+                    </div>
+                  ) : null}
+                </Input>
               )}
               {enabledMethods.includes('injected-wallet') && (
                 <>

--- a/packages/react-kit/src/auth/pages/SignUp.tsx
+++ b/packages/react-kit/src/auth/pages/SignUp.tsx
@@ -104,19 +104,30 @@ export function SignUp() {
   const canContinue = !requiresAgreement || agreedToTerms
 
   const handleRegisterPasskey = () => {
-    if (anyPending || !canContinue) return
+    if (anyPending) return
+    if (!canContinue) {
+      setHighlightAgreement(true)
+      return
+    }
     setError(null)
     registerPasskey()
   }
 
   const handleLoginPasskey = () => {
-    if (anyPending || !canContinue) return
+    if (anyPending) return
+    if (!canContinue) {
+      setHighlightAgreement(true)
+      return
+    }
     setError(null)
     loginPasskey()
   }
 
   const handleGoogleAuth = async () => {
-    if (!canContinue) return
+    if (!canContinue) {
+      setHighlightAgreement(true)
+      return
+    }
     setError(null)
     try {
       await authenticateOAuth({ provider: 'google' })

--- a/packages/react-kit/src/auth/pages/SignUp.tsx
+++ b/packages/react-kit/src/auth/pages/SignUp.tsx
@@ -36,11 +36,17 @@ function shouldShowBothEmailButtons(): boolean {
   )
 }
 
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+function isValidEmailAddress(email: string): boolean {
+  return EMAIL_REGEX.test(email.trim())
+}
+
 export function SignUp() {
   const showBothEmailButtons = shouldShowBothEmailButtons()
   const { goToStep, setEmail, setOtpSession, config, enabledMethods } =
     useAuth()
   const [agreedToTerms, setAgreedToTerms] = useState(false)
+  const [highlightAgreement, setHighlightAgreement] = useState(false)
   const [emailInput, setEmailInput] = useState('')
   const shouldUseOtp = config?.emailAuthMethod === 'otp'
   const { mutateAsync: sendOtp, isPending: isSendOtpPending } = useSendOTP()
@@ -101,6 +107,19 @@ export function SignUp() {
   )
   const canContinue = !requiresAgreement || agreedToTerms
 
+  // Shared pre-check for the email-based auth handlers. Returns false if the
+  // submission shouldn't proceed; also flips `highlightAgreement` on so the
+  // SignUpFooter renders a red border around the terms checkbox.
+  const checkEmailGuard = (): boolean => {
+    if (!emailInput || anyPending) return false
+    if (!isValidEmailAddress(emailInput)) return false
+    if (!canContinue) {
+      setHighlightAgreement(true)
+      return false
+    }
+    return true
+  }
+
   const handleRegisterPasskey = () => {
     if (anyPending || !canContinue) return
     setError(null)
@@ -131,7 +150,7 @@ export function SignUp() {
   }
 
   const handleSendOtp = async () => {
-    if (!emailInput || anyPending || !canContinue) return
+    if (!checkEmailGuard()) return
     setError(null)
     try {
       const { otpId, otpEncryptionTargetBundle } = await sendOtp({
@@ -148,7 +167,7 @@ export function SignUp() {
   }
 
   const handleSendMagicLink = async () => {
-    if (!emailInput || anyPending || !canContinue) return
+    if (!checkEmailGuard()) return
     setError(null)
     try {
       const { otpId, otpEncryptionTargetBundle } = await sendMagicLink({
@@ -239,12 +258,12 @@ export function SignUp() {
                     autoComplete="email"
                     disabled={anyPending}
                     variant="listItemStyle"
+                    className="rounded-3xl"
                     onKeyDown={(e) => {
                       if (
                         e.key === 'Enter' &&
                         emailInput &&
                         !anyPending &&
-                        canContinue &&
                         !showBothEmailButtons
                       ) {
                         handleEmailSubmit()
@@ -252,10 +271,14 @@ export function SignUp() {
                     }}
                   >
                     {!showBothEmailButtons &&
-                      (emailInput && !anyPending && canContinue ? (
+                      (emailInput && !anyPending ? (
                         <button
                           type="button"
-                          className="w-13 h-13 rounded-2xl bg-greyScale/[3%] flex items-center justify-center hover:bg-greyScale/[5%] transition-colors cursor-pointer"
+                          className={`w-13 h-13 rounded-2xl bg-greyScale/[3%] flex items-center justify-center transition-colors ${
+                            isValidEmailAddress(emailInput) && canContinue
+                              ? 'cursor-pointer hover:bg-greyScale/[5%]'
+                              : 'cursor-not-allowed opacity-50'
+                          }`}
                           onClick={handleEmailSubmit}
                         >
                           <Icon
@@ -276,7 +299,11 @@ export function SignUp() {
                         text="Continue with email magic link"
                         iconName="email"
                         trailIcon
-                        disabled={!emailInput || anyPending || !canContinue}
+                        disabled={
+                          !emailInput ||
+                          anyPending ||
+                          !isValidEmailAddress(emailInput)
+                        }
                         onClick={handleSendMagicLink}
                       />
                       <Button
@@ -284,7 +311,11 @@ export function SignUp() {
                         text="Continue with email OTP code"
                         iconName="email"
                         trailIcon
-                        disabled={!emailInput || anyPending || !canContinue}
+                        disabled={
+                          !emailInput ||
+                          anyPending ||
+                          !isValidEmailAddress(emailInput)
+                        }
                         onClick={handleSendOtp}
                       />
                     </>
@@ -310,7 +341,11 @@ export function SignUp() {
             termsAndConditionsUrl={config?.termsAndConditionsUrl}
             privacyPolicyUrl={config?.privacyPolicyUrl}
             agreedToTerms={agreedToTerms}
-            setAgreedToTerms={setAgreedToTerms}
+            setAgreedToTerms={(agreed) => {
+              setAgreedToTerms(agreed)
+              if (agreed) setHighlightAgreement(false)
+            }}
+            highlight={highlightAgreement}
           />
         </div>
       )}

--- a/packages/react-kit/src/auth/pages/SignUp.tsx
+++ b/packages/react-kit/src/auth/pages/SignUp.tsx
@@ -25,7 +25,20 @@ function isOAuthWindowClosedError(message: string): boolean {
   )
 }
 
+// Debug-only override: render both magic-link and OTP buttons so QA can
+// exercise either path regardless of `config.emailAuthMethod`. Toggle by
+// appending `?renderBothEmailButtons=true` to the URL.
+function shouldShowBothEmailButtons(): boolean {
+  if (typeof window === 'undefined') return false
+  return (
+    new URLSearchParams(window.location.search).get(
+      'renderBothEmailButtons',
+    ) === 'true'
+  )
+}
+
 export function SignUp() {
+  const showBothEmailButtons = shouldShowBothEmailButtons()
   const { goToStep, setEmail, setOtpSession, config, enabledMethods } =
     useAuth()
   const [agreedToTerms, setAgreedToTerms] = useState(false)
@@ -35,9 +48,7 @@ export function SignUp() {
   const { mutateAsync: sendOtp, isPending: isSendOtpPending } = useSendOTP()
   const { mutateAsync: sendMagicLink, isPending: isSendMagicLinkPending } =
     useSendMagicLink()
-  const isEmailLoading = shouldUseOtp
-    ? isSendOtpPending
-    : isSendMagicLinkPending
+  const isEmailLoading = isSendOtpPending || isSendMagicLinkPending
 
   const [error, setError] = useState<string | null>(null)
 
@@ -121,7 +132,7 @@ export function SignUp() {
     goToStep('wallet-selection')
   }
 
-  const handleEmailSubmit = async () => {
+  const handleEmailSubmit = async (forceMethod?: 'otp' | 'magicLink') => {
     if (!emailInput || anyPending) return
     if (!isValidEmailAddress(emailInput)) return
     if (!canContinue) {
@@ -129,9 +140,12 @@ export function SignUp() {
       return
     }
 
+    const useOtp =
+      forceMethod !== undefined ? forceMethod === 'otp' : shouldUseOtp
+
     setError(null)
     try {
-      const { otpId, otpEncryptionTargetBundle } = shouldUseOtp
+      const { otpId, otpEncryptionTargetBundle } = useOtp
         ? await sendOtp({ email: emailInput })
         : await sendMagicLink({
             email: emailInput,
@@ -139,7 +153,7 @@ export function SignUp() {
           })
       setEmail(emailInput)
       setOtpSession({ otpId, otpEncryptionTargetBundle })
-      goToStep(shouldUseOtp ? 'otp-input' : 'email-verification')
+      goToStep(useOtp ? 'otp-input' : 'email-verification')
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'Failed to send verification code',
@@ -208,41 +222,80 @@ export function SignUp() {
                 />
               )}
               {enabledMethods.includes('email') && (
-                <Input
-                  iconName="email"
-                  placeholder="Enter your email..."
-                  value={emailInput}
-                  onChange={(e) => setEmailInput(e.target.value)}
-                  type="email"
-                  autoCapitalize="none"
-                  autoComplete="email"
-                  disabled={anyPending}
-                  variant="listItemStyle"
-                  className="rounded-3xl"
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && emailInput && !anyPending) {
-                      handleEmailSubmit()
-                    }
-                  }}
-                >
-                  {emailInput && !anyPending ? (
-                    <button
-                      type="button"
-                      className={`w-13 h-13 rounded-2xl bg-greyScale/[3%] flex items-center justify-center transition-colors ${
-                        isValidEmailAddress(emailInput) && canContinue
-                          ? 'cursor-pointer hover:bg-greyScale/[5%]'
-                          : 'cursor-not-allowed opacity-50'
-                      }`}
-                      onClick={handleEmailSubmit}
-                    >
-                      <Icon name="chevronRight" className="text-greyScale" />
-                    </button>
-                  ) : isEmailLoading ? (
-                    <div className="w-13 h-13 flex items-center justify-center">
-                      <div className="w-5 h-5 border-2 border-solarOrange border-t-transparent rounded-full animate-spin" />
-                    </div>
-                  ) : null}
-                </Input>
+                <>
+                  <Input
+                    iconName="email"
+                    placeholder="Enter your email..."
+                    value={emailInput}
+                    onChange={(e) => setEmailInput(e.target.value)}
+                    type="email"
+                    autoCapitalize="none"
+                    autoComplete="email"
+                    disabled={anyPending}
+                    variant="listItemStyle"
+                    className="rounded-3xl"
+                    onKeyDown={(e) => {
+                      if (
+                        e.key === 'Enter' &&
+                        emailInput &&
+                        !anyPending &&
+                        !showBothEmailButtons
+                      ) {
+                        handleEmailSubmit()
+                      }
+                    }}
+                  >
+                    {!showBothEmailButtons &&
+                      (emailInput && !anyPending ? (
+                        <button
+                          type="button"
+                          className={`w-13 h-13 rounded-2xl bg-greyScale/[3%] flex items-center justify-center transition-colors ${
+                            isValidEmailAddress(emailInput) && canContinue
+                              ? 'cursor-pointer hover:bg-greyScale/[5%]'
+                              : 'cursor-not-allowed opacity-50'
+                          }`}
+                          onClick={() => handleEmailSubmit()}
+                        >
+                          <Icon
+                            name="chevronRight"
+                            className="text-greyScale"
+                          />
+                        </button>
+                      ) : isEmailLoading ? (
+                        <div className="w-13 h-13 flex items-center justify-center">
+                          <div className="w-5 h-5 border-2 border-solarOrange border-t-transparent rounded-full animate-spin" />
+                        </div>
+                      ) : null)}
+                  </Input>
+                  {showBothEmailButtons && (
+                    <>
+                      <Button
+                        action="secondaryNeutral"
+                        text="Continue with email magic link"
+                        iconName="email"
+                        trailIcon
+                        disabled={
+                          !emailInput ||
+                          anyPending ||
+                          !isValidEmailAddress(emailInput)
+                        }
+                        onClick={() => handleEmailSubmit('magicLink')}
+                      />
+                      <Button
+                        action="secondaryNeutral"
+                        text="Continue with email OTP code"
+                        iconName="email"
+                        trailIcon
+                        disabled={
+                          !emailInput ||
+                          anyPending ||
+                          !isValidEmailAddress(emailInput)
+                        }
+                        onClick={() => handleEmailSubmit('otp')}
+                      />
+                    </>
+                  )}
+                </>
               )}
               {enabledMethods.includes('injected-wallet') && (
                 <>

--- a/packages/react-kit/src/shared/components/SignUpFooter/index.tsx
+++ b/packages/react-kit/src/shared/components/SignUpFooter/index.tsx
@@ -6,18 +6,24 @@ export function SignUpFooter({
   privacyPolicyUrl,
   agreedToTerms,
   setAgreedToTerms,
+  highlight = false,
 }: {
   termsAndConditionsUrl?: string | undefined
   privacyPolicyUrl?: string | undefined
   agreedToTerms: boolean
   setAgreedToTerms: (agreed: boolean) => void
+  highlight?: boolean
 }) {
   const showAgreement = !!(termsAndConditionsUrl || privacyPolicyUrl)
 
   return (
     <div className="flex flex-col items-center gap-5">
       {showAgreement && (
-        <div className="flex flex-row items-center gap-2">
+        <div
+          className={`flex flex-row items-center gap-2 rounded-md p-2 transition-colors ${
+            highlight ? 'border border-negative' : 'border border-transparent'
+          }`}
+        >
           <input
             type="checkbox"
             checked={agreedToTerms}

--- a/packages/react-kit/src/shared/utils/common.ts
+++ b/packages/react-kit/src/shared/utils/common.ts
@@ -36,3 +36,8 @@ export function camelCaseToTitle(str: string): string {
     .map((word) => capitalizeFirst(word))
     .join(' ')
 }
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+export function isValidEmailAddress(email: string): boolean {
+  return EMAIL_REGEX.test(email.trim())
+}


### PR DESCRIPTION
Closes [FS-2179](https://linear.app/offchain-labs/issue/FS-2179/fix-tandc-checkbox-so-its-clear-to-user-they-need-to-accept-it)

### Summary

This PR fixes the following:

- `handleEmailSubmit` button will be always rendered (after starting to type) but will stay disabled until a valid email is entered, and terms are agreed to (if set in config)
- If the user tried to press the `handleEmailSubmit` button after entering a valid email and before agreeing to terms, the agree to terms box with be highlighted with a red border

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
