### PR TITLE
fix(react-kit): gate wagmi hooks during Next prerender pass

### DIFF
--- a/apps/zerodev-signer-demo/next.config.ts
+++ b/apps/zerodev-signer-demo/next.config.ts
@@ -2,7 +2,11 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
-  transpilePackages: ['@zerodev/wallet-react', '@zerodev/wallet-core'],
+  transpilePackages: [
+    '@zerodev/wallet-react',
+    '@zerodev/wallet-core',
+    '@zerodev/wallet-react-kit',
+  ],
 }
 
 export default nextConfig

--- a/apps/zerodev-signer-demo/src/app/verify/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/verify/page.tsx
@@ -2,12 +2,19 @@
 
 import { AuthFlow } from '@zerodev/wallet-react-kit'
 import { useRouter } from 'next/navigation'
-import { Suspense, useEffect } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import { useAccount } from 'wagmi'
 
 export const dynamic = 'force-dynamic'
 
 export default function VerifyPage() {
+  // SSR gate: useAccount throws if Next's prerender pass evaluates this page
+  // without a WagmiProvider in context. Defer until mount.
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+  if (!mounted) return null
   return (
     <Suspense>
       <VerifyPageInner />

--- a/packages/react-kit/src/auth/index.tsx
+++ b/packages/react-kit/src/auth/index.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect } from 'react'
+import { type ReactNode, useEffect, useState } from 'react'
 import { ScreenWrapper } from '../shared/components/ScreenWrapper'
 import { StatusView } from '../shared/components/StatusView'
 import { TopNav } from '../shared/components/TopNav'
@@ -63,11 +63,22 @@ function renderStep(step: AuthStep): ReactNode {
   }
 }
 
-export function AuthFlow({
-  onClose: userOnClose,
-}: {
+type AuthFlowProps = {
   onClose?: (() => void) | undefined
-} = {}) {
+}
+
+export function AuthFlow(props: AuthFlowProps = {}) {
+  // SSR gate: useAuth (-> useConfig) throws if rendered without WagmiProvider
+  // in context, which Next App Router prerender can hit. Defer until mount.
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+  if (!mounted) return null
+  return <AuthFlowInner {...props} />
+}
+
+function AuthFlowInner({ onClose: userOnClose }: AuthFlowProps) {
   const { step, goToStep, goBack, reset } = useAuth()
 
   useEffect(() => {

--- a/packages/react-kit/src/signing/index.tsx
+++ b/packages/react-kit/src/signing/index.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, ReactNode } from 'react'
+import { type CSSProperties, type ReactNode, useEffect, useState } from 'react'
 import { ScreenWrapper } from '../shared/components/ScreenWrapper'
 import type { PendingRequest, Request } from '../types.js'
 import { renderRequestContent } from './components/renderRequestContent.js'
@@ -69,13 +69,28 @@ function ControlledSignatureRequest({
   )
 }
 
-function UncontrolledSignatureRequest({
+type UncontrolledSignatureRequestProps = {
+  children: ((args: RenderPropArgs) => ReactNode) | undefined
+} & StyleProps
+
+function UncontrolledSignatureRequest(
+  props: UncontrolledSignatureRequestProps,
+) {
+  // SSR gate: usePendingRequest (-> useConfig) throws if rendered without
+  // WagmiProvider in context, which Next App Router prerender can hit.
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+  if (!mounted) return null
+  return <UncontrolledSignatureRequestInner {...props} />
+}
+
+function UncontrolledSignatureRequestInner({
   children,
   className,
   style,
-}: {
-  children: ((args: RenderPropArgs) => ReactNode) | undefined
-} & StyleProps) {
+}: UncontrolledSignatureRequestProps) {
   const { pendingRequest, pendingRequests, confirm, reject } =
     usePendingRequest()
 


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
