### PR TITLE
feat(react-kit): signing T&C

### DIFF
--- a/packages/react-kit/src/signing/components/SigningActions/index.tsx
+++ b/packages/react-kit/src/signing/components/SigningActions/index.tsx
@@ -1,3 +1,4 @@
+import { useAuth } from '../../../auth/hooks/useAuth'
 import { Button } from '../../../shared/components/Button'
 import { Text } from '../../../shared/components/Text'
 import { Wrapper } from '../../../shared/components/Wrapper'
@@ -13,6 +14,11 @@ export function SigningActions({
   onReject,
   disabled,
 }: SigningActionsProps) {
+  const { config } = useAuth()
+  const termsAndConditionsUrl = config?.termsAndConditionsUrl
+  const privacyPolicyUrl = config?.privacyPolicyUrl
+  const showAgreement = !!(termsAndConditionsUrl || privacyPolicyUrl)
+
   return (
     <Wrapper className="p-1 gap-2 mb-1.5 -mx-1.5 rounded-3xl">
       <div className="flex flex-row items-center gap-1">
@@ -29,28 +35,34 @@ export function SigningActions({
           onClick={onConfirm}
         />
       </div>
-      <Text className="text-center text-body3">
-        By continuing, you accept the{' '}
-        <Text
-          as="a"
-          href="https://zerodev.app/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline"
-        >
-          Terms
-        </Text>{' '}
-        and{' '}
-        <Text
-          as="a"
-          href="https://zerodev.app/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline"
-        >
-          Privacy Policy
+      {showAgreement && (
+        <Text className="text-center text-body3 mt-2">
+          By continuing, you accept the{' '}
+          {termsAndConditionsUrl && (
+            <Text
+              as="a"
+              href={termsAndConditionsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline text-body3"
+            >
+              Terms
+            </Text>
+          )}
+          {termsAndConditionsUrl && privacyPolicyUrl && ' and '}
+          {privacyPolicyUrl && (
+            <Text
+              as="a"
+              href={privacyPolicyUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline text-body3"
+            >
+              Privacy Policy
+            </Text>
+          )}
         </Text>
-      </Text>
+      )}
     </Wrapper>
   )
 }

--- a/packages/react-kit/src/signing/components/SigningLayout/SigningLayout.test.tsx
+++ b/packages/react-kit/src/signing/components/SigningLayout/SigningLayout.test.tsx
@@ -16,6 +16,10 @@ vi.mock('../../../shared/components/Icon', async () => {
   }
 })
 
+vi.mock('../../../auth/hooks/useAuth', () => ({
+  useAuth: () => ({ config: null }),
+}))
+
 import { SigningLayout } from './index'
 
 afterEach(() => {


### PR DESCRIPTION
Closes [FS-2173](https://linear.app/offchain-labs/issue/FS-2173/tandc-privacy-policy-links-on-signing-screens)

### Summary

This PR adds terms and condition urls passed from config to signing screens


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
