### PR TITLE
feat(demo): pick email auth method via UI

### DIFF
--- a/apps/zerodev-signer-demo/src/app/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/page.tsx
@@ -1,11 +1,14 @@
 'use client'
 
 import { AuthFlow } from '@zerodev/wallet-react-kit'
+import { Settings } from 'lucide-react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { Suspense, useEffect } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import { useAccount, useConnect } from 'wagmi'
 
 export const dynamic = 'force-dynamic'
+
+type EmailAuthMethod = 'otp' | 'magicLink'
 
 export default function LandingPage() {
   return (
@@ -28,10 +31,6 @@ function LandingPageInner() {
       router.push('/dashboard')
       return
     }
-    // Only auto-connect once wagmi has settled to disconnected (no in-flight
-    // reconnect) and no connect attempt is already in-flight or pending reset.
-    // Without these gates, connect() races wagmi's reconnect and flashes the
-    // SignUp screen before isConnected hydrates.
     if (
       accountStatus === 'disconnected' &&
       connectStatus === 'idle' &&
@@ -39,25 +38,111 @@ function LandingPageInner() {
     ) {
       connect({ connector: connectors[0] })
     }
-  }, [
-    isConnected,
-    accountStatus,
-    connectStatus,
-    router,
-    connect,
-    connectors,
-  ])
+  }, [isConnected, accountStatus, connectStatus, router, connect, connectors])
 
   return (
-    <div className="mx-auto h-screen w-[500px] flex items-center">
+    <div className="mx-auto min-h-screen w-[500px] flex flex-col justify-center py-4">
       {sessionExpired && (
         <div className="mb-4 px-4 py-3 rounded-lg text-sm text-center bg-yellow-50 text-yellow-700 border border-yellow-200">
           Your session has expired. Please log in again.
         </div>
       )}
-      <div className='h-[800px]'>
+      <div className="flex justify-end pb-2">
+        <EmailMethodSettings />
+      </div>
+      <div className="h-[800px] w-full">
         <AuthFlow />
       </div>
     </div>
+  )
+}
+
+function EmailMethodSettings() {
+  const [open, setOpen] = useState(false)
+  const [method, setMethod] = useState<EmailAuthMethod>(() => {
+    if (typeof window === 'undefined') return 'otp'
+    return localStorage.getItem('zd:emailAuthMethod') === 'magicLink'
+      ? 'magicLink'
+      : 'otp'
+  })
+
+  const handleSave = (next: EmailAuthMethod) => {
+    localStorage.setItem('zd:emailAuthMethod', next)
+    window.location.reload()
+  }
+
+  const handleOpen = () => {
+    // Re-sync from storage on open so a previous Cancel doesn't leave the
+    // radios pointing at an unsaved selection.
+    setMethod(
+      localStorage.getItem('zd:emailAuthMethod') === 'magicLink'
+        ? 'magicLink'
+        : 'otp',
+    )
+    setOpen(true)
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleOpen}
+        aria-label="Email method settings"
+        className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
+      >
+        <Settings className="h-6 w-6" />
+      </button>
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="bg-white rounded-lg shadow-lg p-6 w-[320px] flex flex-col gap-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-base font-semibold text-gray-900">
+              Email auth method
+            </h2>
+            <label className="flex items-center gap-2 cursor-pointer text-sm">
+              <input
+                type="radio"
+                name="emailAuthMethod"
+                value="otp"
+                checked={method === 'otp'}
+                onChange={() => setMethod('otp')}
+              />
+              <span className="text-gray-700">OTP code</span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer text-sm">
+              <input
+                type="radio"
+                name="emailAuthMethod"
+                value="magicLink"
+                checked={method === 'magicLink'}
+                onChange={() => setMethod('magicLink')}
+              />
+              <span className="text-gray-700">Magic link</span>
+            </label>
+            <div className="flex justify-end gap-2 mt-2">
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => handleSave(method)}
+                className="px-3 py-1.5 text-sm bg-gray-900 text-white rounded-md hover:bg-gray-800 cursor-pointer"
+              >
+                Save and reload
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   )
 }

