### PR TITLE
fix(react-kit): remove non-eth logo and hardcoded usd values 

### DIFF
--- a/packages/react-kit/src/signing/pages/Erc20Approval.tsx
+++ b/packages/react-kit/src/signing/pages/Erc20Approval.tsx
@@ -11,8 +11,6 @@ import { SigningPageSkeleton } from '../components/SigningPageSkeleton'
 import { useGasEstimate } from '../hooks/useGasEstimate'
 import { formatGasFee } from '../utils/formatGasFee'
 
-const TOKEN_SUBTITLE = '$175.00 USD'
-const TOKEN_IMAGE_SOURCE = 'https://img.icons8.com/color/1200/ethereum.jpg'
 const SPENDER_IMAGE_SOURCE =
   'https://api.dicebear.com/7.x/identicon/svg?seed=spender'
 
@@ -98,13 +96,7 @@ export function Erc20Approval({
         <div className="flex flex-col gap-2">
           <Text className="text-body1">You&#39;re approving:</Text>
           <ArrowCardPair
-            topCard={
-              <InfoCard
-                title={`${formattedAmount} ${symbol}`}
-                subtitle={TOKEN_SUBTITLE}
-                imageSource={TOKEN_IMAGE_SOURCE}
-              />
-            }
+            topCard={<InfoCard title={`${formattedAmount} ${symbol}`} />}
             bottomCard={
               <InfoCard
                 title="Spender"

--- a/packages/react-kit/src/signing/pages/Erc20Transfer.tsx
+++ b/packages/react-kit/src/signing/pages/Erc20Transfer.tsx
@@ -10,8 +10,6 @@ import { SigningPageSkeleton } from '../components/SigningPageSkeleton'
 import { useGasEstimate } from '../hooks/useGasEstimate'
 import { formatGasFee } from '../utils/formatGasFee'
 
-const TOKEN_SUBTITLE = '$175.00 USD'
-const TOKEN_IMAGE_SOURCE = 'https://img.icons8.com/color/1200/ethereum.jpg'
 const RECIPIENT_IMAGE_SOURCE =
   'https://api.dicebear.com/7.x/identicon/svg?seed=recipient'
 
@@ -93,13 +91,7 @@ export function Erc20Transfer({
         <div className="flex flex-col gap-2">
           <Text className="text-body1">You&#39;re sending</Text>
           <ArrowCardPair
-            topCard={
-              <InfoCard
-                title={`${formattedAmount} ${symbol}`}
-                subtitle={TOKEN_SUBTITLE}
-                imageSource={TOKEN_IMAGE_SOURCE}
-              />
-            }
+            topCard={<InfoCard title={`${formattedAmount} ${symbol}`} />}
             bottomCard={
               <InfoCard
                 title={to}

--- a/packages/react-kit/src/signing/pages/EthTransfer.tsx
+++ b/packages/react-kit/src/signing/pages/EthTransfer.tsx
@@ -8,7 +8,6 @@ import { SigningLayout } from '../components/SigningLayout'
 import { useGasEstimate } from '../hooks/useGasEstimate'
 import { formatGasFee } from '../utils/formatGasFee'
 
-const TOKEN_SUBTITLE = '$175.00 USD'
 const TOKEN_IMAGE_SOURCE = 'https://img.icons8.com/color/1200/ethereum.jpg'
 const RECIPIENT_IMAGE_SOURCE =
   'https://api.dicebear.com/7.x/identicon/svg?seed=recipient'
@@ -50,7 +49,6 @@ export function EthTransfer({ to, value, confirm, reject }: EthTransferProps) {
             topCard={
               <InfoCard
                 title={`${formattedAmount} ETH`}
-                subtitle={TOKEN_SUBTITLE}
                 imageSource={TOKEN_IMAGE_SOURCE}
               />
             }


### PR DESCRIPTION
Closes [FS-2185](https://linear.app/offchain-labs/issue/FS-2185/remove-logo-for-non-eth-tokens-and-usd-value)


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
