### PR TITLE
feat(react-kit): surface gas estimate errors in AlertView

### DIFF
--- a/apps/zerodev-signer-demo/src/app/wagmi-config.ts
+++ b/apps/zerodev-signer-demo/src/app/wagmi-config.ts
@@ -28,8 +28,6 @@ export const config = createConfig({
           magicLinkBaseUrl: `${process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'}/verify`,
           enabledMethods: ['email', 'google', 'passkey', 'injected-wallet'],
           emailAuthMethod: 'otp',
-          termsAndConditionsUrl: 'https://zerodev.app/terms-of-service',
-          privacyPolicyUrl: 'https://zerodev.app/privacy-policy',
         },
       },
     }),

--- a/packages/react-kit/src/shared/components/AlertView/index.tsx
+++ b/packages/react-kit/src/shared/components/AlertView/index.tsx
@@ -17,7 +17,7 @@ export function AlertView({ title, description }: AlertViewProps) {
         <Icon name="info" className="h-3.5 w-3.5 text-solarOrange" />
         <Text className="text-body1">{title}</Text>
       </div>
-      <Text className="text-body3">{description}</Text>
+      <Text className="text-body3 break-all">{description}</Text>
     </Wrapper>
   )
 }

--- a/packages/react-kit/src/signing/components/SigningLayout/index.tsx
+++ b/packages/react-kit/src/signing/components/SigningLayout/index.tsx
@@ -1,51 +1,8 @@
 import type { ReactNode } from 'react'
-import { BaseError, decodeErrorResult, type Hex } from 'viem'
 
 import { AlertView } from '../../../shared/components/AlertView'
+import { getTxErrorInfo } from '../../utils/errors'
 import { SigningActions } from '../SigningActions'