--- a/apps/zerodev-signer-demo/src/app/wagmi-config.ts
+++ b/apps/zerodev-signer-demo/src/app/wagmi-config.ts
@@ -15,6 +15,16 @@ const rpcUrls: Record<number, string | undefined> = {
 // unset for the SDK default ('7702').
 const mode = process.env.NEXT_PUBLIC_WALLET_MODE as WalletMode | undefined
 
+// Read the email auth method choice from localStorage on init. Toggled by
+// the cogwheel on the landing page; changes trigger a page reload so this
+// re-runs with the new value.
+function getEmailAuthMethod(): 'otp' | 'magicLink' {
+  if (typeof window === 'undefined') return 'otp'
+  return localStorage.getItem('zd:emailAuthMethod') === 'magicLink'
+    ? 'magicLink'
+    : 'otp'
+}
+
 export const config = createConfig({
   chains: [arbitrumSepolia, sepolia],
   connectors: [
@@ -27,7 +37,7 @@ export const config = createConfig({
         auth: {
           magicLinkBaseUrl: `${process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'}/verify`,
           enabledMethods: ['email', 'google', 'passkey', 'injected-wallet'],
-          emailAuthMethod: 'otp',
+          emailAuthMethod: getEmailAuthMethod(),
         },
       },
     }),

--- a/e2e/browser/magic-link.spec.ts
+++ b/e2e/browser/magic-link.spec.ts
@@ -37,18 +37,17 @@ test.describe('Magic Link Flow', () => {
     const emailAccount = await createNewAccount()
     const email = emailAccount.address
 
-    // Step 2: Navigate to login page (debug flag renders separate
-    // magic-link + OTP buttons regardless of demo's emailAuthMethod config)
-    await page.goto('/?renderBothEmailButtons=true')
+    // Step 2: Seed the demo's email-method choice so wagmi-config picks
+    // magic-link on first paint. Then navigate.
+    await page.addInitScript(() => {
+      localStorage.setItem('zd:emailAuthMethod', 'magicLink')
+    })
+    await page.goto('/')
     await expect(page.getByText('Continue to your wallet')).toBeVisible()
 
-    // Step 3: Enter email
+    // Step 3: Enter email and submit (press Enter)
     await page.getByPlaceholder('Enter your email').fill(email)
-
-    // Step 4: Click magic link button
-    await page
-      .getByRole('button', { name: /Continue with email magic link/i })
-      .click()
+    await page.getByPlaceholder('Enter your email').press('Enter')
 
     // Step 5: Wait for confirmation that magic link was sent
     // (kit's EmailVerification screen renders "Check your email!")

--- a/e2e/browser/otp.spec.ts
+++ b/e2e/browser/otp.spec.ts
@@ -42,18 +42,17 @@ test.describe('OTP Flow', () => {
     const emailAccount = await createNewAccount()
     const email = emailAccount.address
 
-    // Step 2: Navigate to login page (debug flag renders separate
-    // magic-link + OTP buttons regardless of demo's emailAuthMethod config)
-    await page.goto('/?renderBothEmailButtons=true')
+    // Step 2: Seed the demo's email-method choice so wagmi-config picks OTP
+    // on first paint. Then navigate.
+    await page.addInitScript(() => {
+      localStorage.setItem('zd:emailAuthMethod', 'otp')
+    })
+    await page.goto('/')
     await expect(page.getByText('Continue to your wallet')).toBeVisible()
 
-    // Step 3: Enter email
+    // Step 3: Enter email and submit (press Enter)
     await page.getByPlaceholder('Enter your email').fill(email)
-
-    // Step 4: Click OTP button
-    await page
-      .getByRole('button', { name: /Continue with email OTP code/i })
-      .click()
+    await page.getByPlaceholder('Enter your email').press('Enter')
 
     // Step 5: Wait for OTP verification step
     await expect(

--- a/e2e/browser/post-auth.spec.ts
+++ b/e2e/browser/post-auth.spec.ts
@@ -71,13 +71,12 @@ async function loginWithOtp(
   email: string,
   authToken: string,
 ) {
-  // Debug flag renders separate magic-link + OTP buttons regardless of
-  // demo's emailAuthMethod config.
-  await page.goto('/?renderBothEmailButtons=true')
+  await page.addInitScript(() => {
+    localStorage.setItem('zd:emailAuthMethod', 'otp')
+  })
+  await page.goto('/')
   await page.getByPlaceholder('Enter your email').fill(email)
-  await page
-    .getByRole('button', { name: /Continue with email OTP code/i })
-    .click()
+  await page.getByPlaceholder('Enter your email').press('Enter')
   await expect(
     page.getByText(`Enter the code from the email we sent to ${email}`, {
       exact: false,

--- a/packages/react-kit/src/auth/pages/SignUp.tsx
+++ b/packages/react-kit/src/auth/pages/SignUp.tsx
@@ -25,20 +25,7 @@ function isCancellationError(err: unknown): boolean {
   return msg.includes('oauth popup was closed')
 }
 
-// Debug-only override: render both magic-link and OTP buttons so QA can
-// exercise either path regardless of `config.emailAuthMethod`. Toggle by
-// appending `?renderBothEmailButtons=true` to the URL.
-function shouldShowBothEmailButtons(): boolean {
-  if (typeof window === 'undefined') return false
-  return (
-    new URLSearchParams(window.location.search).get(
-      'renderBothEmailButtons',
-    ) === 'true'
-  )
-}
-
 export function SignUp() {
-  const showBothEmailButtons = shouldShowBothEmailButtons()
   const { goToStep, setEmail, setOtpSession, config, enabledMethods } =
     useAuth()
   const [agreedToTerms, setAgreedToTerms] = useState(false)
@@ -255,78 +242,41 @@ export function SignUp() {
             />
           )}
           {enabledMethods.includes('email') && (
-            <>
-              <Input
-                iconName="email"
-                placeholder="Enter your email..."
-                value={emailInput}
-                onChange={(e) => setEmailInput(e.target.value)}
-                type="email"
-                autoCapitalize="none"
-                autoComplete="email"
-                disabled={anyPending}
-                variant="listItemStyle"
-                className="rounded-3xl"
-                onKeyDown={(e) => {
-                  if (
-                    e.key === 'Enter' &&
-                    emailInput &&
-                    !anyPending &&
-                    !showBothEmailButtons
-                  ) {
-                    handleEmailSubmit()
-                  }
-                }}
-              >
-                {!showBothEmailButtons &&
-                  (emailInput && !anyPending ? (
-                    <button
-                      type="button"
-                      className={`w-13 h-13 rounded-2xl bg-greyScale/[3%] flex items-center justify-center transition-colors ${
-                        isValidEmailAddress(emailInput) &&
-                        !needsToAcceptAgreement
-                          ? 'cursor-pointer hover:bg-greyScale/[5%]'
-                          : 'cursor-not-allowed opacity-50'
-                      }`}
-                      onClick={() => handleEmailSubmit()}
-                    >
-                      <Icon name="chevronRight" className="text-greyScale" />
-                    </button>
-                  ) : isEmailLoading ? (
-                    <div className="w-13 h-13 flex items-center justify-center">
-                      <div className="w-5 h-5 border-2 border-solarOrange border-t-transparent rounded-full animate-spin" />
-                    </div>
-                  ) : null)}
-              </Input>
-              {showBothEmailButtons && (
-                <>
-                  <Button
-                    action="secondaryNeutral"
-                    text="Continue with email magic link"
-                    iconName="email"
-                    trailIcon
-                    disabled={
-                      !emailInput ||
-                      anyPending ||
-                      !isValidEmailAddress(emailInput)
-                    }
-                    onClick={() => handleEmailMagicLink()}
-                  />
-                  <Button
-                    action="secondaryNeutral"
-                    text="Continue with email OTP code"
-                    iconName="email"
-                    trailIcon
-                    disabled={
-                      !emailInput ||
-                      anyPending ||
-                      !isValidEmailAddress(emailInput)
-                    }
-                    onClick={() => handleEmailOtp()}
-                  />
-                </>
-              )}
-            </>
+            <Input
+              iconName="email"
+              placeholder="Enter your email..."
+              value={emailInput}
+              onChange={(e) => setEmailInput(e.target.value)}
+              type="email"
+              autoCapitalize="none"
+              autoComplete="email"
+              disabled={anyPending}
+              variant="listItemStyle"
+              className="rounded-3xl"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && emailInput && !anyPending) {
+                  handleEmailSubmit()
+                }
+              }}
+            >
+              {emailInput && !anyPending ? (
+                <button
+                  type="button"
+                  className={`w-13 h-13 rounded-2xl bg-greyScale/[3%] flex items-center justify-center transition-colors ${
+                    isValidEmailAddress(emailInput) && !needsToAcceptAgreement
+                      ? 'cursor-pointer hover:bg-greyScale/[5%]'
+                      : 'cursor-not-allowed opacity-50'
+                  }`}
+                  onClick={() => handleEmailSubmit()}
+                >
+                  <Icon name="chevronRight" className="text-greyScale" />
+                </button>
+              ) : isEmailLoading ? (
+                <div className="w-13 h-13 flex items-center justify-center">
+                  <div className="w-5 h-5 border-2 border-solarOrange border-t-transparent rounded-full animate-spin" />
+                </div>
+              ) : null}
+            </Input>
           )}
           {enabledMethods.includes('injected-wallet') && (
             <>


### PR DESCRIPTION
Replace the kit's `?renderBothEmailButtons=true` debug param with a cogwheel toggle on the demo so users (and e2e) choose OTP vs magic link without touching code. Choice persists in localStorage and reloads to refresh the wagmi config.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
