### PR TITLE
refactor(auth): replace 'initializing' step with null

### DIFF
--- a/packages/react-kit/docs/pages/react-kit/hooks/use-auth.mdx
+++ b/packages/react-kit/docs/pages/react-kit/hooks/use-auth.mdx
@@ -41,12 +41,12 @@ function MyCustomAuth() {
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `step` | `AuthStep` | The current step in the auth flow. |
+| `step` | `AuthStep \| null` | The current step in the auth flow. `null` means nothing should render yet. |
 | `email` | `string \| null` | The email entered by the user, if any. |
 | `otpId` | `string \| null` | The id of the active OTP challenge, if any. |
 | `enabledMethods` | `AuthMethod[]` | Methods enabled by `config.auth.enabledMethods`. |
 | `config` | `AuthConfig \| null` | The full auth config passed to the connector. |
-| `goToStep` | `(step: AuthStep) => void` | Move the flow to a specific step. |
+| `goToStep` | `(step: AuthStep \| null) => void` | Move the flow to a specific step (or `null` to render nothing). |
 | `goBack` | `(() => void) \| null` | Go back to the previous step. `null` when there's no previous step. |
 | `reset` | `() => void` | Reset the flow to its initial state. |
 | `setEmail` | `(email: string) => void` | Set the email value. |
@@ -56,7 +56,6 @@ function MyCustomAuth() {
 
 ```ts
 type AuthStep =
-  | 'initializing'
   | 'sign-up'
   | 'email-verification'
   | 'otp-input'

--- a/packages/react-kit/src/auth/authStoreSlice.test.ts
+++ b/packages/react-kit/src/auth/authStoreSlice.test.ts
@@ -18,7 +18,7 @@ describe('authStoreSlice', () => {
       const store = createStore()
       const { auth } = store.getState()
 
-      expect(auth.step).toBe('initializing')
+      expect(auth.step).toBeNull()
       expect(auth.stepHistory).toEqual([])
       expect(auth.enabledMethods).toEqual([])
       expect(auth.email).toBeNull()
@@ -37,7 +37,7 @@ describe('authStoreSlice', () => {
       const { auth } = store.getState()
       expect(auth.config).toEqual(config)
       expect(auth.enabledMethods).toEqual(['email', 'google', 'passkey'])
-      expect(auth.step).toBe('initializing')
+      expect(auth.step).toBeNull()
     })
 
     it('sets custom enabled methods from config', () => {
@@ -69,7 +69,7 @@ describe('authStoreSlice', () => {
       expect(auth.stepHistory).toEqual(['sign-up'])
     })
 
-    it('does not push initializing onto history', () => {
+    it('does not push the null step onto history', () => {
       const store = createStore()
       const config = createMockAuthConfig()
       store.getState().auth.initialize(config)
@@ -170,7 +170,7 @@ describe('authStoreSlice', () => {
       store.getState().auth.reset()
 
       const { auth } = store.getState()
-      expect(auth.step).toBe('initializing')
+      expect(auth.step).toBeNull()
       expect(auth.stepHistory).toEqual([])
       expect(auth.email).toBeNull()
       expect(auth.otpId).toBeNull()
@@ -325,7 +325,7 @@ describe('authStoreSlice', () => {
       store.getState().auth.reset()
 
       const { auth } = store.getState()
-      expect(auth.step).toBe('initializing')
+      expect(auth.step).toBeNull()
       expect(auth.email).toBeNull()
       expect(auth.otpId).toBeNull()
       expect(auth.stepHistory).toEqual([])
@@ -344,7 +344,7 @@ describe('authStoreSlice', () => {
       expect(listener).not.toHaveBeenCalled()
 
       store.getState().auth.goToStep('sign-up')
-      expect(listener).toHaveBeenCalledWith('sign-up', 'initializing')
+      expect(listener).toHaveBeenCalledWith('sign-up', null)
       expect(listener).toHaveBeenCalledTimes(1)
     })
 
@@ -383,10 +383,10 @@ describe('authStoreSlice', () => {
       store1.getState().auth.setEmail('user1@example.com')
 
       expect(store1.getState().auth.email).toBe('user1@example.com')
-      expect(store1.getState().auth.step).toBe('initializing')
+      expect(store1.getState().auth.step).toBeNull()
 
       expect(store2.getState().auth.email).toBeNull()
-      expect(store2.getState().auth.step).toBe('initializing')
+      expect(store2.getState().auth.step).toBeNull()
     })
   })
 })

--- a/packages/react-kit/src/auth/authStoreSlice.ts
+++ b/packages/react-kit/src/auth/authStoreSlice.ts
@@ -45,7 +45,7 @@ function clearStoredOtpSession(): void {
 export interface AuthStoreSlice {
   auth: {
     // State
-    step: AuthStep
+    step: AuthStep | null
     stepHistory: AuthStep[]
     enabledMethods: AuthMethod[]
     email: string | null
@@ -67,7 +67,7 @@ export interface AuthStoreSlice {
 
     // Actions
     initialize: (config: AuthConfig) => void
-    goToStep: (step: AuthStep) => void
+    goToStep: (step: AuthStep | null) => void
     goBack: () => void
     reset: () => void
   }
@@ -81,7 +81,7 @@ export const createAuthStoreSlice: StateCreator<
 > = (set, get, _store) => ({
   auth: {
     // Initial state
-    step: 'initializing',
+    step: null,
     stepHistory: [],
     enabledMethods: [],
     email: null,
@@ -105,13 +105,13 @@ export const createAuthStoreSlice: StateCreator<
       }))
     },
 
-    goToStep: (step: AuthStep) => {
+    goToStep: (step: AuthStep | null) => {
       set((state) => ({
         auth: {
           ...state.auth,
           step,
           stepHistory:
-            state.auth.step === 'initializing'
+            state.auth.step === null
               ? state.auth.stepHistory
               : [...state.auth.stepHistory, state.auth.step],
         },
@@ -137,7 +137,7 @@ export const createAuthStoreSlice: StateCreator<
       set((state) => ({
         auth: {
           ...state.auth,
-          step: 'initializing',
+          step: null,
           stepHistory: [],
           email: null,
           otpId: null,

--- a/packages/react-kit/src/auth/hooks/useAuth.test.ts
+++ b/packages/react-kit/src/auth/hooks/useAuth.test.ts
@@ -64,7 +64,7 @@ describe('useAuth', () => {
 
     const { result } = renderHook(() => useAuth())
 
-    expect(result.current.step).toBe('initializing')
+    expect(result.current.step).toBeNull()
     expect(result.current.email).toBeNull()
     expect(result.current.otpId).toBeNull()
     expect(result.current.enabledMethods).toEqual([])
@@ -79,7 +79,7 @@ describe('useAuth', () => {
 
     const { result } = renderHook(() => useAuth())
 
-    expect(result.current.step).toBe('initializing')
+    expect(result.current.step).toBeNull()
     expect(result.current.enabledMethods).toEqual([
       'email',
       'google',
@@ -158,7 +158,7 @@ describe('useAuth', () => {
     result.current.reset()
 
     const { auth } = store.getState()
-    expect(auth.step).toBe('initializing')
+    expect(auth.step).toBeNull()
     expect(auth.email).toBeNull()
   })
 
@@ -195,7 +195,7 @@ describe('useAuth', () => {
 
     const { result, rerender } = renderHook(() => useAuth())
 
-    expect(result.current.step).toBe('initializing')
+    expect(result.current.step).toBeNull()
 
     // Change store state
     store.getState().auth.initialize(config)

--- a/packages/react-kit/src/auth/index.test.tsx
+++ b/packages/react-kit/src/auth/index.test.tsx
@@ -55,7 +55,7 @@ vi.mock('../shared/components/StatusView', () => ({
 }))
 
 // Mock useAuth hook
-let mockStep: AuthStep = 'initializing'
+let mockStep: AuthStep | null = null
 vi.mock('./hooks/useAuth', () => ({
   useAuth: () => ({
     step: mockStep,
@@ -64,7 +64,7 @@ vi.mock('./hooks/useAuth', () => ({
     enabledMethods: ['email', 'google', 'passkey'],
     config: null,
     goToStep: vi.fn(),
-    goBack: vi.fn(),
+    onBack: null,
     reset: vi.fn(),
     setEmail: vi.fn(),
     setOtpId: vi.fn(),
@@ -72,8 +72,8 @@ vi.mock('./hooks/useAuth', () => ({
 }))
 
 describe('AuthFlow', () => {
-  it('renders nothing in initializing state', () => {
-    mockStep = 'initializing'
+  it('renders nothing when step is null', () => {
+    mockStep = null
     const { container } = render(<AuthFlow />)
 
     expect(container.firstChild).toBeNull()

--- a/packages/react-kit/src/auth/index.tsx
+++ b/packages/react-kit/src/auth/index.tsx
@@ -36,7 +36,7 @@ function PasskeyPrompt() {
   )
 }
 
-function renderStep(step: AuthStep): ReactNode {
+function renderStep(step: AuthStep | null): ReactNode {
   switch (step) {
     case 'sign-up':
       return <SignUp />
@@ -67,7 +67,7 @@ export function AuthFlow({
   const { step, goToStep, goBack, reset } = useAuth()
 
   useEffect(() => {
-    if (step === 'initializing' && hasMagicLinkCodeInUrl()) {
+    if (step === null && hasMagicLinkCodeInUrl()) {
       goToStep('verifying-otp')
     }
   }, [step, goToStep])
@@ -80,7 +80,7 @@ export function AuthFlow({
     reset()
     userOnClose?.()
   }
-  const title = TITLE_BY_STEP[step]
+  const title = step ? TITLE_BY_STEP[step] : undefined
 
   return (
     <ScreenWrapper

--- a/packages/react-kit/src/auth/pages/WalletSelection.tsx
+++ b/packages/react-kit/src/auth/pages/WalletSelection.tsx
@@ -15,7 +15,7 @@ export function WalletSelection() {
       { connector },
       {
         onSuccess: () => {
-          goToStep('initializing')
+          goToStep(null)
         },
       },
     )

--- a/packages/react-kit/src/auth/types.ts
+++ b/packages/react-kit/src/auth/types.ts
@@ -1,7 +1,6 @@
 export type AuthMethod = 'email' | 'google' | 'passkey' | 'injected-wallet'
 
 export type AuthStep =
-  | 'initializing'
   | 'sign-up'
   | 'email-verification'
   | 'otp-input'

--- a/packages/react-kit/src/connector.test.ts
+++ b/packages/react-kit/src/connector.test.ts
@@ -243,7 +243,7 @@ describe('connector', () => {
 
       expect(store.getState().auth.config).toEqual(authConfig)
       expect(store.getState().auth.enabledMethods).toEqual(['email', 'google'])
-      expect(store.getState().auth.step).toBe('initializing')
+      expect(store.getState().auth.step).toBeNull()
     })
 
     it('does not initialize auth when config is not provided', () => {
@@ -252,7 +252,7 @@ describe('connector', () => {
 
       expect(store.getState().auth.config).toBeNull()
       expect(store.getState().auth.enabledMethods).toEqual([])
-      expect(store.getState().auth.step).toBe('initializing')
+      expect(store.getState().auth.step).toBeNull()
     })
 
     it('auth config works with signing config', () => {

--- a/packages/react-kit/src/connector.ts
+++ b/packages/react-kit/src/connector.ts
@@ -65,7 +65,7 @@ export function zeroDevWallet(
         if (
           !isAuthorized &&
           params.config?.auth &&
-          store.getState().auth.step === 'initializing'
+          store.getState().auth.step === null
         ) {
           store.getState().auth.goToStep('sign-up')
           await new Promise<void>((resolve) => {
@@ -87,7 +87,7 @@ export function zeroDevWallet(
         await connector.disconnect?.()
         // Reset auth state on disconnect and surface the sign-up page so the
         // user can immediately re-authenticate instead of seeing an empty
-        // AuthFlow (the 'initializing' step renders null).
+        // AuthFlow (a null step renders nothing).
         if (params.config?.auth) {
           store.getState().auth.reset()
           store.getState().auth.initialize(params.config.auth)

--- a/packages/react-kit/src/store.test.ts
+++ b/packages/react-kit/src/store.test.ts
@@ -122,7 +122,7 @@ describe('store', () => {
       const state = store.getState()
 
       expect(state.auth).toBeDefined()
-      expect(state.auth.step).toBe('initializing')
+      expect(state.auth.step).toBeNull()
       expect(state.auth.stepHistory).toEqual([])
       expect(state.auth.enabledMethods).toEqual([])
       expect(state.auth.email).toBeNull()


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