-
-interface TxErrorInfo {
-  title: string
-  description: string
-}
-
-// Replace any embedded `Error(string)` revert hex (selector 0x08c379a0)
-// with its decoded string. Bundler-wrapped errors surface the raw hex.
-function decodeErrorHex(message: string): string {
-  return message.replace(/0x08c379a0[0-9a-fA-F]+/g, (match) => {
-    try {
-      const decoded = decodeErrorResult({
-        abi: [{ type: 'error', name: 'Error', inputs: [{ type: 'string' }] }],
-        data: match as Hex,
-      })
-      return decoded.args[0] as string
-    } catch {
-      return match
-    }
-  })
-}
-
-function getTxErrorInfo(error: Error): TxErrorInfo {
-  const shortMessage = error instanceof BaseError ? error.shortMessage : null
-  const baseMessage = shortMessage ?? error.message
-  const message = decodeErrorHex(baseMessage)
-
-  if (
-    message.toLowerCase().includes('insufficient funds') ||
-    message.toLowerCase().includes('transfer amount exceeds balance')
-  ) {
-    return {
-      title: 'Insufficient funds',
-      description:
-        "You don't have enough funds to cover the amount plus gas fees.",
-    }
-  }
-
-  return {
-    title: 'Unable to process transaction',
-    description: message,
-  }
-}
 
 interface SigningLayoutProps {
   children: ReactNode

--- a/packages/react-kit/src/signing/components/SigningLayout/index.tsx
+++ b/packages/react-kit/src/signing/components/SigningLayout/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { BaseError } from 'viem'
+import { BaseError, decodeErrorResult, type Hex } from 'viem'
 
 import { AlertView } from '../../../shared/components/AlertView'
 import { SigningActions } from '../SigningActions'
@@ -9,13 +9,30 @@ interface TxErrorInfo {
   description: string
 }
 
+// Replace any embedded `Error(string)` revert hex (selector 0x08c379a0)
+// with its decoded string. Bundler-wrapped errors surface the raw hex.
+function decodeErrorHex(message: string): string {
+  return message.replace(/0x08c379a0[0-9a-fA-F]+/g, (match) => {
+    try {
+      const decoded = decodeErrorResult({
+        abi: [{ type: 'error', name: 'Error', inputs: [{ type: 'string' }] }],
+        data: match as Hex,
+      })
+      return decoded.args[0] as string
+    } catch {
+      return match
+    }
+  })
+}
+
 function getTxErrorInfo(error: Error): TxErrorInfo {
   const shortMessage = error instanceof BaseError ? error.shortMessage : null
-  const message = error.message.toLowerCase()
+  const baseMessage = shortMessage ?? error.message
+  const message = decodeErrorHex(baseMessage)
 
   if (
-    message.includes('insufficient funds') ||
-    message.includes('transfer amount exceeds balance')
+    message.toLowerCase().includes('insufficient funds') ||
+    message.toLowerCase().includes('transfer amount exceeds balance')
   ) {
     return {
       title: 'Insufficient funds',
@@ -26,7 +43,7 @@ function getTxErrorInfo(error: Error): TxErrorInfo {
 
   return {
     title: 'Unable to process transaction',
-    description: shortMessage ?? error.message,
+    description: message,
   }
 }
 

--- a/packages/react-kit/src/signing/pages/BatchCalls.tsx
+++ b/packages/react-kit/src/signing/pages/BatchCalls.tsx
@@ -323,17 +323,16 @@ export function BatchCalls({ calls, confirm, reject }: BatchCallsProps) {
           </div>
         </DetailsContainer>
         <DetailsContainer title="Estimated Gas Fee" iconName="lightingFill">
-          {gasError ? (
-            <DataRow label="Fee" value="Error" iconName="gasStation" />
-          ) : gasEstimate != null ? (
-            <DataRow
-              label="Fee"
-              value={formatGasFee(gasEstimate)}
-              iconName="gasStation"
-            />
-          ) : (
-            <DataRowSkeleton label="Fee" />
-          )}
+          {!gasError &&
+            (gasEstimate != null ? (
+              <DataRow
+                label="Fee"
+                value={formatGasFee(gasEstimate)}
+                iconName="gasStation"
+              />
+            ) : (
+              <DataRowSkeleton label="Fee" />
+            ))}
         </DetailsContainer>
       </div>
     </SigningLayout>

--- a/packages/react-kit/src/signing/pages/BatchCalls.tsx
+++ b/packages/react-kit/src/signing/pages/BatchCalls.tsx
@@ -322,9 +322,9 @@ export function BatchCalls({ calls, confirm, reject }: BatchCallsProps) {
             ))}
           </div>
         </DetailsContainer>
-        <DetailsContainer title="Estimated Gas Fee" iconName="lightingFill">
-          {!gasError &&
-            (gasEstimate != null ? (
+        {!gasError && (
+          <DetailsContainer title="Estimated Gas Fee" iconName="lightingFill">
+            {gasEstimate != null ? (
               <DataRow
                 label="Fee"
                 value={formatGasFee(gasEstimate)}
@@ -332,8 +332,9 @@ export function BatchCalls({ calls, confirm, reject }: BatchCallsProps) {
               />
             ) : (
               <DataRowSkeleton label="Fee" />
-            ))}
-        </DetailsContainer>
+            )}
+          </DetailsContainer>
+        )}
       </div>
     </SigningLayout>
   )

--- a/packages/react-kit/src/signing/pages/BatchCalls.tsx
+++ b/packages/react-kit/src/signing/pages/BatchCalls.tsx
@@ -277,7 +277,7 @@ export function BatchCalls({ calls, confirm, reject }: BatchCallsProps) {
   const {
     data: gasEstimate,
     isFetching: gasFetching,
-    isError: gasError,
+    error: gasError,
   } = useGasEstimate({
     calls: calls.map((c) => ({
       to: (c.to ?? zeroAddress) as Address,
@@ -301,6 +301,7 @@ export function BatchCalls({ calls, confirm, reject }: BatchCallsProps) {
       onConfirm={confirm}
       onReject={reject}
       disabled={confirmDisabled}
+      error={gasError}
     >
       <div className="flex flex-col gap-2 pt-4">
         <div className="flex flex-col items-center justify-center gap-2 pb-2">

--- a/packages/react-kit/src/signing/pages/CollectionApproval.tsx
+++ b/packages/react-kit/src/signing/pages/CollectionApproval.tsx
@@ -52,7 +52,7 @@ export function CollectionApproval({
   const {
     data: gasEstimate,
     isFetching: gasFetching,
-    isError: gasError,
+    error: gasError,
   } = useGasEstimate({
     calls: [{ to: contract, data }],
   })
@@ -76,6 +76,7 @@ export function CollectionApproval({
       onConfirm={confirm}
       onReject={reject}
       disabled={confirmDisabled}
+      error={gasError}
     >
       <div className="flex flex-col gap-2 pt-4">
         <div className="flex flex-col items-center justify-center gap-2 pb-2">
@@ -110,17 +111,16 @@ export function CollectionApproval({
               />
             }
           />
-          {gasError ? (
-            <DataRow label="Network fee" value="Error" iconName="gasStation" />
-          ) : gasEstimate != null ? (
-            <DataRow
-              label="Network fee"
-              value={formatGasFee(gasEstimate)}
-              iconName="gasStation"
-            />
-          ) : (
-            <DataRowSkeleton label="Network fee" />
-          )}
+          {!gasError &&
+            (gasEstimate != null ? (
+              <DataRow
+                label="Network fee"
+                value={formatGasFee(gasEstimate)}
+                iconName="gasStation"
+              />
+            ) : (
+              <DataRowSkeleton label="Network fee" />
+            ))}
         </div>
       </div>
     </SigningLayout>

--- a/packages/react-kit/src/signing/pages/CollectionApproval.tsx
+++ b/packages/react-kit/src/signing/pages/CollectionApproval.tsx
@@ -5,6 +5,7 @@ import { Text } from '../../shared/components/Text'
 import { shortenHex } from '../../shared/utils/common'
 import { ArrowCardPair } from '../components/ArrowCardPair'
 import { DataRow, DataRowSkeleton } from '../components/DataRow'
+import { DetailsContainer } from '../components/DetailsContainer'
 import { InfoCard } from '../components/InfoCard'
 import { SigningLayout } from '../components/SigningLayout'
 import { SigningPageSkeleton } from '../components/SigningPageSkeleton'
@@ -111,16 +112,19 @@ export function CollectionApproval({
               />
             }
           />
-          {!gasError &&
-            (gasEstimate != null ? (
-              <DataRow
-                label="Network fee"
-                value={formatGasFee(gasEstimate)}
-                iconName="gasStation"
-              />
-            ) : (
-              <DataRowSkeleton label="Network fee" />
-            ))}
+          {!gasError && (
+            <DetailsContainer title="Estimated Gas Fee" iconName="lightingFill">
+              {gasEstimate != null ? (
+                <DataRow
+                  label="Fee"
+                  value={formatGasFee(gasEstimate)}
+                  iconName="gasStation"
+                />
+              ) : (
+                <DataRowSkeleton label="Fee" />
+              )}
+            </DetailsContainer>
+          )}
         </div>
       </div>
     </SigningLayout>

--- a/packages/react-kit/src/signing/pages/Erc20Approval.tsx
+++ b/packages/react-kit/src/signing/pages/Erc20Approval.tsx
@@ -5,6 +5,7 @@ import { Text } from '../../shared/components/Text'
 import { shortenHex } from '../../shared/utils/common'
 import { ArrowCardPair } from '../components/ArrowCardPair'
 import { DataRow, DataRowSkeleton } from '../components/DataRow'
+import { DetailsContainer } from '../components/DetailsContainer'
 import { InfoCard } from '../components/InfoCard'
 import { SigningLayout } from '../components/SigningLayout'
 import { SigningPageSkeleton } from '../components/SigningPageSkeleton'
@@ -106,16 +107,19 @@ export function Erc20Approval({
               />
             }
           />
-          {!gasError &&
-            (gasEstimate != null ? (
-              <DataRow
-                label="Network fee"
-                value={formatGasFee(gasEstimate)}
-                iconName="gasStation"
-              />
-            ) : (
-              <DataRowSkeleton label="Network fee" />
-            ))}
+          {!gasError && (
+            <DetailsContainer title="Estimated Gas Fee" iconName="lightingFill">
+              {gasEstimate != null ? (
+                <DataRow
+                  label="Fee"
+                  value={formatGasFee(gasEstimate)}
+                  iconName="gasStation"
+                />
+              ) : (
+                <DataRowSkeleton label="Fee" />
+              )}
+            </DetailsContainer>
+          )}
         </div>
       </div>
     </SigningLayout>

--- a/packages/react-kit/src/signing/pages/Erc20Approval.tsx
+++ b/packages/react-kit/src/signing/pages/Erc20Approval.tsx
@@ -46,7 +46,7 @@ export function Erc20Approval({
   const {
     data: gasEstimate,
     isFetching: gasFetching,
-    isError: gasError,
+    error: gasError,
   } = useGasEstimate({
     calls: [{ to: contract, data }],
   })
@@ -84,6 +84,7 @@ export function Erc20Approval({
       onConfirm={confirm}
       onReject={reject}
       disabled={confirmDisabled}
+      error={gasError}
     >
       <div className="flex flex-col gap-2 pt-4">
         <div className="flex flex-col items-center justify-center gap-2 pb-2">
@@ -105,17 +106,16 @@ export function Erc20Approval({
               />
             }
           />
-          {gasError ? (
-            <DataRow label="Network fee" value="Error" iconName="gasStation" />
-          ) : gasEstimate != null ? (
-            <DataRow
-              label="Network fee"
-              value={formatGasFee(gasEstimate)}
-              iconName="gasStation"
-            />
-          ) : (
-            <DataRowSkeleton label="Network fee" />
-          )}
+          {!gasError &&
+            (gasEstimate != null ? (
+              <DataRow
+                label="Network fee"
+                value={formatGasFee(gasEstimate)}
+                iconName="gasStation"
+              />
+            ) : (
+              <DataRowSkeleton label="Network fee" />
+            ))}
         </div>
       </div>
     </SigningLayout>

--- a/packages/react-kit/src/signing/pages/Erc20Transfer.tsx
+++ b/packages/react-kit/src/signing/pages/Erc20Transfer.tsx
@@ -5,6 +5,7 @@ import { Text } from '../../shared/components/Text'
 import { shortenHex } from '../../shared/utils/common'
 import { ArrowCardPair } from '../components/ArrowCardPair'
 import { DataRow, DataRowSkeleton } from '../components/DataRow'
+import { DetailsContainer } from '../components/DetailsContainer'
 import { InfoCard } from '../components/InfoCard'
 import { SigningLayout } from '../components/SigningLayout'
 import { SigningPageSkeleton } from '../components/SigningPageSkeleton'
@@ -103,16 +104,19 @@ export function Erc20Transfer({
               />
             }
           />
-          {!gasError &&
-            (gasEstimate != null ? (
-              <DataRow
-                label="Network fee"
-                value={formatGasFee(gasEstimate)}
-                iconName="gasStation"
-              />
-            ) : (
-              <DataRowSkeleton label="Network fee" />
-            ))}
+          {!gasError && (
+            <DetailsContainer title="Estimated Gas Fee" iconName="lightingFill">
+              {gasEstimate != null ? (
+                <DataRow
+                  label="Fee"
+                  value={formatGasFee(gasEstimate)}
+                  iconName="gasStation"
+                />
+              ) : (
+                <DataRowSkeleton label="Fee" />
+              )}
+            </DetailsContainer>
+          )}
         </div>
       </div>
     </SigningLayout>

--- a/packages/react-kit/src/signing/pages/Erc20Transfer.tsx
+++ b/packages/react-kit/src/signing/pages/Erc20Transfer.tsx
@@ -46,7 +46,7 @@ export function Erc20Transfer({
   const {
     data: gasEstimate,
     isFetching: gasFetching,
-    isError: gasError,
+    error: gasError,
   } = useGasEstimate({
     calls: [{ to: contract, data }],
   })
@@ -81,6 +81,7 @@ export function Erc20Transfer({
       onConfirm={confirm}
       onReject={reject}
       disabled={confirmDisabled}
+      error={gasError}
     >
       <div className="flex flex-col gap-2 pt-4">
         <div className="flex flex-col items-center justify-center gap-2 pb-2">
@@ -102,17 +103,16 @@ export function Erc20Transfer({
               />
             }
           />
-          {gasError ? (
-            <DataRow label="Network fee" value="Error" iconName="gasStation" />
-          ) : gasEstimate != null ? (
-            <DataRow
-              label="Network fee"
-              value={formatGasFee(gasEstimate)}
-              iconName="gasStation"
-            />
-          ) : (
-            <DataRowSkeleton label="Network fee" />
-          )}
+          {!gasError &&
+            (gasEstimate != null ? (
+              <DataRow
+                label="Network fee"
+                value={formatGasFee(gasEstimate)}
+                iconName="gasStation"
+              />
+            ) : (
+              <DataRowSkeleton label="Network fee" />
+            ))}
         </div>
       </div>
     </SigningLayout>

--- a/packages/react-kit/src/signing/pages/EthTransfer.tsx
+++ b/packages/react-kit/src/signing/pages/EthTransfer.tsx
@@ -26,7 +26,7 @@ export function EthTransfer({ to, value, confirm, reject }: EthTransferProps) {
   const {
     data: gasEstimate,
     isFetching,
-    isError,
+    error: gasError,
   } = useGasEstimate({ calls: [{ to, value }] })
 
   const confirmDisabled = isFetching || gasEstimate == null
@@ -36,6 +36,7 @@ export function EthTransfer({ to, value, confirm, reject }: EthTransferProps) {
       onConfirm={confirm}
       onReject={reject}
       disabled={confirmDisabled}
+      error={gasError}
     >
       <div className="flex flex-col gap-2 pt-4">
         <div className="flex flex-col items-center justify-center gap-2 pb-2">
@@ -61,17 +62,16 @@ export function EthTransfer({ to, value, confirm, reject }: EthTransferProps) {
               />
             }
           />
-          {isError ? (
-            <DataRow label="Network fee" value="Error" iconName="gasStation" />
-          ) : gasEstimate != null ? (
-            <DataRow
-              label="Network fee"
-              value={formatGasFee(gasEstimate)}
-              iconName="gasStation"
-            />
-          ) : (
-            <DataRowSkeleton label="Network fee" />
-          )}
+          {!gasError &&
+            (gasEstimate != null ? (
+              <DataRow
+                label="Network fee"
+                value={formatGasFee(gasEstimate)}
+                iconName="gasStation"
+              />
+            ) : (
+              <DataRowSkeleton label="Network fee" />
+            ))}
         </div>
       </div>
     </SigningLayout>

--- a/packages/react-kit/src/signing/pages/EthTransfer.tsx
+++ b/packages/react-kit/src/signing/pages/EthTransfer.tsx
@@ -4,6 +4,7 @@ import { Text } from '../../shared/components/Text'
 import { shortenHex } from '../../shared/utils/common'
 import { ArrowCardPair } from '../components/ArrowCardPair'
 import { DataRow, DataRowSkeleton } from '../components/DataRow'
+import { DetailsContainer } from '../components/DetailsContainer'
 import { InfoCard } from '../components/InfoCard'
 import { SigningLayout } from '../components/SigningLayout'
 import { useGasEstimate } from '../hooks/useGasEstimate'
@@ -62,16 +63,19 @@ export function EthTransfer({ to, value, confirm, reject }: EthTransferProps) {
               />
             }
           />
-          {!gasError &&
-            (gasEstimate != null ? (
-              <DataRow
-                label="Network fee"
-                value={formatGasFee(gasEstimate)}
-                iconName="gasStation"
-              />
-            ) : (
-              <DataRowSkeleton label="Network fee" />
-            ))}
+          {!gasError && (
+            <DetailsContainer title="Estimated Gas Fee" iconName="lightingFill">
+              {gasEstimate != null ? (
+                <DataRow
+                  label="Fee"
+                  value={formatGasFee(gasEstimate)}
+                  iconName="gasStation"
+                />
+              ) : (
+                <DataRowSkeleton label="Fee" />
+              )}
+            </DetailsContainer>
+          )}
         </div>
       </div>
     </SigningLayout>

--- a/packages/react-kit/src/signing/pages/GenericRequest.tsx
+++ b/packages/react-kit/src/signing/pages/GenericRequest.tsx
@@ -75,7 +75,7 @@ function GenericSendTransaction({
   const {
     data: gasEstimate,
     isFetching: gasFetching,
-    isError: gasError,
+    error: gasError,
   } = useGasEstimate({
     calls: [
       {
@@ -93,6 +93,7 @@ function GenericSendTransaction({
       onConfirm={confirm}
       onReject={reject}
       disabled={confirmDisabled}
+      error={gasError}
     >
       <div className="flex flex-col gap-2 pt-4">
         <div className="flex flex-col items-center justify-center gap-2 pb-2">

--- a/packages/react-kit/src/signing/pages/GenericRequest.tsx
+++ b/packages/react-kit/src/signing/pages/GenericRequest.tsx
@@ -110,9 +110,9 @@ function GenericSendTransaction({
           />
           <DataRow label="Data" value={shortenHex(data as Hex)} />
         </DetailsContainer>
-        <DetailsContainer title="Estimated Gas Fee" iconName="lightingFill">
-          {!gasError &&
-            (gasEstimate != null ? (
+        {!gasError && (
+          <DetailsContainer title="Estimated Gas Fee" iconName="lightingFill">
+            {gasEstimate != null ? (
               <DataRow
                 label="Fee"
                 value={formatGasFee(gasEstimate)}
@@ -120,8 +120,9 @@ function GenericSendTransaction({
               />
             ) : (
               <DataRowSkeleton label="Fee" />
-            ))}
-        </DetailsContainer>
+            )}
+          </DetailsContainer>
+        )}
       </div>
     </SigningLayout>
   )

--- a/packages/react-kit/src/signing/pages/GenericRequest.tsx
+++ b/packages/react-kit/src/signing/pages/GenericRequest.tsx
@@ -111,17 +111,16 @@ function GenericSendTransaction({
           <DataRow label="Data" value={shortenHex(data as Hex)} />
         </DetailsContainer>
         <DetailsContainer title="Estimated Gas Fee" iconName="lightingFill">
-          {gasError ? (
-            <DataRow label="Fee" value="Error" iconName="gasStation" />
-          ) : gasEstimate != null ? (
-            <DataRow
-              label="Fee"
-              value={formatGasFee(gasEstimate)}
-              iconName="gasStation"
-            />
-          ) : (
-            <DataRowSkeleton label="Fee" />
-          )}
+          {!gasError &&
+            (gasEstimate != null ? (
+              <DataRow
+                label="Fee"
+                value={formatGasFee(gasEstimate)}
+                iconName="gasStation"
+              />
+            ) : (
+              <DataRowSkeleton label="Fee" />
+            ))}
         </DetailsContainer>
       </div>
     </SigningLayout>

--- a/packages/react-kit/src/signing/utils/errors.ts
+++ b/packages/react-kit/src/signing/utils/errors.ts
@@ -1,0 +1,44 @@
+import { BaseError, decodeErrorResult, type Hex } from 'viem'
+
+interface TxErrorInfo {
+  title: string
+  description: string
+}
+
+// Replace any embedded `Error(string)` revert hex (selector 0x08c379a0)
+// with its decoded string. Bundler-wrapped errors surface the raw hex.
+function decodeErrorHex(message: string): string {
+  return message.replace(/0x08c379a0[0-9a-fA-F]+/g, (match) => {
+    try {
+      const decoded = decodeErrorResult({
+        abi: [{ type: 'error', name: 'Error', inputs: [{ type: 'string' }] }],
+        data: match as Hex,
+      })
+      return decoded.args[0] as string
+    } catch {
+      return match
+    }
+  })
+}
+
+export function getTxErrorInfo(error: Error): TxErrorInfo {
+  const shortMessage = error instanceof BaseError ? error.shortMessage : null
+  const baseMessage = shortMessage ?? error.message
+  const message = decodeErrorHex(baseMessage)
+
+  if (
+    message.toLowerCase().includes('insufficient funds') ||
+    message.toLowerCase().includes('transfer amount exceeds balance')
+  ) {
+    return {
+      title: 'Insufficient funds',
+      description:
+        "You don't have enough funds to cover the amount plus gas fees.",
+    }
+  }
+
+  return {
+    title: 'Unable to process transaction',
+    description: message,
+  }
+}


### PR DESCRIPTION
closes FS-2175

- Route gas estimation errors through `SigningLayout`'s existing AlertView surface so the confirm button gets disabled.
- Decode embedded `Error(string)` revert hex (selector `0x08c379a0`) before display. ERC-4337 errors come from the bundler as `"...UserOperation reverted during simulation with reason: 0x..."` and viem doesn't decode the inner string for us.
- Hide the gas DataRow entirely on error — the AlertView covers the context, the row was redundant.
- `break-all` on AlertView description so long unbreakable strings (hex, addresses) wrap instead of overflowing the box horizontally.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
