### PR TITLE
fix(react-kit): various fixes

### DIFF
--- a/packages/react-kit/src/auth/pages/Verifying.tsx
+++ b/packages/react-kit/src/auth/pages/Verifying.tsx
@@ -32,6 +32,11 @@ export function Verifying() {
       onSuccess: async () => {
         clearOtpSession()
         goToStep('authenticated')
+        // Navigate the address bar off the magic-link landing URL so a
+        // refresh doesn't re-trigger verification.
+        if (typeof window !== 'undefined') {
+          window.history.replaceState({}, '', '/')
+        }
         config?.onSuccess?.()
       },
       onError: (err) => {

--- a/packages/react-kit/src/auth/pages/Verifying.tsx
+++ b/packages/react-kit/src/auth/pages/Verifying.tsx
@@ -32,11 +32,6 @@ export function Verifying() {
       onSuccess: async () => {
         clearOtpSession()
         goToStep('authenticated')
-        // Navigate the address bar off the magic-link landing URL so a
-        // refresh doesn't re-trigger verification.
-        if (typeof window !== 'undefined') {
-          window.history.replaceState({}, '', '/')
-        }
         config?.onSuccess?.()
       },
       onError: (err) => {

--- a/packages/react-kit/src/shared/components/ListItem/index.tsx
+++ b/packages/react-kit/src/shared/components/ListItem/index.tsx
@@ -118,7 +118,7 @@ export function ListItem({
           </div>
         ) : chevron ? (
           <div className="w-13 h-13 flex items-center justify-center">
-            <Icon name="chevronRight" className="h-6 w-6" />
+            <Icon name="chevronRight" className="h-6 w-6 text-greyScale" />
           </div>
         ) : null}
       </button>

--- a/packages/react-kit/src/signing/SignatureRequest.test.tsx
+++ b/packages/react-kit/src/signing/SignatureRequest.test.tsx
@@ -83,10 +83,6 @@ describe('SignatureRequest', () => {
 
     render(<SignatureRequest />)
 
-    // Transaction Summary starts collapsed; expand it to reveal params.
-    const [toggleButton] = screen.getAllByRole('button')
-    fireEvent.click(toggleButton)
-
     expect(screen.getByText(/0x1234/)).toBeDefined()
   })
 

--- a/packages/react-kit/src/signing/pages/BatchCalls.tsx
+++ b/packages/react-kit/src/signing/pages/BatchCalls.tsx
@@ -28,8 +28,6 @@ import { decodeErc20Transfer, isErc20Transfer } from '../utils/erc20Transfer.js'
 import { isEthTransfer } from '../utils/ethTransfer.js'
 import { formatGasFee } from '../utils/formatGasFee'
 
-const EXECUTION_TIME = '≈ 1 sec'
-
 type TokenInfo = {
   symbol?: string | undefined
   decimals?: number | undefined
@@ -335,11 +333,6 @@ export function BatchCalls({ calls, confirm, reject }: BatchCallsProps) {
           ) : (
             <DataRowSkeleton label="Fee" />
           )}
-          <DataRow
-            label="Total execution time"
-            value={EXECUTION_TIME}
-            iconName="clock"
-          />
         </DetailsContainer>
       </div>
     </SigningLayout>

--- a/packages/react-kit/src/signing/pages/Erc20Transfer.tsx
+++ b/packages/react-kit/src/signing/pages/Erc20Transfer.tsx
@@ -2,6 +2,7 @@ import { type Address, erc20Abi, formatUnits, type Hex } from 'viem'
 import { useReadContract } from 'wagmi'
 
 import { Text } from '../../shared/components/Text'
+import { shortenHex } from '../../shared/utils/common'
 import { ArrowCardPair } from '../components/ArrowCardPair'
 import { DataRow, DataRowSkeleton } from '../components/DataRow'
 import { InfoCard } from '../components/InfoCard'
@@ -102,7 +103,7 @@ export function Erc20Transfer({
             }
             bottomCard={
               <InfoCard
-                title={to}
+                title={shortenHex(to)}
                 subtitle="Recipient"
                 imageSource={RECIPIENT_IMAGE_SOURCE}
               />

--- a/packages/react-kit/src/signing/pages/Erc20Transfer.tsx
+++ b/packages/react-kit/src/signing/pages/Erc20Transfer.tsx
@@ -88,7 +88,8 @@ export function Erc20Transfer({
         <div className="flex flex-col items-center justify-center gap-2 pb-2">
           <Text className="text-h2">Send Token</Text>
           <Text className="text-center">
-            You are about to send {formattedAmount} {symbol} to {to}.
+            You are about to send {formattedAmount} {symbol} to {shortenHex(to)}
+            .
           </Text>
         </div>
         <div className="flex flex-col gap-2">

--- a/packages/react-kit/src/signing/pages/EthTransfer.tsx
+++ b/packages/react-kit/src/signing/pages/EthTransfer.tsx
@@ -1,6 +1,7 @@
 import { type Address, formatEther, type Hex } from 'viem'
 
 import { Text } from '../../shared/components/Text'
+import { shortenHex } from '../../shared/utils/common'
 import { ArrowCardPair } from '../components/ArrowCardPair'
 import { DataRow, DataRowSkeleton } from '../components/DataRow'
 import { InfoCard } from '../components/InfoCard'
@@ -56,7 +57,7 @@ export function EthTransfer({ to, value, confirm, reject }: EthTransferProps) {
             }
             bottomCard={
               <InfoCard
-                title={to}
+                title={shortenHex(to)}
                 subtitle="Recipient"
                 imageSource={RECIPIENT_IMAGE_SOURCE}
               />

--- a/packages/react-kit/src/signing/pages/EthTransfer.tsx
+++ b/packages/react-kit/src/signing/pages/EthTransfer.tsx
@@ -42,7 +42,7 @@ export function EthTransfer({ to, value, confirm, reject }: EthTransferProps) {
         <div className="flex flex-col items-center justify-center gap-2 pb-2">
           <Text className="text-h2">Send Token</Text>
           <Text className="text-center">
-            You are about to send {formattedAmount} ETH to {to}.
+            You are about to send {formattedAmount} ETH to {shortenHex(to)}.
           </Text>
         </div>
         <div className="flex flex-col gap-2">

--- a/packages/react-kit/src/signing/pages/GenericRequest.tsx
+++ b/packages/react-kit/src/signing/pages/GenericRequest.tsx
@@ -101,7 +101,6 @@ function GenericSendTransaction({
         <DetailsContainer
           title="Transaction Summary"
           iconName="arrowSwapHorizontal"
-          collapsible
         >
           <DataRow label="To" value={shortenHex((to ?? '0x') as string)} />
           <DataRow
@@ -122,11 +121,6 @@ function GenericSendTransaction({
           ) : (
             <DataRowSkeleton label="Fee" />
           )}
-          <DataRow
-            label="Total execution time"
-            value="≈ 1 sec"
-            iconName="clock"
-          />
         </DetailsContainer>
       </div>
     </SigningLayout>


### PR DESCRIPTION
Closes [FS-2186](https://linear.app/offchain-labs/issue/FS-2186/default-to-opened-state-in-tx-details-for-genericrequest), [FS-2184](https://linear.app/offchain-labs/issue/FS-2184/remove-total-execution-time-from-signing-pages), [FS-2178](https://linear.app/offchain-labs/issue/FS-2178/shorten-addresses-in-signing-screens), [FS-2172](https://linear.app/offchain-labs/issue/FS-2172/fix-white-chevron-on-injected-wallets-button-in-dark-mode)

### Summary

This PR fixes the following:

- Make TxDetails in Generic Request non-collapsed
- Remove "total execution time" from signing pages
- Shorten address in the `to` field
- Fix white chevron on injected wallets button

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
