### PR TITLE
feat: add mobile modules and separate exports for tree-shakability

### DIFF
--- a/apps/expo-example/docs/oauth-native.md
+++ b/apps/expo-example/docs/oauth-native.md
@@ -27,7 +27,11 @@ redirect URI is then derived from `RP_ID` in
 [`src/config/auth.ts`](../src/config/auth.ts)); when unset or `false`,
 `Linking.createURL(<path>)` builds the custom-scheme fallback.
 The OAuth branch lands in the `Linking.addEventListener('url', ...)`
-handler inside [`src/oauth/createNativeOAuthGetSessionId.ts`](../src/oauth/createNativeOAuthGetSessionId.ts);
+handler inside `@zerodev/wallet-react`'s
+`createOAuthGetSessionIdWithExpoWebBrowser` helper, which this app wires
+up via [`src/hooks/useAuthenticateOAuth.native.ts`](../src/hooks/useAuthenticateOAuth.native.ts)
+(consuming the `useAuthenticateOAuthWithExpoWebBrowser` convenience hook
+from `@zerodev/wallet-react/react-native/oauth/with-expo-web-browser`);
 the magic-link branch lands in
 [`src/app/verify-email.tsx`](../src/app/verify-email.tsx) via
 expo-router's `useLocalSearchParams`.

--- a/apps/expo-example/metro.config.js
+++ b/apps/expo-example/metro.config.js
@@ -5,6 +5,16 @@ const config = getDefaultConfig(__dirname)
 const packagesDir = path.resolve(__dirname, '../../packages')
 const appPackageJson = path.resolve(__dirname, 'package.json')
 
+// Required so Metro honors `package.json` "exports" maps and our conditional
+// `react-native` entries in @zerodev/wallet-react and @zerodev/wallet-core
+// resolve correctly.
+config.resolver.unstable_enablePackageExports = true
+config.resolver.unstable_conditionNames = [
+  ...(config.resolver.unstable_conditionNames ?? []),
+  'react-native',
+  'import',
+]
+
 // Packages that must resolve to a single copy to avoid duplicate
 // React contexts. pnpm creates separate .pnpm entries with different
 // peer-dep hashes for the app vs workspace packages.
@@ -17,11 +27,17 @@ const workspaceSingletons = new Set([
 
 // Packages that must resolve to the app's copy globally — safe because
 // they are leaf packages with no internal dependencies that would break.
+// `@zerodev/wallet-react` and `@zerodev/wallet-core` are in this set
+// because the connector holds Zustand state reachable from hooks —
+// duplicate copies under different pnpm `.pnpm` hashes would split
+// auth/session state across the app.
 const globalSingletons = new Set([
   'react',
   'react-dom',
   'react-native',
   'tslib',
+  '@zerodev/wallet-react',
+  '@zerodev/wallet-core',
 ])
 
 // Check if moduleName matches or is a sub-path of any package in the set

--- a/apps/expo-example/src/components/export/ExportBox.tsx
+++ b/apps/expo-example/src/components/export/ExportBox.tsx
@@ -1,6 +1,7 @@
+import { ZeroDevExportWebView } from '@zerodev/wallet-react/react-native/export/webview'
 import { useState } from 'react'
 import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
-import { ExportWebView } from './ExportWebView'
+import { RP_ID } from '@/config/auth'
 
 type Props = {
   kind: 'wallet' | 'privateKey'
@@ -35,8 +36,9 @@ export function ExportBox({ kind }: Props) {
         ]}
         pointerEvents={stage === 'ready' ? 'auto' : 'none'}
       >
-        <ExportWebView
+        <ZeroDevExportWebView
           kind={kind}
+          rpId={RP_ID}
           onReady={() => setStage('ready')}
           onError={(msg) => {
             setStage('error')

--- a/apps/expo-example/src/hooks/useAuthenticateOAuth.d.ts
+++ b/apps/expo-example/src/hooks/useAuthenticateOAuth.d.ts
@@ -1,1 +1,10 @@
-export { useAuthenticateOAuth } from '@zerodev/wallet-react'
+// Re-declare the app-side wrapper hook's signature so TS sees a no-arg hook
+// regardless of platform (Metro picks `.native.ts` on RN, `.web.ts` on web).
+// The library's RN-side type narrows the hook to require getSessionId +
+// redirectUri at the type level; our wrapper supplies both internally so the
+// app calls `useAuthenticateOAuth()` with no args.
+import type { useAuthenticateOAuth as UseAuthOAuth } from '@zerodev/wallet-react'
+
+type AuthReturn = ReturnType<typeof UseAuthOAuth>
+
+export declare function useAuthenticateOAuth(): AuthReturn

--- a/apps/expo-example/src/hooks/useAuthenticateOAuth.native.ts
+++ b/apps/expo-example/src/hooks/useAuthenticateOAuth.native.ts
@@ -1,12 +1,8 @@
-import { useAuthenticateOAuth as useBase } from '@zerodev/wallet-react'
-import { useMemo } from 'react'
+import { useAuthenticateOAuthWithExpoWebBrowser } from '@zerodev/wallet-react/react-native/oauth/with-expo-web-browser'
 import { OAUTH_REDIRECT_URI } from '@/config/auth'
-import { createNativeOAuthGetSessionId } from '@/oauth/createNativeOAuthGetSessionId'
 
 export function useAuthenticateOAuth() {
-  const getSessionId = useMemo(
-    () => createNativeOAuthGetSessionId({ redirectUri: OAUTH_REDIRECT_URI }),
-    [],
-  )
-  return useBase({ getSessionId, redirectUri: OAUTH_REDIRECT_URI })
+  return useAuthenticateOAuthWithExpoWebBrowser({
+    redirectUri: OAUTH_REDIRECT_URI,
+  })
 }

--- a/apps/expo-example/src/lib/asyncSessionStorage.ts
+++ b/apps/expo-example/src/lib/asyncSessionStorage.ts
@@ -1,8 +1,0 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
-import type { StorageAdapter } from '@zerodev/wallet-core'
-
-export const asyncSessionStorage: StorageAdapter = {
-  getItem: (key) => AsyncStorage.getItem(key),
-  setItem: (key, value) => AsyncStorage.setItem(key, value),
-  removeItem: (key) => AsyncStorage.removeItem(key),
-}

--- a/apps/expo-example/src/wagmi/config.native.ts
+++ b/apps/expo-example/src/wagmi/config.native.ts
@@ -1,10 +1,10 @@
+import { createReactNativePasskeyStamper } from '@zerodev/wallet-core/react-native/stampers/passkey'
+import { createSecureStoreStamper } from '@zerodev/wallet-core/react-native/stampers/secure-store'
+import { asyncStorageAdapter } from '@zerodev/wallet-core/react-native/storage/async-storage'
 import { zeroDevWallet } from '@zerodev/wallet-react'
 import { createConfig, createStorage, http } from 'wagmi'
 import { arbitrumSepolia, sepolia } from 'wagmi/chains'
 import { RP_ID } from '@/config/auth'
-import { asyncSessionStorage } from '@/lib/asyncSessionStorage'
-import { createReactNativePasskeyStamper } from '@/lib/reactNativePasskeyStamper'
-import { createSecureStoreStamper } from '@/lib/secureStoreStamper'
 
 const ZERODEV_PROJECT_ID = process.env.EXPO_PUBLIC_ZERODEV_PROJECT_ID ?? ''
 const chains = [sepolia, arbitrumSepolia] as const
@@ -21,17 +21,15 @@ export const wagmiConfig = createConfig({
         headers: { Origin: `https://${RP_ID}` },
       },
       apiKeyStamper: createSecureStoreStamper(),
-      passkeyStamper: createReactNativePasskeyStamper({
-        rpId: RP_ID,
-      }),
-      sessionStorage: asyncSessionStorage,
-      persistStorage: asyncSessionStorage,
+      passkeyStamper: createReactNativePasskeyStamper({ rpId: RP_ID }),
+      sessionStorage: asyncStorageAdapter,
+      persistStorage: asyncStorageAdapter,
     }),
   ],
   transports: {
     [sepolia.id]: http(),
     [arbitrumSepolia.id]: http(),
   },
-  storage: createStorage({ storage: asyncSessionStorage }),
+  storage: createStorage({ storage: asyncStorageAdapter }),
   multiInjectedProviderDiscovery: false,
 })

--- a/apps/zerodev-signer-demo/next.config.ts
+++ b/apps/zerodev-signer-demo/next.config.ts
@@ -1,8 +1,25 @@
+import path from 'node:path'
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   transpilePackages: ['@zerodev/wallet-react', '@zerodev/wallet-core'],
+  // Force a single wagmi / @wagmi/core instance in the bundle. wagmi exposes
+  // its config through React Context; if two physical copies end up loaded,
+  // `WagmiProvider` and `useConfig` reference different Contexts and hooks
+  // throw WagmiProviderNotFoundError. Duplicates can arise whenever the same
+  // wagmi version is resolved with different (optional) peer-dependency
+  // contexts across paths — common in workspaces. Aliasing both packages to
+  // this app's node_modules guarantees every import resolves to the same
+  // module identity.
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      wagmi: path.resolve(__dirname, 'node_modules/wagmi'),
+      '@wagmi/core': path.resolve(__dirname, 'node_modules/@wagmi/core'),
+    }
+    return config
+  },
 }
 
 export default nextConfig

--- a/biome.json
+++ b/biome.json
@@ -139,11 +139,11 @@
     {
       "includes": [
         "**/src/index.ts",
+        "**/src/index.native.ts",
         "**/actions/index.ts",
         "**/auth/index.ts",
         "**/wallet/index.ts",
-        "**/client/index.ts",
-        "**/stampers/index.ts"
+        "**/client/index.ts"
       ],
       "linter": {
         "rules": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -85,7 +85,7 @@
   ],
   "scripts": {
     "build": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm && pnpm run build:types",
-    "build:cjs": "tsc --project ./tsconfig.build.json --module node16 --moduleResolution node16 --outDir ./dist/_cjs --removeComments --verbatimModuleSyntax false && printf '{\"type\":\"commonjs\"}' > ./dist/_cjs/package.json",
+    "build:cjs": "tsc --project ./tsconfig.build.json --module commonjs --moduleResolution node --outDir ./dist/_cjs --removeComments --verbatimModuleSyntax false && printf '{\"type\":\"commonjs\"}' > ./dist/_cjs/package.json",
     "build:esm": "tsc --project ./tsconfig.build.json --outDir ./dist/_esm && printf '{\"type\": \"module\",\"sideEffects\":false}' > ./dist/_esm/package.json",
     "build:types": "tsc --project ./tsconfig.build.json --outDir ./dist/_types --emitDeclarationOnly --declaration --declarationMap",
     "dev": "tsc --watch",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,14 +2,65 @@
   "name": "@zerodev/wallet-core",
   "version": "0.0.1-alpha.20",
   "description": "ZeroDev Wallet SDK built on Turnkey",
+  "type": "module",
+  "sideEffects": false,
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",
   "types": "./dist/_types/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/_types/index.d.ts",
-      "import": "./dist/_esm/index.js",
-      "require": "./dist/_cjs/index.js"
+      "react-native": {
+        "types": "./dist/_types/index.native.d.ts",
+        "default": "./dist/_esm/index.native.js"
+      },
+      "browser": {
+        "types": "./dist/_types/index.d.ts",
+        "default": "./dist/_esm/index.js"
+      },
+      "import": {
+        "types": "./dist/_types/index.d.ts",
+        "default": "./dist/_esm/index.js"
+      },
+      "require": {
+        "types": "./dist/_types/index.d.ts",
+        "default": "./dist/_cjs/index.js"
+      },
+      "default": {
+        "types": "./dist/_types/index.d.ts",
+        "default": "./dist/_esm/index.js"
+      }
+    },
+    "./react-native": {
+      "browser": "./dist/_esm/stubs/native-on-web.js",
+      "import": {
+        "types": "./dist/_types/index.native.d.ts",
+        "default": "./dist/_esm/index.native.js"
+      },
+      "default": "./dist/_esm/index.native.js"
+    },
+    "./react-native/stampers/secure-store": {
+      "browser": "./dist/_esm/stubs/native-on-web.js",
+      "import": {
+        "types": "./dist/_types/native/stampers/secureStore.d.ts",
+        "default": "./dist/_esm/native/stampers/secureStore.js"
+      },
+      "default": "./dist/_esm/native/stampers/secureStore.js"
+    },
+    "./react-native/stampers/passkey": {
+      "browser": "./dist/_esm/stubs/native-on-web.js",
+      "import": {
+        "types": "./dist/_types/native/stampers/passkey.d.ts",
+        "default": "./dist/_esm/native/stampers/passkey.js"
+      },
+      "default": "./dist/_esm/native/stampers/passkey.js"
+    },
+    "./react-native/storage/async-storage": {
+      "browser": "./dist/_esm/stubs/native-on-web.js",
+      "import": {
+        "types": "./dist/_types/native/storage/asyncStorage.d.ts",
+        "default": "./dist/_esm/native/storage/asyncStorage.js"
+      },
+      "default": "./dist/_esm/native/storage/asyncStorage.js"
     },
     "./viem": {
       "types": "./dist/_types/adapters/viem.d.ts",
@@ -20,11 +71,6 @@
       "types": "./dist/_types/actions/index.d.ts",
       "import": "./dist/_esm/actions/index.js",
       "require": "./dist/_cjs/actions/index.js"
-    },
-    "./stampers": {
-      "types": "./dist/_types/stampers/index.d.ts",
-      "import": "./dist/_esm/stampers/index.js",
-      "require": "./dist/_cjs/stampers/index.js"
     }
   },
   "files": [
@@ -39,7 +85,7 @@
   ],
   "scripts": {
     "build": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm && pnpm run build:types",
-    "build:cjs": "tsc --project ./tsconfig.build.json --module commonjs --moduleResolution node --outDir ./dist/_cjs --removeComments --verbatimModuleSyntax false && printf '{\"type\":\"commonjs\"}' > ./dist/_cjs/package.json",
+    "build:cjs": "tsc --project ./tsconfig.build.json --module node16 --moduleResolution node16 --outDir ./dist/_cjs --removeComments --verbatimModuleSyntax false && printf '{\"type\":\"commonjs\"}' > ./dist/_cjs/package.json",
     "build:esm": "tsc --project ./tsconfig.build.json --outDir ./dist/_esm && printf '{\"type\": \"module\",\"sideEffects\":false}' > ./dist/_esm/package.json",
     "build:types": "tsc --project ./tsconfig.build.json --outDir ./dist/_types --emitDeclarationOnly --declaration --declarationMap",
     "dev": "tsc --watch",
@@ -68,12 +114,47 @@
     "json-canonicalize": "^2.0.0"
   },
   "peerDependencies": {
-    "viem": "^2.38.0"
+    "viem": "^2.38.0",
+    "@react-native-async-storage/async-storage": ">=2.0.0",
+    "@turnkey/api-key-stamper": ">=0.6.0",
+    "@turnkey/crypto": ">=2.8.0",
+    "@turnkey/react-native-passkey-stamper": ">=1.2.0",
+    "expo-secure-store": ">=14.0.0",
+    "react-native": ">=0.73.0",
+    "uuid": ">=11.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@react-native-async-storage/async-storage": {
+      "optional": true
+    },
+    "@turnkey/api-key-stamper": {
+      "optional": true
+    },
+    "@turnkey/crypto": {
+      "optional": true
+    },
+    "@turnkey/react-native-passkey-stamper": {
+      "optional": true
+    },
+    "expo-secure-store": {
+      "optional": true
+    },
+    "react-native": {
+      "optional": true
+    },
+    "uuid": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@hpke/core": "^1.9.0",
+    "@react-native-async-storage/async-storage": "2.2.0",
+    "@turnkey/api-key-stamper": "0.6.4",
+    "@turnkey/crypto": "2.8.13",
+    "@turnkey/react-native-passkey-stamper": "1.2.12",
     "@types/node": "^20.0.0",
-    "typescript": "5.9.3"
-  },
-  "type": "module"
+    "expo-secure-store": "55.0.9",
+    "typescript": "5.9.3",
+    "uuid": "^13.0.0"
+  }
 }

--- a/packages/core/src/core/createZeroDevWalletCore.ts
+++ b/packages/core/src/core/createZeroDevWalletCore.ts
@@ -16,10 +16,7 @@ import {
   DEFAULT_SESSION_EXPIRATION_IN_SECONDS,
   KMS_SERVER_URL,
 } from '../constants.js'
-import { createIndexedDbStamper } from '../stampers/indexedDbStamper.js'
 import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'
-import { createWebauthnStamper } from '../stampers/webauthnStamper.js'
-import { createWebStorageAdapter } from '../storage/adapters.js'
 import {
   createStorageManager,
   type StorageAdapter,
@@ -28,14 +25,14 @@ import { SessionType, type ZeroDevWalletSession } from '../types/session.js'
 import { buildClientSignature } from '../utils/buildClientSignature.js'
 import { encryptOtpAttempt } from '../utils/encryptOtpAttempt.js'
 import { humanReadableDateTime, parseSession } from '../utils/utils.js'
-export interface ZeroDevWalletConfig {
+export interface ZeroDevWalletConfigCore {
   organizationId?: string
   proxyBaseUrl?: string
   projectId: string
-  sessionStorage?: StorageAdapter
-  rpId?: string
-  apiKeyStamper?: ApiKeyStamper
-  passkeyStamper?: PasskeyStamper
+  sessionStorage: StorageAdapter
+  rpId: string
+  apiKeyStamper: ApiKeyStamper
+  passkeyStamper: PasskeyStamper
   fetchOptions?: CreateTransportOptions['fetchOptions']
 }
 
@@ -118,24 +115,19 @@ export interface ZeroDevWalletSDK {
   toAccount: () => Promise<LocalAccount>
 }
 
-export async function createZeroDevWallet(
-  config: ZeroDevWalletConfig,
+export async function createZeroDevWalletCore(
+  config: ZeroDevWalletConfigCore,
 ): Promise<ZeroDevWalletSDK> {
   const {
     projectId,
     sessionStorage,
-    rpId = window.location.hostname,
+    rpId,
+    apiKeyStamper,
+    passkeyStamper,
     organizationId = DEFAULT_ORGANIZATION_ID,
   } = config
 
-  const sessionStorageManager = createStorageManager(
-    sessionStorage || createWebStorageAdapter(),
-  )
-
-  const apiKeyStamper = config.apiKeyStamper ?? (await createIndexedDbStamper())
-
-  const passkeyStamper =
-    config.passkeyStamper ?? (await createWebauthnStamper({ rpId }))
+  const sessionStorageManager = createStorageManager(sessionStorage)
 
   const client = createClient({
     apiKeyStamper,

--- a/packages/core/src/index.native.ts
+++ b/packages/core/src/index.native.ts
@@ -1,14 +1,18 @@
 import { isReactNative } from './utils/platform.js'
 
-if (isReactNative()) {
+if (!isReactNative()) {
   // biome-ignore lint/suspicious/noConsole: Warning users if they try to use the web entry on React Native.
   console.warn(
-    '@zerodev/wallet-core: the web entry was loaded in a React Native runtime. Check that your metro.config.js has `unstable_enablePackageExports: true` and `"react-native"` in `unstable_conditionNames`.',
+    '@zerodev/wallet-core/react-native: the React Native entry was loaded outside a React Native runtime. If this is a non-RN context, import `@zerodev/wallet-core` (the bare specifier) instead.',
   )
 }
 
+// Re-export shared API surface. Note: we intentionally do NOT re-export the
+// web stamper factories (createIndexedDbStamper, createWebauthnStamper,
+// createIframeStamper) here — they're web-only. The native adapter factories
+// live behind their own granular subpaths so consumers using alternative
+// adapters (Keychain, MMKV, custom) skip the unused peer-dep installs.
 export type {
-  // Auth types
   ApiKeyAuthenticator,
   AuthenticateWithEmailParameters,
   AuthenticateWithEmailReturnType,
@@ -18,7 +22,6 @@ export type {
   EmailCustomization,
   GetAuthenticatorsParameters,
   GetAuthenticatorsReturnType,
-  // Wallet types
   GetUserWalletParameters,
   GetUserWalletReturnType,
   GetWhoamiParameters,
@@ -41,14 +44,10 @@ export type {
   SignUserOperationParameters,
   SignUserOperationReturnType,
 } from './actions/index.js'
-
-// Actions
 export {
-  // Auth actions
   authenticateWithEmail,
   authenticateWithOAuth,
   getAuthenticators,
-  // Wallet actions
   getUserWallet,
   getWhoami,
   loginWithOTP,
@@ -60,10 +59,8 @@ export {
   signUserOperation,
 } from './actions/index.js'
 export type { ToViemAccountParams } from './adapters/viem.js'
-// Adapters
 export { toViemAccount } from './adapters/viem.js'
 export type { ZeroDevWalletActions } from './client/decorators/client.js'
-// Client decorators
 export { zeroDevWalletActions } from './client/decorators/client.js'
 export type {
   Client,
@@ -71,21 +68,24 @@ export type {
   CreateTransportOptions,
   Transport,
 } from './client/index.js'
-// Client
 export {
   createBaseClient,
   createClient,
   type ZeroDevWalletClient,
   zeroDevWalletTransport,
 } from './client/index.js'
-// Constants
 export { KMS_SERVER_URL } from './constants.js'
 export type {
   AuthParams,
   ZeroDevWalletSDK,
 } from './core/createZeroDevWalletCore.js'
-// Stampers
-export { createIframeStamper } from './stampers/iframeStamper.js'
+// RN entry re-exports core directly. `ZeroDevWalletConfigCore` already has
+// all four adapter fields required, so RN consumers get compile-time enforcement
+// without a separate type wrapper.
+export {
+  createZeroDevWalletCore as createZeroDevWallet,
+  type ZeroDevWalletConfigCore as ZeroDevWalletConfig,
+} from './core/createZeroDevWalletCore.js'
 export type {
   ApiKeyStamper,
   Attestation,
@@ -94,20 +94,9 @@ export type {
   PasskeyRegistrationResult,
   PasskeyStamper,
 } from './stampers/types.js'
-// Storage
 export type { StorageAdapter, StorageManager } from './storage/manager.js'
-// Session types
 export type { StamperType, ZeroDevWalletSession } from './types/session.js'
 export type { KeyFormat } from './utils/exportPrivateKey.js'
 export { exportPrivateKey } from './utils/exportPrivateKey.js'
 export { exportWallet } from './utils/exportWallet.js'
-// Utils
 export { normalizeTimestamp } from './utils/utils.js'
-// Core — bare specifier resolves web defaults (IndexedDB, WebAuthn, session
-// storage, hostname-derived rpId) before forwarding to the shared factory.
-// RN consumers go through `@zerodev/wallet-core/react-native`, which exposes
-// the strict `ZeroDevWalletConfig` (= core's required-fields shape) directly.
-export {
-  createZeroDevWallet,
-  type ZeroDevWalletConfig,
-} from './web/createZeroDevWallet.js'

--- a/packages/core/src/native/stampers/passkey.ts
+++ b/packages/core/src/native/stampers/passkey.ts
@@ -2,11 +2,11 @@ import {
   createPasskey,
   PasskeyStamper as TurnkeyPasskeyStamper,
 } from '@turnkey/react-native-passkey-stamper'
+import { v4 as uuidv4 } from 'uuid'
 import type {
   PasskeyRegistrationOptions,
   PasskeyStamper,
-} from '@zerodev/wallet-core'
-import { v4 as uuidv4 } from 'uuid'
+} from '../../stampers/types.js'
 
 export async function createReactNativePasskeyStamper({
   rpId,

--- a/packages/core/src/native/stampers/secureStore.ts
+++ b/packages/core/src/native/stampers/secureStore.ts
@@ -1,7 +1,7 @@
 import { ApiKeyStamper } from '@turnkey/api-key-stamper'
 import { generateP256KeyPair } from '@turnkey/crypto'
-import type { ApiKeyStamper as ZDApiKeyStamper } from '@zerodev/wallet-core'
 import * as SecureStore from 'expo-secure-store'
+import type { ApiKeyStamper as ZDApiKeyStamper } from '../../stampers/types.js'
 
 const PUBLIC_KEY = 'zerodev.publicKey'
 const PRIVATE_KEY = 'zerodev.privateKey'
@@ -71,8 +71,10 @@ class SecureStoreStamperInner {
 async function warmApiKeyStamperForMetroDev(
   inner: SecureStoreStamperInner,
 ): Promise<void> {
-  // biome-ignore lint/correctness/noUndeclaredVariables: This variable is set to true when react-native is running in Dev mode
-  if (!__DEV__) return
+  // `__DEV__` is a global set by React Native's Metro; read it via globalThis
+  // so this file needs no ambient `.d.ts` (which would conflict with RN's own
+  // typings when both happen to be in scope, e.g. in the editor).
+  if (!(globalThis as { __DEV__?: boolean }).__DEV__) return
 
   // In Expo dev, Turnkey's API key stamper loads its React Native signer with a
   // dynamic import the first time `stamp()` runs. OTP verification is usually
@@ -84,6 +86,7 @@ async function warmApiKeyStamperForMetroDev(
   try {
     await inner.stamp('{"purpose":"metro-dev-warmup"}')
   } catch (error) {
+    // biome-ignore lint/suspicious/noConsole: This only runs in dev mode
     console.warn('Failed to warm API key stamper in dev:', error)
   }
 }

--- a/packages/core/src/native/stampers/secureStore.ts
+++ b/packages/core/src/native/stampers/secureStore.ts
@@ -1,4 +1,4 @@
-import { ApiKeyStamper } from '@turnkey/api-key-stamper'
+import { ApiKeyStamper, SignatureFormat } from '@turnkey/api-key-stamper'
 import { generateP256KeyPair } from '@turnkey/crypto'
 import * as SecureStore from 'expo-secure-store'
 import type { ApiKeyStamper as ZDApiKeyStamper } from '../../stampers/types.js'
@@ -38,9 +38,7 @@ class SecureStoreStamperInner {
     this.publicKeyHex = pair.publicKey
   }
 
-  async stamp(
-    payload: string,
-  ): Promise<{ stampHeaderName: string; stampHeaderValue: string }> {
+  private async getTurnkeyApiKeyStamper(): Promise<ApiKeyStamper> {
     if (!this.publicKeyHex) {
       throw new Error(
         'Key not initialized. Call init() or resetKeyPair() first.',
@@ -52,13 +50,23 @@ class SecureStoreStamperInner {
       throw new Error('No private key found in secure store.')
     }
 
-    const stamper = new ApiKeyStamper({
+    return new ApiKeyStamper({
       apiPublicKey: this.publicKeyHex,
       apiPrivateKey: privateKey,
     })
+  }
 
+  async stamp(
+    payload: string,
+  ): Promise<{ stampHeaderName: string; stampHeaderValue: string }> {
+    const stamper = await this.getTurnkeyApiKeyStamper()
     const { stampHeaderName, stampHeaderValue } = await stamper.stamp(payload)
     return { stampHeaderName, stampHeaderValue }
+  }
+
+  async sign(payload: string): Promise<string> {
+    const stamper = await this.getTurnkeyApiKeyStamper()
+    return stamper.sign(payload, SignatureFormat.Der)
   }
 
   async clear(): Promise<void> {
@@ -104,6 +112,9 @@ export async function createSecureStoreStamper(): Promise<ZDApiKeyStamper> {
     },
     async stamp(payload: string) {
       return inner.stamp(payload)
+    },
+    async sign(payload: string) {
+      return inner.sign(payload)
     },
     async clear() {
       await inner.clear()

--- a/packages/core/src/native/storage/asyncStorage.ts
+++ b/packages/core/src/native/storage/asyncStorage.ts
@@ -1,0 +1,18 @@
+import type { AsyncStorageStatic } from '@react-native-async-storage/async-storage'
+import * as AsyncStorageNS from '@react-native-async-storage/async-storage'
+import type { StorageAdapter } from '../../storage/manager.js'
+
+// CJS package whose `.d.ts` declares `export default AsyncStorage`. Our tsconfig
+// keeps `esModuleInterop: false` (and `verbatimModuleSyntax: true`), so a plain
+// `import AsyncStorage from '...'` types as the module namespace instead of
+// the default. Unwrap explicitly. At runtime Metro returns the default object
+// either way; this only affects the static type.
+const AsyncStorage: AsyncStorageStatic = (
+  AsyncStorageNS as unknown as { default: AsyncStorageStatic }
+).default
+
+export const asyncStorageAdapter: StorageAdapter = {
+  getItem: (key) => AsyncStorage.getItem(key),
+  setItem: (key, value) => AsyncStorage.setItem(key, value),
+  removeItem: (key) => AsyncStorage.removeItem(key),
+}

--- a/packages/core/src/stampers/index.ts
+++ b/packages/core/src/stampers/index.ts
@@ -1,8 +1,0 @@
-export { createIframeStamper } from './iframeStamper.js'
-export { createIndexedDbStamper } from './indexedDbStamper.js'
-export type {
-  ApiKeyStamper,
-  IframeStamper,
-  PasskeyStamper,
-} from './types.js'
-export { createWebauthnStamper } from './webauthnStamper.js'

--- a/packages/core/src/stubs/native-on-web.ts
+++ b/packages/core/src/stubs/native-on-web.ts
@@ -1,0 +1,3 @@
+throw new Error(
+  '@zerodev/wallet-core react-native subpaths cannot be imported in a web environment. Use the bare specifier (`import { ... } from "@zerodev/wallet-core"`) instead.',
+)

--- a/packages/core/src/utils/exportPrivateKey.ts
+++ b/packages/core/src/utils/exportPrivateKey.ts
@@ -1,4 +1,4 @@
-import type { ZeroDevWalletSDK } from '../core/createZeroDevWallet.js'
+import type { ZeroDevWalletSDK } from '../core/createZeroDevWalletCore.js'
 import type { KeyFormat } from '../stampers/types.js'
 
 export type ExportPrivateKeyParameters = {

--- a/packages/core/src/utils/exportWallet.ts
+++ b/packages/core/src/utils/exportWallet.ts
@@ -1,4 +1,4 @@
-import type { ZeroDevWalletSDK } from '../core/createZeroDevWallet.js'
+import type { ZeroDevWalletSDK } from '../core/createZeroDevWalletCore.js'
 
 export type ExportWalletParameters = {
   /** Wallet to use for the export */

--- a/packages/core/src/utils/platform.ts
+++ b/packages/core/src/utils/platform.ts
@@ -1,0 +1,21 @@
+export function isReactNative(): boolean {
+  if (
+    typeof navigator !== 'undefined' &&
+    (navigator as { product?: string }).product === 'ReactNative'
+  ) {
+    return true
+  }
+  if (
+    typeof window !== 'undefined' &&
+    Object.hasOwn(window, 'ReactNativeWebView')
+  ) {
+    return true
+  }
+  if (
+    typeof globalThis !== 'undefined' &&
+    Object.hasOwn(globalThis, 'HermesEngine')
+  ) {
+    return true
+  }
+  return false
+}

--- a/packages/core/src/web/createZeroDevWallet.ts
+++ b/packages/core/src/web/createZeroDevWallet.ts
@@ -1,0 +1,45 @@
+import {
+  createZeroDevWalletCore,
+  type ZeroDevWalletConfigCore,
+  type ZeroDevWalletSDK,
+} from '../core/createZeroDevWalletCore.js'
+import { createIndexedDbStamper } from '../stampers/indexedDbStamper.js'
+import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'
+import { createWebauthnStamper } from '../stampers/webauthnStamper.js'
+import { createWebStorageAdapter } from '../storage/adapters.js'
+import type { StorageAdapter } from '../storage/manager.js'
+
+/**
+ * Web config: all four web-defaulted fields are optional overrides.
+ * `rpId` falls back to `window.location.hostname`; the others fall back to
+ * IndexedDB / WebAuthn / sessionStorage-backed implementations. RN consumers
+ * go through `@zerodev/wallet-core/react-native`, which exposes the strict
+ * `ZeroDevWalletConfigCore` shape directly.
+ */
+export type ZeroDevWalletConfig = Omit<
+  ZeroDevWalletConfigCore,
+  'apiKeyStamper' | 'passkeyStamper' | 'rpId' | 'sessionStorage'
+> & {
+  rpId?: string
+  sessionStorage?: StorageAdapter
+  apiKeyStamper?: ApiKeyStamper
+  passkeyStamper?: PasskeyStamper
+}
+
+export async function createZeroDevWallet(
+  config: ZeroDevWalletConfig,
+): Promise<ZeroDevWalletSDK> {
+  const rpId = config.rpId ?? window.location.hostname
+  const apiKeyStamper = config.apiKeyStamper ?? (await createIndexedDbStamper())
+  const passkeyStamper =
+    config.passkeyStamper ?? (await createWebauthnStamper({ rpId }))
+  const sessionStorage = config.sessionStorage ?? createWebStorageAdapter()
+
+  return createZeroDevWalletCore({
+    ...config,
+    rpId,
+    apiKeyStamper,
+    passkeyStamper,
+    sessionStorage,
+  })
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,20 +2,62 @@
   "name": "@zerodev/wallet-react",
   "version": "0.0.1-alpha.23",
   "description": "React hooks for ZeroDev Wallet SDK",
+  "type": "module",
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",
   "types": "./dist/_types/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/_types/index.d.ts",
-      "import": "./dist/_esm/index.js",
-      "require": "./dist/_cjs/index.js"
+      "react-native": {
+        "types": "./dist/_types/index.native.d.ts",
+        "default": "./dist/_esm/index.native.js"
+      },
+      "browser": {
+        "types": "./dist/_types/index.d.ts",
+        "default": "./dist/_esm/index.js"
+      },
+      "import": {
+        "types": "./dist/_types/index.d.ts",
+        "default": "./dist/_esm/index.js"
+      },
+      "require": {
+        "types": "./dist/_types/index.d.ts",
+        "default": "./dist/_cjs/index.js"
+      },
+      "default": {
+        "types": "./dist/_types/index.d.ts",
+        "default": "./dist/_esm/index.js"
+      }
+    },
+    "./react-native": {
+      "browser": "./dist/_esm/stubs/native-on-web.js",
+      "import": {
+        "types": "./dist/_types/index.native.d.ts",
+        "default": "./dist/_esm/index.native.js"
+      },
+      "default": "./dist/_esm/index.native.js"
+    },
+    "./react-native/oauth/with-expo-web-browser": {
+      "browser": "./dist/_esm/stubs/native-on-web.js",
+      "import": {
+        "types": "./dist/_types/native/oauth/useAuthenticateOAuthWithExpoWebBrowser.d.ts",
+        "default": "./dist/_esm/native/oauth/useAuthenticateOAuthWithExpoWebBrowser.js"
+      },
+      "default": "./dist/_esm/native/oauth/useAuthenticateOAuthWithExpoWebBrowser.js"
+    },
+    "./react-native/export/webview": {
+      "browser": "./dist/_esm/stubs/native-on-web.js",
+      "import": {
+        "types": "./dist/_types/native/export/ExportWebView.d.ts",
+        "default": "./dist/_esm/native/export/ExportWebView.js"
+      },
+      "default": "./dist/_esm/native/export/ExportWebView.js"
     }
   },
   "scripts": {
     "build": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm && pnpm run build:types",
-    "build:cjs": "tsc --project ./tsconfig.build.json --module commonjs --moduleResolution node --outDir ./dist/_cjs --removeComments --verbatimModuleSyntax false && printf '{\"type\":\"commonjs\"}' > ./dist/_cjs/package.json",
+    "build:cjs": "tsc --project ./tsconfig.build.json --module node16 --moduleResolution node16 --outDir ./dist/_cjs --removeComments --verbatimModuleSyntax false && printf '{\"type\":\"commonjs\"}' > ./dist/_cjs/package.json",
     "build:esm": "tsc --project ./tsconfig.build.json --outDir ./dist/_esm && printf '{\"type\": \"module\",\"sideEffects\":false}' > ./dist/_esm/package.json",
     "build:types": "tsc --project ./tsconfig.build.json --outDir ./dist/_types --emitDeclarationOnly --declaration --declarationMap",
     "dev": "tsc --watch",
@@ -40,11 +82,37 @@
     "react": "^18.0.0 || ^19.0.0",
     "viem": "^2.38.0",
     "wagmi": "^2.19.0",
-    "zustand": "^5.0.3"
+    "zustand": "^5.0.3",
+    "expo-linking": ">=7.0.0",
+    "expo-web-browser": ">=14.0.0",
+    "react-native": ">=0.73.0",
+    "react-native-webview": ">=13.0.0",
+    "uuid": ">=11.0.0"
+  },
+  "peerDependenciesMeta": {
+    "expo-linking": {
+      "optional": true
+    },
+    "expo-web-browser": {
+      "optional": true
+    },
+    "react-native": {
+      "optional": true
+    },
+    "react-native-webview": {
+      "optional": true
+    },
+    "uuid": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/react": "^19",
-    "typescript": "5.9.3"
-  },
-  "type": "module"
+    "expo-linking": "^8.0.8",
+    "expo-web-browser": "^15.0.7",
+    "react-native": "0.83.4",
+    "react-native-webview": "13.16.0",
+    "typescript": "5.9.3",
+    "uuid": "^13.0.0"
+  }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -57,7 +57,7 @@
   },
   "scripts": {
     "build": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm && pnpm run build:types",
-    "build:cjs": "tsc --project ./tsconfig.build.json --module node16 --moduleResolution node16 --outDir ./dist/_cjs --removeComments --verbatimModuleSyntax false && printf '{\"type\":\"commonjs\"}' > ./dist/_cjs/package.json",
+    "build:cjs": "tsc --project ./tsconfig.build.json --module commonjs --moduleResolution node --outDir ./dist/_cjs --removeComments --verbatimModuleSyntax false && printf '{\"type\":\"commonjs\"}' > ./dist/_cjs/package.json",
     "build:esm": "tsc --project ./tsconfig.build.json --outDir ./dist/_esm && printf '{\"type\": \"module\",\"sideEffects\":false}' > ./dist/_esm/package.json",
     "build:types": "tsc --project ./tsconfig.build.json --outDir ./dist/_types --emitDeclarationOnly --declaration --declarationMap",
     "dev": "tsc --watch",

--- a/packages/react/src/actions.test.ts
+++ b/packages/react/src/actions.test.ts
@@ -7,8 +7,6 @@ import {
 } from '@zerodev/wallet-core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
-  exportPrivateKey,
-  exportWallet,
   getAuthenticators,
   loginPasskey,
   refreshSession,
@@ -16,6 +14,8 @@ import {
   sendOTP,
   verifyOTP,
 } from './actions.js'
+import { exportPrivateKey } from './web/exportPrivateKey.js'
+import { exportWallet } from './web/exportWallet.js'
 
 // Mock wagmi connect
 vi.mock('@wagmi/core/actions', () => ({
@@ -447,7 +447,7 @@ describe('React Actions', () => {
       const config = createMockConfig(connector)
 
       await expect(refreshSession(config)).rejects.toThrow(
-        'No active session to refresh',
+        'Wallet not initialized',
       )
     })
   })

--- a/packages/react/src/actions.ts
+++ b/packages/react/src/actions.ts
@@ -1,11 +1,12 @@
 import type { Config, Connector } from '@wagmi/core'
 import { connect as wagmiConnect } from '@wagmi/core/actions'
-import {
-  createIframeStamper,
-  exportPrivateKey as exportPrivateKeySdk,
-  exportWallet as exportWalletSdk,
-  type GetAuthenticatorsReturnType,
+import type {
+  GetAuthenticatorsReturnType,
+  ZeroDevWalletSDK,
 } from '@zerodev/wallet-core'
+import type { createZeroDevWalletStore } from './store.js'
+
+type ZeroDevStore = ReturnType<typeof createZeroDevWalletStore>
 
 /**
  * Get ZeroDev connector from config
@@ -19,6 +20,27 @@ export function getZeroDevConnector(config: Config): Connector {
 }
 
 /**
+ * Get the typed ZeroDev store from a connector. Centralises the
+ * `@ts-expect-error` cast for the connector's custom `getStore` method.
+ */
+export async function getZeroDevStore(
+  connector: Connector,
+): Promise<ZeroDevStore> {
+  // @ts-expect-error - getStore is a custom method on the ZeroDev connector
+  return (await connector.getStore()) as ZeroDevStore
+}
+
+/**
+ * Read the initialised wallet from a ZeroDev store. Throws
+ * `'Wallet not initialized'` when the connector's setup hasn't run yet.
+ */
+export function getZeroDevWallet(store: ZeroDevStore): ZeroDevWalletSDK {
+  const wallet = store.getState().wallet
+  if (!wallet) throw new Error('Wallet not initialized')
+  return wallet
+}
+
+/**
  * Register with passkey
  */
 export async function registerPasskey(
@@ -28,12 +50,8 @@ export async function registerPasskey(
   },
 ): Promise<void> {
   const connector = parameters?.connector ?? getZeroDevConnector(config)
-
-  // @ts-expect-error - getStore is a custom method
-  const store = await connector.getStore()
-  const wallet = store.getState().wallet
-
-  if (!wallet) throw new Error('Wallet not initialized')
+  const store = await getZeroDevStore(connector)
+  const wallet = getZeroDevWallet(store)
 
   await wallet.auth({
     type: 'passkey',
@@ -70,12 +88,8 @@ export async function loginPasskey(
   },
 ): Promise<void> {
   const connector = parameters?.connector ?? getZeroDevConnector(config)
-
-  // @ts-expect-error - getStore is a custom method
-  const store = await connector.getStore()
-  const wallet = store.getState().wallet
-
-  if (!wallet) throw new Error('Wallet not initialized')
+  const store = await getZeroDevStore(connector)
+  const wallet = getZeroDevWallet(store)
 
   await wallet.auth({
     type: 'passkey',
@@ -115,12 +129,8 @@ export async function sendOTP(
   },
 ): Promise<{ otpId: string; otpEncryptionTargetBundle: string }> {
   const connector = parameters.connector ?? getZeroDevConnector(config)
-
-  // @ts-expect-error - getStore is a custom method
-  const store = await connector.getStore()
-  const wallet = store.getState().wallet
-
-  if (!wallet) throw new Error('Wallet not initialized')
+  const store = await getZeroDevStore(connector)
+  const wallet = getZeroDevWallet(store)
 
   const result = await wallet.auth({
     type: 'otp',
@@ -166,12 +176,8 @@ export async function verifyOTP(
   },
 ): Promise<void> {
   const connector = parameters.connector ?? getZeroDevConnector(config)
-
-  // @ts-expect-error - getStore is a custom method
-  const store = await connector.getStore()
-  const wallet = store.getState().wallet
-
-  if (!wallet) throw new Error('Wallet not initialized')
+  const store = await getZeroDevStore(connector)
+  const wallet = getZeroDevWallet(store)
 
   await wallet.auth({
     type: 'otp',
@@ -214,13 +220,11 @@ export async function refreshSession(
   } = {},
 ): Promise<unknown> {
   const connector = parameters.connector ?? getZeroDevConnector(config)
-
-  // @ts-expect-error - getStore is a custom method
-  const store = await connector.getStore()
-  const wallet = store.getState().wallet
+  const store = await getZeroDevStore(connector)
+  const wallet = getZeroDevWallet(store)
   const currentSession = store.getState().session
 
-  if (!wallet || !currentSession) {
+  if (!currentSession) {
     throw new Error('No active session to refresh')
   }
 
@@ -245,12 +249,8 @@ export async function getAuthenticators(
   config: Config,
 ): Promise<GetAuthenticatorsReturnType> {
   const connector = getZeroDevConnector(config)
-
-  // @ts-expect-error - getStore is a custom method
-  const store = await connector.getStore()
-  const wallet = store.getState().wallet
-
-  if (!wallet) throw new Error('Wallet not initialized')
+  const store = await getZeroDevStore(connector)
+  const wallet = getZeroDevWallet(store)
 
   const oauthConfig = store.getState().oauthConfig
   if (!oauthConfig) {
@@ -279,132 +279,6 @@ export declare namespace getAuthenticators {
 }
 
 /**
- * Export wallet
- */
-export async function exportWallet(
-  config: Config,
-  parameters: {
-    iframeContainerId: string
-    iframeStyles?: Record<string, string>
-    connector?: Connector
-  },
-): Promise<void> {
-  const connector = parameters.connector ?? getZeroDevConnector(config)
-
-  // @ts-expect-error - getStore is a custom method
-  const store = await connector.getStore()
-  const wallet = store.getState().wallet
-
-  if (!wallet) throw new Error('Wallet not initialized')
-
-  const iframeContainer = document.getElementById(parameters.iframeContainerId)
-  if (!iframeContainer) {
-    throw new Error('Iframe container not found')
-  }
-
-  const iframeStamper = await createIframeStamper({
-    iframeUrl: 'https://export.turnkey.com',
-    iframeContainer,
-    iframeElementId: 'export-wallet-iframe',
-  })
-
-  const publicKey = await iframeStamper.init()
-
-  if (parameters.iframeStyles) {
-    await iframeStamper.applySettings({ styles: parameters.iframeStyles })
-  }
-
-  const { exportBundle, organizationId } = await exportWalletSdk({
-    wallet,
-    targetPublicKey: publicKey,
-  })
-
-  const success = await iframeStamper.injectWalletExportBundle(
-    exportBundle,
-    organizationId,
-  )
-  if (success !== true) {
-    throw new Error('Failed to inject export bundle')
-  }
-}
-
-export declare namespace exportWallet {
-  type Parameters = {
-    iframeContainerId: string
-    iframeStyles?: Record<string, string>
-    connector?: Connector
-  }
-  type ReturnType = void
-  type ErrorType = Error
-}
-
-/**
- * Export private key
- */
-export async function exportPrivateKey(
-  config: Config,
-  parameters: {
-    iframeContainerId: string
-    iframeStyles?: Record<string, string>
-    address?: string
-    keyFormat?: 'Hexadecimal' | 'Solana'
-    connector?: Connector
-  },
-): Promise<void> {
-  const connector = parameters.connector ?? getZeroDevConnector(config)
-
-  // @ts-expect-error - getStore is a custom method
-  const store = await connector.getStore()
-  const wallet = store.getState().wallet
-
-  if (!wallet) throw new Error('Wallet not initialized')
-
-  const iframeContainer = document.getElementById(parameters.iframeContainerId)
-  if (!iframeContainer) {
-    throw new Error('Iframe container not found')
-  }
-
-  const iframeStamper = await createIframeStamper({
-    iframeUrl: 'https://export.turnkey.com',
-    iframeContainer,
-    iframeElementId: 'export-private-key-iframe',
-  })
-
-  const publicKey = await iframeStamper.init()
-
-  if (parameters.iframeStyles) {
-    await iframeStamper.applySettings({ styles: parameters.iframeStyles })
-  }
-
-  const { exportBundle, organizationId } = await exportPrivateKeySdk({
-    wallet,
-    targetPublicKey: publicKey,
-    ...(parameters.address && { address: parameters.address }),
-  })
-
-  const success = await iframeStamper.injectKeyExportBundle(
-    exportBundle,
-    organizationId,
-    parameters.keyFormat ?? 'Hexadecimal',
-  )
-  if (success !== true) {
-    throw new Error('Failed to inject export bundle')
-  }
-}
-
-export declare namespace exportPrivateKey {
-  type Parameters = {
-    iframeContainerId: string
-    iframeStyles?: Record<string, string>
-    address?: string
-    keyFormat?: 'Hexadecimal' | 'Solana'
-    connector?: Connector
-  }
-  type ReturnType = void
-  type ErrorType = Error
-}
-
-/**
  * Send magic link via email
  */
 export async function sendMagicLink(
@@ -417,12 +291,8 @@ export async function sendMagicLink(
   },
 ): Promise<{ otpId: string; otpEncryptionTargetBundle: string }> {
   const connector = parameters.connector ?? getZeroDevConnector(config)
-
-  // @ts-expect-error - getStore is a custom method
-  const store = await connector.getStore()
-  const wallet = store.getState().wallet
-
-  if (!wallet) throw new Error('Wallet not initialized')
+  const store = await getZeroDevStore(connector)
+  const wallet = getZeroDevWallet(store)
 
   const result = await wallet.auth({
     type: 'magicLink',
@@ -465,12 +335,8 @@ export async function verifyMagicLink(
   },
 ): Promise<void> {
   const connector = parameters.connector ?? getZeroDevConnector(config)
-
-  // @ts-expect-error - getStore is a custom method
-  const store = await connector.getStore()
-  const wallet = store.getState().wallet
-
-  if (!wallet) throw new Error('Wallet not initialized')
+  const store = await getZeroDevStore(connector)
+  const wallet = getZeroDevWallet(store)
 
   await wallet.auth({
     type: 'magicLink',

--- a/packages/react/src/authenticateOAuth.test.ts
+++ b/packages/react/src/authenticateOAuth.test.ts
@@ -7,13 +7,6 @@ vi.mock('@wagmi/core/actions', () => ({
   connect: vi.fn().mockResolvedValue({}),
 }))
 
-// Mocked so tests in the "web default fallback" describe block below can
-// assert on how authenticateOAuth dispatches to it. Tests outside that block
-// use an explicit adapter and never reach the web fallback path.
-vi.mock('./getSessionIdWeb.js', () => ({
-  getSessionIdWeb: vi.fn(),
-}))
-
 // Mocked so tests don't run real URL verification — they only need to assert
 // that the URL returned by `wallet.client.getOAuthLoginUrl` is verified before
 // it reaches the adapter. The verification itself is covered in
@@ -79,9 +72,7 @@ function createMockConfig(connector = createMockConnector()) {
 // specifically care about adapter behavior call authenticateOAuth directly.
 function callAuth(
   config: Config,
-  overrides: Partial<
-    authenticateOAuth.Parameters & authenticateOAuth.AdapterOptions
-  > = {},
+  overrides: Partial<authenticateOAuth.Parameters> = {},
 ) {
   return authenticateOAuth(config, {
     provider: 'google',
@@ -127,34 +118,6 @@ describe('authenticateOAuth', () => {
     await expect(callAuth(config)).rejects.toThrow(
       'Failed to get wallet public key',
     )
-  })
-
-  it('throws when only redirectUri is provided', async () => {
-    const wallet = createMockWallet()
-    const store = createMockStore(wallet)
-    const connector = createMockConnector(store)
-    const config = createMockConfig(connector)
-
-    await expect(
-      authenticateOAuth(config, {
-        provider: 'google',
-        redirectUri: 'zerodev://oauth',
-      }),
-    ).rejects.toThrow('redirectUri and getSessionId must be provided together')
-  })
-
-  it('throws when only getSessionId is provided', async () => {
-    const wallet = createMockWallet()
-    const store = createMockStore(wallet)
-    const connector = createMockConnector(store)
-    const config = createMockConfig(connector)
-
-    await expect(
-      authenticateOAuth(config, {
-        provider: 'google',
-        getSessionId: async () => 'session-id',
-      }),
-    ).rejects.toThrow('redirectUri and getSessionId must be provided together')
   })
 
   it('uses consumer adapter when getSessionId + redirectUri are provided', async () => {
@@ -217,6 +180,33 @@ describe('authenticateOAuth', () => {
     )
   })
 
+  it('preserves caller pathname/query and drops hash from returnTo', async () => {
+    const wallet = createMockWallet()
+    const store = createMockStore(wallet)
+    const connector = createMockConnector(store)
+    const config = createMockConfig(connector)
+
+    const getSessionId = vi.fn().mockResolvedValue('sid')
+    await authenticateOAuth(config, {
+      provider: 'google',
+      redirectUri: 'https://app.example.com/dashboard?utm=src#section',
+      getSessionId,
+    })
+
+    const returnTo: string =
+      wallet.client.getOAuthLoginUrl.mock.calls[0][0].returnTo
+    const parsed = new URL(returnTo)
+    expect(parsed.origin).toBe('https://app.example.com')
+    expect(parsed.pathname).toBe('/dashboard')
+    expect(parsed.searchParams.get('utm')).toBe('src')
+    expect(parsed.searchParams.get('oauth_success')).toBe('true')
+    expect(parsed.searchParams.get('oauth_provider')).toBe('google')
+    expect(parsed.hash).toBe('')
+  })
+
+  // This also transitively guarantees the web hook's popup is NOT opened on
+  // verification failure: the web hook's `getSessionId` IS `getSessionIdWeb`,
+  // and this test asserts the adapter is never invoked when verification throws.
   it('verifies the URL before invoking the adapter', async () => {
     const { verifyGoogleLoginUrl } = await import(
       './utils/verifyGoogleLoginUrl.js'
@@ -273,133 +263,5 @@ describe('authenticateOAuth', () => {
     const config = createMockConfig(connector)
 
     await expect(callAuth(config)).rejects.toThrow('Auth backend error')
-  })
-})
-
-/**
- * Tests below cover authenticateOAuth's web default fallback (calling
- * getSessionIdWeb when no adapter is provided). Delete this block when
- * getSessionIdWeb is extracted to @zerodev/wallet-react-kit and the fallback
- * is removed from authenticateOAuth.
- */
-describe('authenticateOAuth — web default fallback', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    // @ts-expect-error - Mocking location
-    window.location = {
-      origin: 'https://app.example.com',
-      href: 'https://app.example.com/',
-    } as Location
-  })
-
-  it('uses getSessionIdWeb when no adapter is provided', async () => {
-    const { getSessionIdWeb } = await import('./getSessionIdWeb.js')
-    vi.mocked(getSessionIdWeb).mockResolvedValue('web-session-id')
-
-    const wallet = createMockWallet()
-    const store = createMockStore(wallet)
-    const connector = createMockConnector(store)
-    const config = createMockConfig(connector)
-
-    await authenticateOAuth(config, { provider: 'google' })
-
-    expect(getSessionIdWeb).toHaveBeenCalledWith(
-      MOCK_OAUTH_URL,
-      'https://app.example.com',
-      undefined,
-    )
-    expect(wallet.auth).toHaveBeenCalledWith({
-      type: 'oauth',
-      provider: 'google',
-      sessionId: 'web-session-id',
-    })
-  })
-
-  it('constructs returnTo from window.location.href on default path', async () => {
-    const { getSessionIdWeb } = await import('./getSessionIdWeb.js')
-    vi.mocked(getSessionIdWeb).mockResolvedValue('sid')
-
-    const wallet = createMockWallet()
-    const store = createMockStore(wallet)
-    const connector = createMockConnector(store)
-    const config = createMockConfig(connector)
-
-    await authenticateOAuth(config, { provider: 'google' })
-
-    const returnTo: string =
-      wallet.client.getOAuthLoginUrl.mock.calls[0][0].returnTo
-    expect(returnTo).toBe(
-      'https://app.example.com/?oauth_success=true&oauth_provider=google',
-    )
-  })
-
-  it('preserves caller pathname/query and drops hash from returnTo on default path', async () => {
-    const { getSessionIdWeb } = await import('./getSessionIdWeb.js')
-    vi.mocked(getSessionIdWeb).mockResolvedValue('sid')
-
-    // @ts-expect-error - Mocking location
-    window.location = {
-      origin: 'https://app.example.com',
-      href: 'https://app.example.com/dashboard?utm=src#section',
-    } as Location
-
-    const wallet = createMockWallet()
-    const store = createMockStore(wallet)
-    const connector = createMockConnector(store)
-    const config = createMockConfig(connector)
-
-    await authenticateOAuth(config, { provider: 'google' })
-
-    const returnTo: string =
-      wallet.client.getOAuthLoginUrl.mock.calls[0][0].returnTo
-    const parsed = new URL(returnTo)
-    expect(parsed.pathname).toBe('/dashboard')
-    expect(parsed.searchParams.get('oauth_success')).toBe('true')
-    expect(parsed.searchParams.get('oauth_provider')).toBe('google')
-    expect(parsed.searchParams.get('utm')).toBe('src')
-    expect(parsed.hash).toBe('')
-  })
-
-  it('passes timeoutMs to getSessionIdWeb on default path', async () => {
-    const { getSessionIdWeb } = await import('./getSessionIdWeb.js')
-    vi.mocked(getSessionIdWeb).mockResolvedValue('sid')
-
-    const wallet = createMockWallet()
-    const store = createMockStore(wallet)
-    const connector = createMockConnector(store)
-    const config = createMockConfig(connector)
-
-    await authenticateOAuth(config, {
-      provider: 'google',
-      timeoutMs: 30_000,
-    })
-
-    expect(getSessionIdWeb).toHaveBeenCalledWith(
-      MOCK_OAUTH_URL,
-      'https://app.example.com',
-      30_000,
-    )
-  })
-
-  it('does NOT open popup when nonce verification fails', async () => {
-    const { getSessionIdWeb } = await import('./getSessionIdWeb.js')
-    const { verifyGoogleLoginUrl } = await import(
-      './utils/verifyGoogleLoginUrl.js'
-    )
-    vi.mocked(verifyGoogleLoginUrl).mockImplementationOnce(() => {
-      throw new Error('login URL nonce does not match public key hash')
-    })
-
-    const wallet = createMockWallet()
-    const store = createMockStore(wallet)
-    const connector = createMockConnector(store)
-    const config = createMockConfig(connector)
-
-    await expect(
-      authenticateOAuth(config, { provider: 'google' }),
-    ).rejects.toThrow(/nonce does not match public key hash/)
-
-    expect(getSessionIdWeb).not.toHaveBeenCalled()
-    expect(wallet.auth).not.toHaveBeenCalled()
   })
 })

--- a/packages/react/src/authenticateOAuth.ts
+++ b/packages/react/src/authenticateOAuth.ts
@@ -1,8 +1,11 @@
 import type { Config, Connector } from '@wagmi/core'
 import { connect as wagmiConnect } from '@wagmi/core/actions'
 import type { createZeroDevWallet } from '@zerodev/wallet-core'
-import { getZeroDevConnector } from './actions.js'
-import { getSessionIdWeb } from './getSessionIdWeb.js'
+import {
+  getZeroDevConnector,
+  getZeroDevStore,
+  getZeroDevWallet,
+} from './actions.js'
 import type { createZeroDevWalletStore } from './store.js'
 import {
   type OAuthProvider,
@@ -10,10 +13,9 @@ import {
 } from './utils/verifyGoogleLoginUrl.js'
 
 /**
- * Pluggable callback for obtaining an OAuth session ID.
- * On web the default popup + parent-polling flow is used.
- * On React Native, pass a function that opens a system browser and
- * resolves with the sessionId extracted from the deep-link redirect.
+ * Pluggable callback for obtaining an OAuth session ID. The web hook supplies
+ * a popup + parent-polling flow (`getSessionIdWeb`); the RN hook requires
+ * consumer-supplied adapters (e.g. expo-web-browser + expo-linking).
  */
 export type GetOAuthSessionIdFn = (params: {
   oauthUrl: string
@@ -45,32 +47,21 @@ async function completeOAuth(
 }
 
 /**
- * Authenticate with OAuth.
- *
- * By default (no `getSessionId`/`redirectUri` provided), uses a built-in web
- * popup + parent-polling flow. Pass `timeoutMs` to configure how long that web
- * popup flow may run before it fails. On native, pass a consumer-supplied
- * `getSessionId` adapter (e.g. using expo-web-browser + expo-linking) plus the
- * `redirectUri` the backend should redirect to. Must be provided together.
+ * Platform-agnostic OAuth orchestration core. REQUIRES both `getSessionId`
+ * and `redirectUri` — no web-fallback defaults at this layer. The web hook
+ * supplies `getSessionIdWeb` + `window.location.href`; the native hook
+ * supplies its own adapter pair.
  */
 export async function authenticateOAuth(
   config: Config,
-  parameters: authenticateOAuth.Parameters & authenticateOAuth.AdapterOptions,
+  parameters: authenticateOAuth.Parameters,
 ): Promise<void> {
-  const { provider, getSessionId, redirectUri, timeoutMs } = parameters
-
-  if (Boolean(redirectUri) !== Boolean(getSessionId)) {
-    throw new Error('redirectUri and getSessionId must be provided together')
-  }
-
+  const { provider, getSessionId, redirectUri } = parameters
   const connector = parameters.connector ?? getZeroDevConnector(config)
-
-  // @ts-expect-error - getStore is a custom method
-  const store = await connector.getStore()
-  const wallet = store.getState().wallet
+  const store = await getZeroDevStore(connector)
+  const wallet = getZeroDevWallet(store)
   const oauthConfig = store.getState().oauthConfig
 
-  if (!wallet) throw new Error('Wallet not initialized')
   if (!oauthConfig) {
     throw new Error('Wallet not initialized. Please wait for connector setup.')
   }
@@ -80,10 +71,7 @@ export async function authenticateOAuth(
     throw new Error('Failed to get wallet public key')
   }
 
-  // Build OAuth URL that redirects to backend
-  // Preserve the caller's full path so the popup lands on the same route
-  // (e.g. /dashboard) where the SDK is mounted, not just the origin.
-  const returnUrl = new URL(redirectUri ?? window.location.href)
+  const returnUrl = new URL(redirectUri)
   returnUrl.hash = ''
   returnUrl.searchParams.set('oauth_success', 'true')
   returnUrl.searchParams.set('oauth_provider', provider)
@@ -102,9 +90,7 @@ export async function authenticateOAuth(
   })
   verifyGoogleLoginUrl(oauthUrl, publicKey)
 
-  const sessionId = getSessionId
-    ? await getSessionId({ oauthUrl, provider })
-    : await getSessionIdWeb(oauthUrl, window.location.origin, timeoutMs)
+  const sessionId = await getSessionId({ oauthUrl, provider })
 
   await completeOAuth(wallet, store, config, connector, provider, sessionId)
 }
@@ -113,11 +99,8 @@ export declare namespace authenticateOAuth {
   type Parameters = {
     provider: OAuthProvider
     connector?: Connector
-  }
-  type AdapterOptions = {
-    getSessionId?: GetOAuthSessionIdFn
-    redirectUri?: string
-    timeoutMs?: number
+    getSessionId: GetOAuthSessionIdFn
+    redirectUri: string
   }
   type ReturnType = void
   type ErrorType = Error

--- a/packages/react/src/connector.ts
+++ b/packages/react/src/connector.ts
@@ -263,7 +263,7 @@ export function zeroDevWallet(
         const shouldInit =
           typeof params.autoInitialize === 'function'
             ? params.autoInitialize()
-            : (params.autoInitialize ?? typeof window !== 'undefined')
+            : (params.autoInitialize ?? true)
         if (shouldInit) {
           await initialize()
         }

--- a/packages/react/src/connector.ts
+++ b/packages/react/src/connector.ts
@@ -17,6 +17,7 @@ import { type Chain, createPublicClient, createWalletClient, http } from 'viem'
 import { createProvider } from './provider.js'
 import { type CreateStoreOptions, createZeroDevWalletStore } from './store.js'
 import { getAAUrl } from './utils/aaUtils.js'
+import { isReactNative } from './utils/platform.js'
 
 /**
  * Account mode the connector exposes to wagmi.
@@ -263,7 +264,8 @@ export function zeroDevWallet(
         const shouldInit =
           typeof params.autoInitialize === 'function'
             ? params.autoInitialize()
-            : (params.autoInitialize ?? true)
+            : (params.autoInitialize ??
+              (typeof window !== 'undefined' || isReactNative()))
         if (shouldInit) {
           await initialize()
         }

--- a/packages/react/src/hooks/useAuthenticateOAuth.ts
+++ b/packages/react/src/hooks/useAuthenticateOAuth.ts
@@ -6,8 +6,10 @@ import {
   useMutation,
 } from '@tanstack/react-query'
 import { type Config, type ResolvedRegister, useConfig } from 'wagmi'
-import { authenticateOAuth } from '../authenticateOAuth.js'
-import { getSessionIdWeb } from '../getSessionIdWeb.js'
+import {
+  authenticateOAuth,
+  type GetOAuthSessionIdFn,
+} from '../authenticateOAuth.js'
 import type { OAuthProvider } from '../utils/verifyGoogleLoginUrl.js'
 
 type ConfigParameter<config extends Config = Config> = {
@@ -15,20 +17,27 @@ type ConfigParameter<config extends Config = Config> = {
 }
 
 /**
- * Web variant — hard-wires the popup-based `getSessionIdWeb` flow and
- * `window.location.href` as the redirect URI. Consumers needing a custom
- * OAuth flow call `authenticateOAuth` directly.
+ * Generic variant — REQUIRES `getSessionId` and `redirectUri` at the hook
+ * level. No platform fallback, no auto-wired adapter. Use this when you're
+ * providing your own OAuth implementation (e.g. `react-native-app-auth`, a
+ * custom popup flow, or any other custom integration).
  *
- * `timeoutMs` (optional) configures how long the popup-polling flow may run
- * before it fails. Defaults to 5 minutes (defined in `getSessionIdWeb`).
+ * For the blessed Expo-based React Native flow (expo-web-browser +
+ * expo-linking deep-link race), import `useAuthenticateOAuthWithExpoWebBrowser`
+ * from `@zerodev/wallet-react/react-native/oauth/with-expo-web-browser`
+ * instead — it auto-wires the adapter with a `useMemo`, so you only pass
+ * `redirectUri`.
+ *
+ * Importing this generic hook does NOT pull `expo-web-browser` /
+ * `expo-linking` into your bundle.
  */
 export function useAuthenticateOAuth<
   config extends Config = ResolvedRegister['config'],
   context = unknown,
 >(
-  parameters: useAuthenticateOAuth.Parameters<config, context> = {},
+  parameters: useAuthenticateOAuth.Parameters<config, context>,
 ): useAuthenticateOAuth.ReturnType<context> {
-  const { mutation, timeoutMs } = parameters
+  const { mutation, getSessionId, redirectUri } = parameters
   const config = useConfig(parameters)
 
   return useMutation({
@@ -36,9 +45,8 @@ export function useAuthenticateOAuth<
     async mutationFn(variables: { provider: OAuthProvider }) {
       return authenticateOAuth(config, {
         ...variables,
-        getSessionId: ({ oauthUrl }) =>
-          getSessionIdWeb(oauthUrl, window.location.origin, timeoutMs),
-        redirectUri: window.location.href,
+        getSessionId,
+        redirectUri,
       })
     },
     mutationKey: ['authenticateOAuth'],
@@ -50,8 +58,8 @@ export declare namespace useAuthenticateOAuth {
     config extends Config = Config,
     context = unknown,
   > = ConfigParameter<config> & {
-    /** Popup-polling timeout in ms. Defaults to 5 minutes. */
-    timeoutMs?: number
+    getSessionId: GetOAuthSessionIdFn
+    redirectUri: string
     mutation?:
       | UseMutationOptions<
           authenticateOAuth.ReturnType,

--- a/packages/react/src/hooks/useExportPrivateKey.ts
+++ b/packages/react/src/hooks/useExportPrivateKey.ts
@@ -6,7 +6,7 @@ import {
   useMutation,
 } from '@tanstack/react-query'
 import { type Config, type ResolvedRegister, useConfig } from 'wagmi'
-import { exportPrivateKey } from '../actions.js'
+import { exportPrivateKey } from '../web/exportPrivateKey.js'
 
 type ConfigParameter<config extends Config = Config> = {
   config?: Config | config | undefined

--- a/packages/react/src/hooks/useExportWallet.ts
+++ b/packages/react/src/hooks/useExportWallet.ts
@@ -6,7 +6,7 @@ import {
   useMutation,
 } from '@tanstack/react-query'
 import { type Config, type ResolvedRegister, useConfig } from 'wagmi'
-import { exportWallet } from '../actions.js'
+import { exportWallet } from '../web/exportWallet.js'
 
 type ConfigParameter<config extends Config = Config> = {
   config?: Config | config | undefined

--- a/packages/react/src/index.native.ts
+++ b/packages/react/src/index.native.ts
@@ -1,11 +1,17 @@
 import { isReactNative } from './utils/platform.js'
 
-if (isReactNative()) {
+if (!isReactNative()) {
   console.warn(
-    '@zerodev/wallet-react: the web entry was loaded in a React Native runtime. Check that your metro.config.js has `unstable_enablePackageExports: true` and `"react-native"` in `unstable_conditionNames`.',
+    '@zerodev/wallet-react/react-native: the React Native entry was loaded outside a React Native runtime. If this is a non-RN context, import `@zerodev/wallet-react` (the bare specifier) instead.',
   )
 }
 
+// Shared API surface — identical to the bare specifier, EXCEPT:
+//  - useAuthenticateOAuth comes from ./native/hooks/useAuthenticateOAuth.js
+//    (type-narrowed to require getSessionId + redirectUri)
+//  - useExportWallet / useExportPrivateKey are intentionally NOT re-exported;
+//    the native export flow is component-driven via ZeroDevExportWebView at
+//    @zerodev/wallet-react/react-native/export/webview.
 export {
   getZeroDevConnector,
   getZeroDevStore,
@@ -17,10 +23,7 @@ export type {
   ZeroDevWalletConnectorParams,
 } from './connector.js'
 export { zeroDevWallet } from './connector.js'
-export { useAuthenticateOAuth } from './hooks/useAuthenticateOAuth.js'
 export { useAuthenticators } from './hooks/useAuthenticators.js'
-export { useExportPrivateKey } from './hooks/useExportPrivateKey.js'
-export { useExportWallet } from './hooks/useExportWallet.js'
 export { useLoginPasskey } from './hooks/useLoginPasskey.js'
 export { useRefreshSession } from './hooks/useRefreshSession.js'
 export { useRegisterPasskey } from './hooks/useRegisterPasskey.js'
@@ -28,6 +31,8 @@ export { useSendMagicLink } from './hooks/useSendMagicLink.js'
 export { useSendOTP } from './hooks/useSendOTP.js'
 export { useVerifyMagicLink } from './hooks/useVerifyMagicLink.js'
 export { useVerifyOTP } from './hooks/useVerifyOTP.js'
+// Native-specific auth hook
+export { useAuthenticateOAuth } from './native/hooks/useAuthenticateOAuth.js'
 export type { ZeroDevProvider } from './provider.js'
 export type { ZeroDevWalletState } from './store.js'
 export { createZeroDevWalletStore } from './store.js'

--- a/packages/react/src/index.native.ts
+++ b/packages/react/src/index.native.ts
@@ -7,8 +7,9 @@ if (!isReactNative()) {
 }
 
 // Shared API surface — identical to the bare specifier, EXCEPT:
-//  - useAuthenticateOAuth comes from ./native/hooks/useAuthenticateOAuth.js
-//    (type-narrowed to require getSessionId + redirectUri)
+//  - useAuthenticateOAuth is the generic variant from ./hooks (requires
+//    getSessionId + redirectUri); the bare specifier exports the
+//    popup-wired web variant from ./web instead.
 //  - useExportWallet / useExportPrivateKey are intentionally NOT re-exported;
 //    the native export flow is component-driven via ZeroDevExportWebView at
 //    @zerodev/wallet-react/react-native/export/webview.
@@ -23,6 +24,8 @@ export type {
   ZeroDevWalletConnectorParams,
 } from './connector.js'
 export { zeroDevWallet } from './connector.js'
+// Generic OAuth hook — caller supplies getSessionId + redirectUri
+export { useAuthenticateOAuth } from './hooks/useAuthenticateOAuth.js'
 export { useAuthenticators } from './hooks/useAuthenticators.js'
 export { useLoginPasskey } from './hooks/useLoginPasskey.js'
 export { useRefreshSession } from './hooks/useRefreshSession.js'
@@ -31,8 +34,6 @@ export { useSendMagicLink } from './hooks/useSendMagicLink.js'
 export { useSendOTP } from './hooks/useSendOTP.js'
 export { useVerifyMagicLink } from './hooks/useVerifyMagicLink.js'
 export { useVerifyOTP } from './hooks/useVerifyOTP.js'
-// Native-specific auth hook
-export { useAuthenticateOAuth } from './native/hooks/useAuthenticateOAuth.js'
 export type { ZeroDevProvider } from './provider.js'
 export type { ZeroDevWalletState } from './store.js'
 export { createZeroDevWalletStore } from './store.js'

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -17,7 +17,6 @@ export type {
   ZeroDevWalletConnectorParams,
 } from './connector.js'
 export { zeroDevWallet } from './connector.js'
-export { useAuthenticateOAuth } from './hooks/useAuthenticateOAuth.js'
 export { useAuthenticators } from './hooks/useAuthenticators.js'
 export { useExportPrivateKey } from './hooks/useExportPrivateKey.js'
 export { useExportWallet } from './hooks/useExportWallet.js'
@@ -37,3 +36,4 @@ export {
   OAUTH_PROVIDERS,
   verifyGoogleLoginUrl,
 } from './utils/verifyGoogleLoginUrl.js'
+export { useAuthenticateOAuth } from './web/useAuthenticateOAuth.js'

--- a/packages/react/src/native/export/ExportWebView.tsx
+++ b/packages/react/src/native/export/ExportWebView.tsx
@@ -3,11 +3,15 @@ import { useRef } from 'react'
 import type { StyleProp, ViewStyle } from 'react-native'
 import { WebView, type WebViewMessageEvent } from 'react-native-webview'
 import { v4 as uuidv4 } from 'uuid'
-import { type Config, useConfig } from 'wagmi'
-import { RP_ID } from '@/config/auth'
+import { useConfig } from 'wagmi'
+import {
+  getZeroDevConnector,
+  getZeroDevStore,
+  getZeroDevWallet,
+} from '../../actions.js'
 
 /**
- * WebView-isolated Turnkey export. Loads our wrapper HTML which embeds
+ * WebView-isolated Turnkey export. Loads a wrapper HTML which embeds
  * `https://export.turnkey.com` as an iframe; the iframe owns the keypair,
  * decrypts the HPKE bundle, and renders the secret in its own JS context.
  * RN never holds the plaintext.
@@ -26,6 +30,8 @@ import { RP_ID } from '@/config/auth'
  */
 type Props = {
   kind: 'wallet' | 'privateKey'
+  /** Required: the wrapper's baseUrl origin (e.g. the consumer's RP_ID). */
+  rpId: string
   /** Fires after the iframe acks BUNDLE_INJECTED — the secret is on screen. */
   onReady?: () => void
   /** Fires on bundle-fetch failure or iframe-side ERROR. */
@@ -35,29 +41,6 @@ type Props = {
 }
 
 const TURNKEY_EXPORT_ORIGIN = 'https://export.turnkey.com'
-
-if (!RP_ID) {
-  throw new Error('RP_ID is required to build the wrapper baseUrl')
-}
-const wrapperOrigin = `https://${RP_ID}`
-
-async function resolveZeroDevWallet(config: Config) {
-  // The connector id is a string literal in @zerodev/wallet-core's connector
-  // factory; the SDK looks itself up the same way (see packages/react/src/
-  // actions.ts). Mirror that pattern here until the SDK exports a typed
-  // accessor.
-  const connector = config.connectors.find((c) => c.id === 'zerodev-wallet')
-  if (!connector) {
-    throw new Error('ZeroDev connector not found in Wagmi config')
-  }
-  // @ts-expect-error - getStore is a custom method on the ZeroDev connector
-  const store = await connector.getStore()
-  const wallet = store.getState().wallet
-  if (!wallet) {
-    throw new Error('Wallet not initialized')
-  }
-  return wallet
-}
 
 type InjectPayload =
   | {
@@ -74,7 +57,8 @@ type InjectPayload =
       keyFormat: 'HEXADECIMAL'
     }
 
-const wrapperHtml = `<!doctype html>
+function buildWrapperHtml() {
+  return `<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -120,8 +104,20 @@ const wrapperHtml = `<!doctype html>
     </script>
   </body>
 </html>`
+}
 
-export function ExportWebView({ kind, onReady, onError, style }: Props) {
+export function ZeroDevExportWebView({
+  kind,
+  rpId,
+  onReady,
+  onError,
+  style,
+}: Props) {
+  if (!rpId) {
+    throw new Error('ZeroDevExportWebView: rpId is required')
+  }
+  const wrapperOrigin = `https://${rpId}`
+
   const config = useConfig()
   const webViewRef = useRef<WebView>(null)
   // PUBLIC_KEY_READY can only be acted on once per mount. Resets when the
@@ -146,7 +142,9 @@ export function ExportWebView({ kind, onReady, onError, style }: Props) {
         if (typeof data.value !== 'string') return
         handledPubkey.current = true
         try {
-          const wallet = await resolveZeroDevWallet(config)
+          const connector = getZeroDevConnector(config)
+          const store = await getZeroDevStore(connector)
+          const wallet = getZeroDevWallet(store)
           const bundle =
             kind === 'wallet'
               ? await exportWallet({ wallet, targetPublicKey: data.value })
@@ -203,7 +201,7 @@ export function ExportWebView({ kind, onReady, onError, style }: Props) {
   return (
     <WebView
       ref={webViewRef}
-      source={{ html: wrapperHtml, baseUrl: wrapperOrigin }}
+      source={{ html: buildWrapperHtml(), baseUrl: wrapperOrigin }}
       originWhitelist={[wrapperOrigin, TURNKEY_EXPORT_ORIGIN, 'about:*']}
       onShouldStartLoadWithRequest={(request) => {
         const url = request.url

--- a/packages/react/src/native/hooks/useAuthenticateOAuth.ts
+++ b/packages/react/src/native/hooks/useAuthenticateOAuth.ts
@@ -6,29 +6,37 @@ import {
   useMutation,
 } from '@tanstack/react-query'
 import { type Config, type ResolvedRegister, useConfig } from 'wagmi'
-import { authenticateOAuth } from '../authenticateOAuth.js'
-import { getSessionIdWeb } from '../getSessionIdWeb.js'
-import type { OAuthProvider } from '../utils/verifyGoogleLoginUrl.js'
+import {
+  authenticateOAuth,
+  type GetOAuthSessionIdFn,
+} from '../../authenticateOAuth.js'
+import type { OAuthProvider } from '../../utils/verifyGoogleLoginUrl.js'
 
 type ConfigParameter<config extends Config = Config> = {
   config?: Config | config | undefined
 }
 
 /**
- * Web variant — hard-wires the popup-based `getSessionIdWeb` flow and
- * `window.location.href` as the redirect URI. Consumers needing a custom
- * OAuth flow call `authenticateOAuth` directly.
+ * Generic native variant — REQUIRES `getSessionId` and `redirectUri` at the
+ * hook level. No platform fallback, no auto-wired adapter. Use this when
+ * you're providing your own OAuth implementation (e.g. `react-native-app-auth`
+ * or a custom flow).
  *
- * `timeoutMs` (optional) configures how long the popup-polling flow may run
- * before it fails. Defaults to 5 minutes (defined in `getSessionIdWeb`).
+ * For the blessed Expo-based flow (expo-web-browser + expo-linking deep-link
+ * race), import `useAuthenticateOAuthWithExpoWebBrowser` from
+ * `@zerodev/wallet-react/react-native/oauth/with-expo-web-browser` instead —
+ * it auto-wires the adapter with a `useMemo`, so you only pass `redirectUri`.
+ *
+ * Importing this generic hook does NOT pull `expo-web-browser` / `expo-linking`
+ * into your bundle.
  */
 export function useAuthenticateOAuth<
   config extends Config = ResolvedRegister['config'],
   context = unknown,
 >(
-  parameters: useAuthenticateOAuth.Parameters<config, context> = {},
+  parameters: useAuthenticateOAuth.Parameters<config, context>,
 ): useAuthenticateOAuth.ReturnType<context> {
-  const { mutation, timeoutMs } = parameters
+  const { mutation, getSessionId, redirectUri } = parameters
   const config = useConfig(parameters)
 
   return useMutation({
@@ -36,9 +44,8 @@ export function useAuthenticateOAuth<
     async mutationFn(variables: { provider: OAuthProvider }) {
       return authenticateOAuth(config, {
         ...variables,
-        getSessionId: ({ oauthUrl }) =>
-          getSessionIdWeb(oauthUrl, window.location.origin, timeoutMs),
-        redirectUri: window.location.href,
+        getSessionId,
+        redirectUri,
       })
     },
     mutationKey: ['authenticateOAuth'],
@@ -50,8 +57,8 @@ export declare namespace useAuthenticateOAuth {
     config extends Config = Config,
     context = unknown,
   > = ConfigParameter<config> & {
-    /** Popup-polling timeout in ms. Defaults to 5 minutes. */
-    timeoutMs?: number
+    getSessionId: GetOAuthSessionIdFn
+    redirectUri: string
     mutation?:
       | UseMutationOptions<
           authenticateOAuth.ReturnType,

--- a/packages/react/src/native/oauth/expoWebBrowser.ts
+++ b/packages/react/src/native/oauth/expoWebBrowser.ts
@@ -1,6 +1,6 @@
-import type { GetOAuthSessionIdFn } from '@zerodev/wallet-react'
 import * as Linking from 'expo-linking'
 import * as WebBrowser from 'expo-web-browser'
+import type { GetOAuthSessionIdFn } from '../../authenticateOAuth.js'
 
 /**
  * Races two observation primitives because iOS and Android deliver the
@@ -12,7 +12,7 @@ import * as WebBrowser from 'expo-web-browser'
  *     internally and resolves `openAuthSessionAsync` with the URL.
  * Whichever fires first wins.
  */
-export function createNativeOAuthGetSessionId(params: {
+export function createOAuthGetSessionIdWithExpoWebBrowser(params: {
   redirectUri: string
 }): GetOAuthSessionIdFn {
   return async ({ oauthUrl }) => {

--- a/packages/react/src/native/oauth/useAuthenticateOAuthWithExpoWebBrowser.ts
+++ b/packages/react/src/native/oauth/useAuthenticateOAuthWithExpoWebBrowser.ts
@@ -1,0 +1,43 @@
+'use client'
+
+import { useMemo } from 'react'
+import type { Config, ResolvedRegister } from 'wagmi'
+import { useAuthenticateOAuth } from '../hooks/useAuthenticateOAuth.js'
+import { createOAuthGetSessionIdWithExpoWebBrowser } from './expoWebBrowser.js'
+
+/**
+ * Convenience native hook that auto-wires
+ * `createOAuthGetSessionIdWithExpoWebBrowser` (expo-web-browser + expo-linking
+ * deep-link race). Consumer supplies only `redirectUri` (their app's deep
+ * link).
+ *
+ * Importing from this subpath commits to installing `expo-web-browser` and
+ * `expo-linking`. Consumers using a different OAuth library should import
+ * the generic `useAuthenticateOAuth` from `@zerodev/wallet-react/react-native`
+ * and supply their own `getSessionId` — that path does not pull these peers.
+ */
+export function useAuthenticateOAuthWithExpoWebBrowser<
+  config extends Config = ResolvedRegister['config'],
+  context = unknown,
+>(
+  parameters: useAuthenticateOAuthWithExpoWebBrowser.Parameters<
+    config,
+    context
+  >,
+): useAuthenticateOAuth.ReturnType<context> {
+  const { redirectUri } = parameters
+  const getSessionId = useMemo(
+    () => createOAuthGetSessionIdWithExpoWebBrowser({ redirectUri }),
+    [redirectUri],
+  )
+  return useAuthenticateOAuth({ ...parameters, getSessionId })
+}
+
+export declare namespace useAuthenticateOAuthWithExpoWebBrowser {
+  // Same as the generic hook's Parameters but with `getSessionId` omitted —
+  // it's supplied internally.
+  type Parameters<config extends Config = Config, context = unknown> = Omit<
+    useAuthenticateOAuth.Parameters<config, context>,
+    'getSessionId'
+  >
+}

--- a/packages/react/src/native/oauth/useAuthenticateOAuthWithExpoWebBrowser.ts
+++ b/packages/react/src/native/oauth/useAuthenticateOAuthWithExpoWebBrowser.ts
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react'
 import type { Config, ResolvedRegister } from 'wagmi'
-import { useAuthenticateOAuth } from '../hooks/useAuthenticateOAuth.js'
+import { useAuthenticateOAuth } from '../../hooks/useAuthenticateOAuth.js'
 import { createOAuthGetSessionIdWithExpoWebBrowser } from './expoWebBrowser.js'
 
 /**

--- a/packages/react/src/provider.ts
+++ b/packages/react/src/provider.ts
@@ -62,7 +62,7 @@ export function createProvider({
   // Mirrors the default in `connector.ts` — keep these in sync.
   const mode: WalletMode = config.mode ?? '7702'
   const emitter = Provider.createEmitter()
-  let sessionRefreshTimer: NodeJS.Timeout | null = null
+  let sessionRefreshTimer: ReturnType<typeof setTimeout> | null = null
 
   // Session auto-refresh logic
   const scheduleSessionRefresh = () => {

--- a/packages/react/src/stubs/native-on-web.ts
+++ b/packages/react/src/stubs/native-on-web.ts
@@ -1,0 +1,3 @@
+throw new Error(
+  '@zerodev/wallet-react react-native subpaths cannot be imported in a web environment. Use the bare specifier (`import { ... } from "@zerodev/wallet-react"`) instead.',
+)

--- a/packages/react/src/utils/platform.ts
+++ b/packages/react/src/utils/platform.ts
@@ -1,0 +1,25 @@
+// Duplicated verbatim from @zerodev/wallet-core's utils/platform.ts.
+// Intentional duplication avoids cross-package bare-specifier imports that
+// could resolve to the wrong platform entry under non-standard package
+// manager / bundler configs.
+export function isReactNative(): boolean {
+  if (
+    typeof navigator !== 'undefined' &&
+    (navigator as { product?: string }).product === 'ReactNative'
+  ) {
+    return true
+  }
+  if (
+    typeof window !== 'undefined' &&
+    Object.hasOwn(window, 'ReactNativeWebView')
+  ) {
+    return true
+  }
+  if (
+    typeof globalThis !== 'undefined' &&
+    Object.hasOwn(globalThis, 'HermesEngine')
+  ) {
+    return true
+  }
+  return false
+}

--- a/packages/react/src/web/exportPrivateKey.ts
+++ b/packages/react/src/web/exportPrivateKey.ts
@@ -1,0 +1,72 @@
+import type { Config, Connector } from '@wagmi/core'
+import {
+  createIframeStamper,
+  exportPrivateKey as exportPrivateKeySdk,
+} from '@zerodev/wallet-core'
+import {
+  getZeroDevConnector,
+  getZeroDevStore,
+  getZeroDevWallet,
+} from '../actions.js'
+
+/**
+ * Export private key (web — uses Turnkey iframe stamper)
+ */
+export async function exportPrivateKey(
+  config: Config,
+  parameters: {
+    iframeContainerId: string
+    iframeStyles?: Record<string, string>
+    address?: string
+    keyFormat?: 'Hexadecimal' | 'Solana'
+    connector?: Connector
+  },
+): Promise<void> {
+  const connector = parameters.connector ?? getZeroDevConnector(config)
+  const store = await getZeroDevStore(connector)
+  const wallet = getZeroDevWallet(store)
+
+  const iframeContainer = document.getElementById(parameters.iframeContainerId)
+  if (!iframeContainer) {
+    throw new Error('Iframe container not found')
+  }
+
+  const iframeStamper = await createIframeStamper({
+    iframeUrl: 'https://export.turnkey.com',
+    iframeContainer,
+    iframeElementId: 'export-private-key-iframe',
+  })
+
+  const publicKey = await iframeStamper.init()
+
+  if (parameters.iframeStyles) {
+    await iframeStamper.applySettings({ styles: parameters.iframeStyles })
+  }
+
+  const { exportBundle, organizationId } = await exportPrivateKeySdk({
+    wallet,
+    targetPublicKey: publicKey,
+    ...(parameters.address && { address: parameters.address }),
+  })
+
+  const success = await iframeStamper.injectKeyExportBundle(
+    exportBundle,
+    organizationId,
+    parameters.keyFormat ?? 'Hexadecimal',
+  )
+  if (success !== true) {
+    throw new Error('Failed to inject export bundle')
+  }
+}
+
+export declare namespace exportPrivateKey {
+  type Parameters = {
+    iframeContainerId: string
+    iframeStyles?: Record<string, string>
+    address?: string
+    keyFormat?: 'Hexadecimal' | 'Solana'
+    connector?: Connector
+  }
+  type ReturnType = void
+  type ErrorType = Error
+}

--- a/packages/react/src/web/exportWallet.ts
+++ b/packages/react/src/web/exportWallet.ts
@@ -1,0 +1,66 @@
+import type { Config, Connector } from '@wagmi/core'
+import {
+  createIframeStamper,
+  exportWallet as exportWalletSdk,
+} from '@zerodev/wallet-core'
+import {
+  getZeroDevConnector,
+  getZeroDevStore,
+  getZeroDevWallet,
+} from '../actions.js'
+
+/**
+ * Export wallet (web — uses Turnkey iframe stamper)
+ */
+export async function exportWallet(
+  config: Config,
+  parameters: {
+    iframeContainerId: string
+    iframeStyles?: Record<string, string>
+    connector?: Connector
+  },
+): Promise<void> {
+  const connector = parameters.connector ?? getZeroDevConnector(config)
+  const store = await getZeroDevStore(connector)
+  const wallet = getZeroDevWallet(store)
+
+  const iframeContainer = document.getElementById(parameters.iframeContainerId)
+  if (!iframeContainer) {
+    throw new Error('Iframe container not found')
+  }
+
+  const iframeStamper = await createIframeStamper({
+    iframeUrl: 'https://export.turnkey.com',
+    iframeContainer,
+    iframeElementId: 'export-wallet-iframe',
+  })
+
+  const publicKey = await iframeStamper.init()
+
+  if (parameters.iframeStyles) {
+    await iframeStamper.applySettings({ styles: parameters.iframeStyles })
+  }
+
+  const { exportBundle, organizationId } = await exportWalletSdk({
+    wallet,
+    targetPublicKey: publicKey,
+  })
+
+  const success = await iframeStamper.injectWalletExportBundle(
+    exportBundle,
+    organizationId,
+  )
+  if (success !== true) {
+    throw new Error('Failed to inject export bundle')
+  }
+}
+
+export declare namespace exportWallet {
+  type Parameters = {
+    iframeContainerId: string
+    iframeStyles?: Record<string, string>
+    connector?: Connector
+  }
+  type ReturnType = void
+  type ErrorType = Error
+}

--- a/packages/react/src/web/useAuthenticateOAuth.ts
+++ b/packages/react/src/web/useAuthenticateOAuth.ts
@@ -6,37 +6,29 @@ import {
   useMutation,
 } from '@tanstack/react-query'
 import { type Config, type ResolvedRegister, useConfig } from 'wagmi'
-import {
-  authenticateOAuth,
-  type GetOAuthSessionIdFn,
-} from '../../authenticateOAuth.js'
-import type { OAuthProvider } from '../../utils/verifyGoogleLoginUrl.js'
+import { authenticateOAuth } from '../authenticateOAuth.js'
+import { getSessionIdWeb } from '../getSessionIdWeb.js'
+import type { OAuthProvider } from '../utils/verifyGoogleLoginUrl.js'
 
 type ConfigParameter<config extends Config = Config> = {
   config?: Config | config | undefined
 }
 
 /**
- * Generic native variant — REQUIRES `getSessionId` and `redirectUri` at the
- * hook level. No platform fallback, no auto-wired adapter. Use this when
- * you're providing your own OAuth implementation (e.g. `react-native-app-auth`
- * or a custom flow).
+ * Web variant — hard-wires the popup-based `getSessionIdWeb` flow and
+ * `window.location.href` as the redirect URI. Consumers needing a custom
+ * OAuth flow call `authenticateOAuth` directly.
  *
- * For the blessed Expo-based flow (expo-web-browser + expo-linking deep-link
- * race), import `useAuthenticateOAuthWithExpoWebBrowser` from
- * `@zerodev/wallet-react/react-native/oauth/with-expo-web-browser` instead —
- * it auto-wires the adapter with a `useMemo`, so you only pass `redirectUri`.
- *
- * Importing this generic hook does NOT pull `expo-web-browser` / `expo-linking`
- * into your bundle.
+ * `timeoutMs` (optional) configures how long the popup-polling flow may run
+ * before it fails. Defaults to 5 minutes (defined in `getSessionIdWeb`).
  */
 export function useAuthenticateOAuth<
   config extends Config = ResolvedRegister['config'],
   context = unknown,
 >(
-  parameters: useAuthenticateOAuth.Parameters<config, context>,
+  parameters: useAuthenticateOAuth.Parameters<config, context> = {},
 ): useAuthenticateOAuth.ReturnType<context> {
-  const { mutation, getSessionId, redirectUri } = parameters
+  const { mutation, timeoutMs } = parameters
   const config = useConfig(parameters)
 
   return useMutation({
@@ -44,8 +36,9 @@ export function useAuthenticateOAuth<
     async mutationFn(variables: { provider: OAuthProvider }) {
       return authenticateOAuth(config, {
         ...variables,
-        getSessionId,
-        redirectUri,
+        getSessionId: ({ oauthUrl }) =>
+          getSessionIdWeb(oauthUrl, window.location.origin, timeoutMs),
+        redirectUri: window.location.href,
       })
     },
     mutationKey: ['authenticateOAuth'],
@@ -57,8 +50,8 @@ export declare namespace useAuthenticateOAuth {
     config extends Config = Config,
     context = unknown,
   > = ConfigParameter<config> & {
-    getSessionId: GetOAuthSessionIdFn
-    redirectUri: string
+    /** Popup-polling timeout in ms. Defaults to 5 minutes. */
+    timeoutMs?: number
     mutation?:
       | UseMutationOptions<
           authenticateOAuth.ReturnType,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,19 +268,40 @@ importers:
       json-canonicalize:
         specifier: ^2.0.0
         version: 2.0.0
+      react-native:
+        specifier: '>=0.73.0'
+        version: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
       viem:
         specifier: ^2.38.0
-        version: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.1.12)
+        version: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12)
     devDependencies:
       '@hpke/core':
         specifier: ^1.9.0
         version: 1.9.0
+      '@react-native-async-storage/async-storage':
+        specifier: 2.2.0
+        version: 2.2.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))
+      '@turnkey/api-key-stamper':
+        specifier: 0.6.4
+        version: 0.6.4
+      '@turnkey/crypto':
+        specifier: 2.8.13
+        version: 2.8.13
+      '@turnkey/react-native-passkey-stamper':
+        specifier: 1.2.12
+        version: 1.2.12(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.11
+      expo-secure-store:
+        specifier: 55.0.9
+        version: 55.0.9(expo@55.0.9)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      uuid:
+        specifier: ^13.0.0
+        version: 13.0.0
 
   packages/react:
     dependencies:
@@ -310,7 +331,7 @@ importers:
         version: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       wagmi:
         specifier: ^2.19.0
-        version: 2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+        version: 2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.0))(@types/react@19.2.2)(bufferutil@4.0.9)(expo-web-browser@15.0.10(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       zustand:
         specifier: ^5.0.3
         version: 5.0.8(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
@@ -318,9 +339,24 @@ importers:
       '@types/react':
         specifier: ^19
         version: 19.2.2
+      expo-linking:
+        specifier: ^8.0.8
+        version: 8.0.12(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      expo-web-browser:
+        specifier: ^15.0.7
+        version: 15.0.10(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))
+      react-native:
+        specifier: 0.83.4
+        version: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      react-native-webview:
+        specifier: 13.16.0
+        version: 13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      uuid:
+        specifier: ^13.0.0
+        version: 13.0.0
 
   packages/react-kit:
     dependencies:
@@ -494,6 +530,9 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
+  '@babel/code-frame@7.10.4':
+    resolution: {integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==}
+
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
@@ -595,6 +634,10 @@ packages:
 
   '@babel/helpers@7.29.2':
     resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/highlight@7.25.9':
+    resolution: {integrity: sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.0':
@@ -1596,11 +1639,20 @@ packages:
   '@expo/code-signing-certificates@0.0.6':
     resolution: {integrity: sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w==}
 
+  '@expo/config-plugins@54.0.4':
+    resolution: {integrity: sha512-g2yXGICdoOw5i3LkQSDxl2Q5AlQCrG7oniu0pCPPO+UxGb7He4AFqSvPSy8HpRUj55io17hT62FTjYRD+d6j3Q==}
+
   '@expo/config-plugins@55.0.8':
     resolution: {integrity: sha512-8WfWTRntTCcowfOS+tHdB0z98gKetTwktg4G5TWkCkXVa8Jt1NUnvzaaU4UHk2vbR2U4N84RyZJFizSwfF6C9g==}
 
+  '@expo/config-types@54.0.10':
+    resolution: {integrity: sha512-/J16SC2an1LdtCZ67xhSkGXpALYUVUNyZws7v+PVsFZxClYehDSoKLqyRaGkpHlYrCc08bS0RF5E0JV6g50psA==}
+
   '@expo/config-types@55.0.5':
     resolution: {integrity: sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==}
+
+  '@expo/config@12.0.13':
+    resolution: {integrity: sha512-Cu52arBa4vSaupIWsF0h7F/Cg//N374nYb7HAxV0I4KceKA7x2UXpYaHOL7EEYYvp7tZdThBjvGpVmr8ScIvaQ==}
 
   '@expo/config@55.0.15':
     resolution: {integrity: sha512-lHc0ELIQ8126jYOMZpLv3WIuvordW98jFg5aT/J1/12n2ycuXu01XLZkJsdw0avO34cusUYb1It+MvY8JiMduA==}
@@ -1625,6 +1677,9 @@ packages:
       expo: '*'
       react: '*'
       react-native: '*'
+
+  '@expo/env@2.0.11':
+    resolution: {integrity: sha512-xV+ps6YCW7XIPVUwFVCRN2nox09dnRwy8uIjwHWTODu0zFw4kp4omnVkl0OOjuu2XOe7tdgAHxikrkJt9xB/7Q==}
 
   '@expo/env@2.1.1':
     resolution: {integrity: sha512-rVvHC4I6xlPcg+mAO09ydUi2Wjv1ZytpLmHOSzvXzBAz9mMrJggqCe4s4dubjJvi/Ino/xQCLhbaLCnTtLpikg==}
@@ -1687,6 +1742,9 @@ packages:
 
   '@expo/package-manager@1.10.3':
     resolution: {integrity: sha512-ZuXiK/9fCrIuLjPSe1VYmfp0Sa85kCMwd8QQpgyi5ufppYKRtLBg14QOgUqj8ZMbJTxE0xqzd0XR7kOs3vAK9A==}
+
+  '@expo/plist@0.4.8':
+    resolution: {integrity: sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==}
 
   '@expo/plist@0.5.2':
     resolution: {integrity: sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==}
@@ -5260,6 +5318,9 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -5862,6 +5923,10 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
@@ -6380,6 +6445,14 @@ packages:
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
 
+  dotenv-expand@11.0.7:
+    resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
+    engines: {node: '>=12'}
+
+  dotenv@16.4.7:
+    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -6768,6 +6841,12 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-constants@18.0.13:
+    resolution: {integrity: sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
+
   expo-constants@55.0.15:
     resolution: {integrity: sha512-w394fcZLJjeKN+9ZnJzL/HiarE1nwZFDa+3S9frevh6Ur+MAAs9QDrcXhDrV8T3xqRzzYaqsP6Z8TFZ4efWN1A==}
     peerDependencies:
@@ -6836,6 +6915,12 @@ packages:
 
   expo-linking@55.0.14:
     resolution: {integrity: sha512-ZSqOvJyEquf04M5/ZpQo2diK9QRnNrzgqZo7p8gzxaPPHxP6IyUJnmcd12qT+dTxnRTVmUpxFQVHHWbvwPNIwQ==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  expo-linking@8.0.12:
+    resolution: {integrity: sha512-FpXeIpFgZuxihwT9lBo86YD3y6LphBuAhN680MMxm/Y7fmsc57vimn2d3vFu68VI0+Z9w457t494mu2wvlgWTQ==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -6933,6 +7018,12 @@ packages:
     resolution: {integrity: sha512-evxNpagCkjT3lE6bGV570TFzRtKuIuLY8I37RYHoriXCJ+ZKCN1hbmklK29uAixya+BxGpeTI2K4FqYeJLvfrw==}
     peerDependencies:
       expo: '*'
+
+  expo-web-browser@15.0.10:
+    resolution: {integrity: sha512-fvDhW4bhmXAeWFNFiInmsGCK83PAqAcQaFyp/3pE/jbdKmFKoRCWr46uZGIfN4msLK/OODhaQ/+US7GSJNDHJg==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
 
   expo-web-browser@55.0.10:
     resolution: {integrity: sha512-2d6qVrg/nt0JvW5uAqOMDG/xITIXFe1Prkq1ri+I3PrC0QmV5cMYNSagU9ykfC8S7YKWxF1qO7Qsih9fxNa9dw==}
@@ -8817,6 +8908,9 @@ packages:
   multitars@0.2.4:
     resolution: {integrity: sha512-XgLbg1HHchFauMCQPRwMj6MSyDd5koPlTA1hM3rUFkeXzGpjU/I9fP3to7yrObE9jcN8ChIOQGrM0tV0kUZaKg==}
 
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
   nano-spawn@1.0.3:
     resolution: {integrity: sha512-jtpsQDetTnvS2Ts1fiRdci5rx0VYws5jGyC+4IYOTnIQ/wwdf6JdomlHBwqC3bJYOvaKu0C2GSZ1A60anrYpaA==}
     engines: {node: '>=20.17'}
@@ -10368,6 +10462,11 @@ packages:
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   superstruct@1.0.4:
     resolution: {integrity: sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==}
     engines: {node: '>=14.0.0'}
@@ -10437,6 +10536,13 @@ packages:
 
   text-encoding-utf-8@1.0.2:
     resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   thread-stream@0.15.2:
     resolution: {integrity: sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==}
@@ -10528,6 +10634,9 @@ packages:
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
@@ -11467,6 +11576,10 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@babel/code-frame@7.10.4':
+    dependencies:
+      '@babel/highlight': 7.25.9
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -11620,6 +11733,13 @@ snapshots:
     dependencies:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
+
+  '@babel/highlight@7.25.9':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
 
   '@babel/parser@7.29.0':
     dependencies:
@@ -12777,9 +12897,104 @@ snapshots:
       - typescript
       - utf-8-validate
 
+  '@expo/cli@55.0.19(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-constants@55.0.15)(expo-font@55.0.4)(expo-router@55.0.13)(expo@55.0.9)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@expo/code-signing-certificates': 0.0.6
+      '@expo/config': 55.0.15(typescript@5.9.3)
+      '@expo/config-plugins': 55.0.8
+      '@expo/devcert': 1.2.1
+      '@expo/env': 2.1.1
+      '@expo/image-utils': 0.8.13(typescript@5.9.3)
+      '@expo/json-file': 10.0.13
+      '@expo/log-box': 55.0.8(@expo/dom-webview@55.0.3)(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@expo/metro': 54.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@expo/metro-config': 55.0.11(bufferutil@4.0.9)(expo@55.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@expo/osascript': 2.4.2
+      '@expo/package-manager': 1.10.3
+      '@expo/plist': 0.5.2
+      '@expo/prebuild-config': 55.0.16(expo@55.0.9)(typescript@5.9.3)
+      '@expo/require-utils': 55.0.4(typescript@5.9.3)
+      '@expo/router-server': 55.0.11(@expo/metro-runtime@55.0.10)(expo-constants@55.0.15)(expo-font@55.0.4)(expo-router@55.0.13)(expo-server@55.0.8)(expo@55.0.9)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@expo/schema-utils': 55.0.3
+      '@expo/spawn-async': 1.7.2
+      '@expo/ws-tunnel': 1.0.6
+      '@expo/xcpretty': 4.4.1
+      '@react-native/dev-middleware': 0.83.4(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      accepts: 1.3.8
+      arg: 5.0.2
+      better-opn: 3.0.2
+      bplist-creator: 0.1.0
+      bplist-parser: 0.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      compression: 1.8.1
+      connect: 3.7.0
+      debug: 4.4.3
+      dnssd-advertise: 1.1.4
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      expo-server: 55.0.8
+      fetch-nodeshim: 0.4.10
+      getenv: 2.0.0
+      glob: 13.0.6
+      lan-network: 0.2.0
+      multitars: 0.2.4
+      node-forge: 1.4.0
+      npm-package-arg: 11.0.3
+      ora: 3.4.0
+      picomatch: 4.0.3
+      pretty-format: 29.7.0
+      progress: 2.0.3
+      prompts: 2.4.2
+      resolve-from: 5.0.0
+      semver: 7.7.3
+      send: 0.19.2
+      slugify: 1.6.8
+      source-map-support: 0.5.21
+      stacktrace-parser: 0.1.11
+      structured-headers: 0.4.1
+      terminal-link: 2.1.1
+      toqr: 0.1.1
+      wrap-ansi: 7.0.0
+      ws: 8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      zod: 3.25.76
+    optionalDependencies:
+      expo-router: 55.0.13(30ce0dec8f7e0dc4f640cd174ef65e3d)
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - '@expo/dom-webview'
+      - '@expo/metro-runtime'
+      - bufferutil
+      - expo-constants
+      - expo-font
+      - react
+      - react-dom
+      - react-server-dom-webpack
+      - supports-color
+      - typescript
+      - utf-8-validate
+
   '@expo/code-signing-certificates@0.0.6':
     dependencies:
       node-forge: 1.4.0
+
+  '@expo/config-plugins@54.0.4':
+    dependencies:
+      '@expo/config-types': 54.0.10
+      '@expo/json-file': 10.0.13
+      '@expo/plist': 0.4.8
+      '@expo/sdk-runtime-versions': 1.0.0
+      chalk: 4.1.2
+      debug: 4.4.3
+      getenv: 2.0.0
+      glob: 13.0.6
+      resolve-from: 5.0.0
+      semver: 7.7.3
+      slash: 3.0.0
+      slugify: 1.6.8
+      xcode: 3.0.1
+      xml2js: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@expo/config-plugins@55.0.8':
     dependencies:
@@ -12799,7 +13014,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/config-types@54.0.10': {}
+
   '@expo/config-types@55.0.5': {}
+
+  '@expo/config@12.0.13':
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      '@expo/config-plugins': 54.0.4
+      '@expo/config-types': 54.0.10
+      '@expo/json-file': 10.0.13
+      deepmerge: 4.3.1
+      getenv: 2.0.0
+      glob: 13.0.6
+      require-from-string: 2.0.2
+      resolve-from: 5.0.0
+      resolve-workspace-root: 2.0.1
+      semver: 7.7.3
+      slugify: 1.6.8
+      sucrase: 3.35.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@expo/config@55.0.15(typescript@5.9.3)':
     dependencies:
@@ -12831,11 +13066,34 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
 
+  '@expo/devtools@55.0.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
+    dependencies:
+      chalk: 4.1.2
+    optionalDependencies:
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+
   '@expo/dom-webview@55.0.3(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)':
     dependencies:
       expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
+
+  '@expo/dom-webview@55.0.3(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
+    dependencies:
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+
+  '@expo/env@2.0.11':
+    dependencies:
+      chalk: 4.1.2
+      debug: 4.4.3
+      dotenv: 16.4.7
+      dotenv-expand: 11.0.7
+      getenv: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@expo/env@2.1.1':
     dependencies:
@@ -12896,6 +13154,16 @@ snapshots:
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
       stacktrace-parser: 0.1.11
 
+  '@expo/log-box@55.0.11(@expo/dom-webview@55.0.3)(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
+    dependencies:
+      '@expo/dom-webview': 55.0.3(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      anser: 1.4.10
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      stacktrace-parser: 0.1.11
+    optional: true
+
   '@expo/log-box@55.0.8(@expo/dom-webview@55.0.3)(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)':
     dependencies:
       '@expo/dom-webview': 55.0.3(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)
@@ -12904,6 +13172,44 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
       stacktrace-parser: 0.1.11
+
+  '@expo/log-box@55.0.8(@expo/dom-webview@55.0.3)(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
+    dependencies:
+      '@expo/dom-webview': 55.0.3(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      anser: 1.4.10
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      stacktrace-parser: 0.1.11
+
+  '@expo/metro-config@55.0.11(bufferutil@4.0.9)(expo@55.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@expo/config': 55.0.15(typescript@5.9.3)
+      '@expo/env': 2.1.1
+      '@expo/json-file': 10.0.13
+      '@expo/metro': 54.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@expo/spawn-async': 1.7.2
+      browserslist: 4.28.1
+      chalk: 4.1.2
+      debug: 4.4.3
+      getenv: 2.0.0
+      glob: 13.0.6
+      hermes-parser: 0.32.1
+      jsc-safe-url: 0.2.4
+      lightningcss: 1.32.0
+      picomatch: 4.0.3
+      postcss: 8.4.49
+      resolve-from: 5.0.0
+    optionalDependencies:
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - typescript
+      - utf-8-validate
 
   '@expo/metro-config@55.0.11(bufferutil@4.0.9)(expo@55.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
@@ -12949,6 +13255,43 @@ snapshots:
     transitivePeerDependencies:
       - '@expo/dom-webview'
 
+  '@expo/metro-runtime@55.0.10(@expo/dom-webview@55.0.3)(expo@55.0.9)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
+    dependencies:
+      '@expo/log-box': 55.0.11(@expo/dom-webview@55.0.3)(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      anser: 1.4.10
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      pretty-format: 29.7.0
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      stacktrace-parser: 0.1.11
+      whatwg-fetch: 3.6.20
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.0)
+    transitivePeerDependencies:
+      - '@expo/dom-webview'
+    optional: true
+
+  '@expo/metro@54.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      metro: 0.83.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3
+      metro-minify-terser: 0.83.3
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@expo/metro@54.2.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)':
     dependencies:
       metro: 0.83.3(bufferutil@4.0.9)(utf-8-validate@6.0.6)
@@ -12982,6 +13325,12 @@ snapshots:
       npm-package-arg: 11.0.3
       ora: 3.4.0
       resolve-workspace-root: 2.0.1
+
+  '@expo/plist@0.4.8':
+    dependencies:
+      '@xmldom/xmldom': 0.8.11
+      base64-js: 1.5.1
+      xmlbuilder: 15.1.1
 
   '@expo/plist@0.5.2':
     dependencies:
@@ -13031,6 +13380,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/router-server@55.0.11(@expo/metro-runtime@55.0.10)(expo-constants@55.0.15)(expo-font@55.0.4)(expo-router@55.0.13)(expo-server@55.0.8)(expo@55.0.9)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      debug: 4.4.3
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      expo-constants: 55.0.15(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))
+      expo-font: 55.0.4(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      expo-server: 55.0.8
+      react: 19.2.0
+    optionalDependencies:
+      '@expo/metro-runtime': 55.0.10(@expo/dom-webview@55.0.3)(expo@55.0.9)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      expo-router: 55.0.13(30ce0dec8f7e0dc4f640cd174ef65e3d)
+      react-dom: 19.2.4(react@19.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@expo/schema-utils@55.0.3': {}
 
   '@expo/sdk-runtime-versions@1.0.0': {}
@@ -13046,6 +13410,12 @@ snapshots:
       expo-font: 55.0.4(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
+
+  '@expo/vector-icons@15.1.1(expo-font@55.0.4)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
+    dependencies:
+      expo-font: 55.0.4(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
 
   '@expo/ws-tunnel@1.0.6': {}
 
@@ -14017,6 +14387,19 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.3(@types/react@19.2.2)
 
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.4(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.3(@types/react@19.2.2)
+    optional: true
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
       react: 19.2.0
@@ -14065,6 +14448,29 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.3(@types/react@19.2.2)
 
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.2.0)
+      aria-hidden: 1.2.6
+      react: 19.2.0
+      react-dom: 19.2.4(react@19.2.0)
+      react-remove-scroll: 2.7.2(@types/react@19.2.2)(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.3(@types/react@19.2.2)
+    optional: true
+
   '@radix-ui/react-direction@1.1.1(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
       react: 19.2.0
@@ -14083,6 +14489,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.3(@types/react@19.2.2)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.4(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.3(@types/react@19.2.2)
+    optional: true
 
   '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -14115,6 +14535,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.3(@types/react@19.2.2)
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.4(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.3(@types/react@19.2.2)
+    optional: true
 
   '@radix-ui/react-form@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -14329,6 +14761,17 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.3(@types/react@19.2.2)
 
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.4(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.3(@types/react@19.2.2)
+    optional: true
+
   '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
@@ -14339,6 +14782,17 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.3(@types/react@19.2.2)
 
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.4(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.3(@types/react@19.2.2)
+    optional: true
+
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.2)(react@19.2.0)
@@ -14347,6 +14801,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.3(@types/react@19.2.2)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.4(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.3(@types/react@19.2.2)
+    optional: true
 
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -14401,6 +14865,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.3(@types/react@19.2.2)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.4(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.3(@types/react@19.2.2)
+    optional: true
 
   '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -14520,6 +15002,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.3(@types/react@19.2.2)
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.4(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.3(@types/react@19.2.2)
+    optional: true
 
   '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -14678,6 +15177,11 @@ snapshots:
     dependencies:
       merge-options: 3.0.4
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
+
+  '@react-native-async-storage/async-storage@2.2.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))':
+    dependencies:
+      merge-options: 3.0.4
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
 
   '@react-native/assets-registry@0.79.2': {}
 
@@ -14847,6 +15351,22 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@react-native/community-cli-plugin@0.83.4(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@react-native/dev-middleware': 0.83.4(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      debug: 4.4.3
+      invariant: 2.2.4
+      metro: 0.83.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      metro-config: 0.83.5(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      metro-core: 0.83.5
+      semver: 7.7.3
+    optionalDependencies:
+      '@react-native/metro-config': 0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@react-native/debugger-frontend@0.79.2': {}
 
   '@react-native/debugger-frontend@0.83.4': {}
@@ -14869,6 +15389,25 @@ snapshots:
       open: 7.4.2
       serve-static: 1.16.3
       ws: 6.2.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@react-native/dev-middleware@0.83.4(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@isaacs/ttlcache': 1.4.1
+      '@react-native/debugger-frontend': 0.83.4
+      '@react-native/debugger-shell': 0.83.4
+      chrome-launcher: 0.15.2
+      chromium-edge-launcher: 0.2.0
+      connect: 3.7.0
+      debug: 4.4.3
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      open: 7.4.2
+      serve-static: 1.16.3
+      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -14950,6 +15489,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
 
+  '@react-native/virtualized-lists@0.83.4(@types/react@19.2.2)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
+    dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      '@types/react': 19.2.2
+
   ? '@react-navigation/bottom-tabs@7.15.8(@react-navigation/native@7.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)'
   : dependencies:
       '@react-navigation/elements': 2.9.13(@react-navigation/native@7.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)
@@ -14962,6 +15510,20 @@ snapshots:
       sf-symbols-typescript: 2.2.0
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
+
+  '@react-navigation/bottom-tabs@7.15.8(@react-navigation/native@7.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
+    dependencies:
+      '@react-navigation/elements': 2.9.13(@react-navigation/native@7.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@react-navigation/native': 7.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      color: 4.2.3
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react-native-screens: 4.23.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      sf-symbols-typescript: 2.2.0
+    transitivePeerDependencies:
+      - '@react-native-masked-view/masked-view'
+    optional: true
 
   '@react-navigation/core@7.17.1(react@19.2.0)':
     dependencies:
@@ -14985,6 +15547,17 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.2.0)
       use-sync-external-store: 1.6.0(react@19.2.0)
 
+  '@react-navigation/elements@2.9.13(@react-navigation/native@7.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
+    dependencies:
+      '@react-navigation/native': 7.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      color: 4.2.3
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      use-latest-callback: 0.2.6(react@19.2.0)
+      use-sync-external-store: 1.6.0(react@19.2.0)
+    optional: true
+
   ? '@react-navigation/native-stack@7.14.9(@react-navigation/native@7.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)'
   : dependencies:
       '@react-navigation/elements': 2.9.13(@react-navigation/native@7.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)
@@ -14999,6 +15572,21 @@ snapshots:
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
 
+  '@react-navigation/native-stack@7.14.9(@react-navigation/native@7.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
+    dependencies:
+      '@react-navigation/elements': 2.9.13(@react-navigation/native@7.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@react-navigation/native': 7.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      color: 4.2.3
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react-native-screens: 4.23.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      sf-symbols-typescript: 2.2.0
+      warn-once: 0.1.1
+    transitivePeerDependencies:
+      - '@react-native-masked-view/masked-view'
+    optional: true
+
   '@react-navigation/native@7.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)':
     dependencies:
       '@react-navigation/core': 7.17.1(react@19.2.0)
@@ -15008,6 +15596,17 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
       use-latest-callback: 0.2.6(react@19.2.0)
+
+  '@react-navigation/native@7.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
+    dependencies:
+      '@react-navigation/core': 7.17.1(react@19.2.0)
+      escape-string-regexp: 4.0.0
+      fast-deep-equal: 3.1.3
+      nanoid: 3.3.11
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      use-latest-callback: 0.2.6(react@19.2.0)
+    optional: true
 
   '@react-navigation/routers@7.5.3':
     dependencies:
@@ -16874,6 +17473,18 @@ snapshots:
       - react
       - react-native
 
+  '@turnkey/react-native-passkey-stamper@1.2.12(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
+    dependencies:
+      '@turnkey/encoding': 0.6.0
+      '@turnkey/http': 3.18.0
+      buffer: 6.0.3
+      react-native-passkey: 3.3.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      sha256-uint8array: 0.10.7
+    transitivePeerDependencies:
+      - encoding
+      - react
+      - react-native
+
   '@turnkey/sdk-types@0.13.0': {}
 
   '@turnkey/webauthn-stamper@0.6.0':
@@ -17487,6 +18098,59 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
+
+  '@wagmi/connectors@6.2.0(9e47b2c1e487771edac9e1d1aff383dd)':
+    dependencies:
+      '@base-org/account': 2.4.0(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@gemini-wallet/core': 0.3.2(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@metamask/sdk': 0.33.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.2)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.0))(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
+      porto: 0.2.35(cb8a575eb36f4c75ca6bf0ed203794ce)
+      viem: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@tanstack/react-query'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - expo-auth-session
+      - expo-crypto
+      - expo-web-browser
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react
+      - react-native
+      - supports-color
+      - uploadthing
+      - use-sync-external-store
+      - utf-8-validate
+      - wagmi
+      - zod
 
   '@wagmi/connectors@6.2.0(@tanstack/react-query@5.90.21(react@19.2.0))(@types/react@19.2.2)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.2)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.0))(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.9)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)':
     dependencies:
@@ -18662,6 +19326,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  any-promise@1.3.0: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -19415,6 +20081,8 @@ snapshots:
 
   commander@2.20.3: {}
 
+  commander@4.1.1: {}
+
   commander@7.2.0: {}
 
   commander@8.3.0: {}
@@ -19948,6 +20616,12 @@ snapshots:
     dependencies:
       no-case: 3.0.4
       tslib: 2.8.1
+
+  dotenv-expand@11.0.7:
+    dependencies:
+      dotenv: 16.4.7
+
+  dotenv@16.4.7: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -20570,17 +21244,45 @@ snapshots:
       - supports-color
       - typescript
 
+  expo-asset@55.0.10(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3):
+    dependencies:
+      '@expo/image-utils': 0.8.13(typescript@5.9.3)
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      expo-constants: 55.0.15(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   expo-clipboard@55.0.9(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0):
     dependencies:
       expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
 
+  expo-constants@18.0.13(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)):
+    dependencies:
+      '@expo/config': 12.0.13
+      '@expo/env': 2.0.11
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-constants@55.0.15(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)):
     dependencies:
       '@expo/env': 2.1.1
       expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - supports-color
+
+  expo-constants@55.0.15(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)):
+    dependencies:
+      '@expo/env': 2.1.1
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - supports-color
 
@@ -20614,6 +21316,11 @@ snapshots:
       expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
 
+  expo-file-system@55.0.12(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)):
+    dependencies:
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+
   expo-font@55.0.4(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0):
     dependencies:
       expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -20621,11 +21328,25 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
 
+  expo-font@55.0.4(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
+    dependencies:
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      fontfaceobserver: 2.3.0
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+
   expo-glass-effect@55.0.10(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0):
     dependencies:
       expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
+
+  expo-glass-effect@55.0.10(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
+    dependencies:
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+    optional: true
 
   expo-image@55.0.9(expo@55.0.9)(react-native-web@0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0):
     dependencies:
@@ -20635,6 +21356,16 @@ snapshots:
       sf-symbols-typescript: 2.2.0
     optionalDependencies:
       react-native-web: 0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+
+  expo-image@55.0.9(expo@55.0.9)(react-native-web@0.21.2(react-dom@19.2.4(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
+    dependencies:
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      sf-symbols-typescript: 2.2.0
+    optionalDependencies:
+      react-native-web: 0.21.2(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+    optional: true
 
   expo-json-utils@55.0.2: {}
 
@@ -20649,6 +21380,16 @@ snapshots:
       invariant: 2.2.4
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - expo
+      - supports-color
+
+  expo-linking@8.0.12(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
+    dependencies:
+      expo-constants: 18.0.13(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))
+      invariant: 2.2.4
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - expo
       - supports-color
@@ -20678,6 +21419,12 @@ snapshots:
       invariant: 2.2.4
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
+
+  expo-modules-core@55.0.18(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
+    dependencies:
+      invariant: 2.2.4
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
 
   expo-router@55.0.13(17b24391732a5424954f634473c92917):
     dependencies:
@@ -20726,6 +21473,54 @@ snapshots:
       - expo-font
       - supports-color
 
+  expo-router@55.0.13(30ce0dec8f7e0dc4f640cd174ef65e3d):
+    dependencies:
+      '@expo/log-box': 55.0.11(@expo/dom-webview@55.0.3)(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@expo/metro-runtime': 55.0.10(@expo/dom-webview@55.0.3)(expo@55.0.9)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@expo/schema-utils': 55.0.3
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@react-navigation/bottom-tabs': 7.15.8(@react-navigation/native@7.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@react-navigation/native': 7.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@react-navigation/native-stack': 7.14.9(@react-navigation/native@7.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      client-only: 0.0.1
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      expo-constants: 55.0.15(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))
+      expo-glass-effect: 55.0.10(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      expo-image: 55.0.9(expo@55.0.9)(react-native-web@0.21.2(react-dom@19.2.4(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      expo-linking: 8.0.12(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      expo-server: 55.0.8
+      expo-symbols: 55.0.7(expo-font@55.0.4)(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      fast-deep-equal: 3.1.3
+      invariant: 2.2.4
+      nanoid: 3.3.11
+      query-string: 7.1.3
+      react: 19.2.0
+      react-fast-compare: 3.2.2
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react-native-screens: 4.23.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      semver: 7.6.3
+      server-only: 0.0.1
+      sf-symbols-typescript: 2.2.0
+      shallowequal: 1.1.0
+      use-latest-callback: 0.2.6(react@19.2.0)
+      vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.0)
+      react-native-reanimated: 4.3.0(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react-native-web: 0.21.2(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+    transitivePeerDependencies:
+      - '@react-native-masked-view/masked-view'
+      - '@types/react'
+      - '@types/react-dom'
+      - expo-font
+      - supports-color
+    optional: true
+
   expo-screen-capture@55.0.13(expo@55.0.9)(react@19.2.0):
     dependencies:
       expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -20760,9 +21555,24 @@ snapshots:
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
       sf-symbols-typescript: 2.2.0
 
+  expo-symbols@55.0.7(expo-font@55.0.4)(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
+    dependencies:
+      '@expo-google-fonts/material-symbols': 0.4.27
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      expo-font: 55.0.4(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      sf-symbols-typescript: 2.2.0
+    optional: true
+
   expo-updates-interface@55.1.6(expo@55.0.9):
     dependencies:
       expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+
+  expo-web-browser@15.0.10(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)):
+    dependencies:
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
 
   expo-web-browser@55.0.10(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)):
     dependencies:
@@ -20800,6 +21610,48 @@ snapshots:
       '@expo/dom-webview': 55.0.3(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)
       '@expo/metro-runtime': 55.0.10(@expo/dom-webview@55.0.3)(expo@55.0.9)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)
       react-native-webview: 13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - expo-router
+      - expo-widgets
+      - react-dom
+      - react-server-dom-webpack
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  expo@55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-router@55.0.13)(react-dom@19.2.4(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@expo/cli': 55.0.19(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.10)(bufferutil@4.0.9)(expo-constants@55.0.15)(expo-font@55.0.4)(expo-router@55.0.13)(expo@55.0.9)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@expo/config': 55.0.15(typescript@5.9.3)
+      '@expo/config-plugins': 55.0.8
+      '@expo/devtools': 55.0.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@expo/fingerprint': 0.16.6
+      '@expo/local-build-cache-provider': 55.0.7(typescript@5.9.3)
+      '@expo/log-box': 55.0.8(@expo/dom-webview@55.0.3)(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@expo/metro': 54.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@expo/metro-config': 55.0.11(bufferutil@4.0.9)(expo@55.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@expo/vector-icons': 15.1.1(expo-font@55.0.4)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@ungap/structured-clone': 1.3.0
+      babel-preset-expo: 55.0.13(@babel/core@7.29.0)(@babel/runtime@7.28.4)(expo@55.0.9)(react-refresh@0.14.2)
+      expo-asset: 55.0.10(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)
+      expo-constants: 55.0.15(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))
+      expo-file-system: 55.0.12(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))
+      expo-font: 55.0.4(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      expo-keep-awake: 55.0.4(expo@55.0.9)(react@19.2.0)
+      expo-modules-autolinking: 55.0.12(typescript@5.9.3)
+      expo-modules-core: 55.0.18(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      pretty-format: 29.7.0
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      react-refresh: 0.14.2
+      whatwg-url-minimum: 0.1.1
+    optionalDependencies:
+      '@expo/dom-webview': 55.0.3(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@expo/metro-runtime': 55.0.10(@expo/dom-webview@55.0.3)(expo@55.0.9)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react-native-webview: 13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -22951,6 +23803,26 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  metro-transform-worker@0.83.5(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      flow-enums-runtime: 0.0.6
+      metro: 0.83.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      metro-babel-transformer: 0.83.5
+      metro-cache: 0.83.5
+      metro-cache-key: 0.83.5
+      metro-minify-terser: 0.83.5
+      metro-source-map: 0.83.5
+      metro-transform-plugins: 0.83.5
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   metro-transform-worker@0.83.5(bufferutil@4.0.9)(utf-8-validate@6.0.6):
     dependencies:
       '@babel/core': 7.29.0
@@ -23038,6 +23910,53 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  metro@0.83.3(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.2.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   metro@0.83.3(bufferutil@4.0.9)(utf-8-validate@6.0.6):
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -23079,6 +23998,53 @@ snapshots:
       source-map: 0.5.7
       throat: 5.0.0
       ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.5(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 2.0.0
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.33.3
+      image-size: 1.2.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.5
+      metro-cache: 0.83.5
+      metro-cache-key: 0.83.5
+      metro-config: 0.83.5(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      metro-core: 0.83.5
+      metro-file-map: 0.83.5
+      metro-resolver: 0.83.5
+      metro-runtime: 0.83.5
+      metro-source-map: 0.83.5
+      metro-symbolicate: 0.83.5
+      metro-transform-plugins: 0.83.5
+      metro-transform-worker: 0.83.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      mime-types: 3.0.2
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
@@ -23540,6 +24506,12 @@ snapshots:
   multiformats@9.9.0: {}
 
   multitars@0.2.4: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
 
   nano-spawn@1.0.3: {}
 
@@ -24222,6 +25194,28 @@ snapshots:
       - immer
       - use-sync-external-store
 
+  porto@0.2.35(cb8a575eb36f4c75ca6bf0ed203794ce):
+    dependencies:
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.2)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.0))(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      hono: 4.10.4
+      idb-keyval: 6.2.2
+      mipd: 0.0.7(typescript@5.9.3)
+      ox: 0.9.10(typescript@5.9.3)(zod@4.1.12)
+      viem: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zod: 4.1.12
+      zustand: 5.0.8(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.4.0(react@19.2.0))
+    optionalDependencies:
+      '@tanstack/react-query': 5.90.21(react@19.2.0)
+      expo-web-browser: 15.0.10(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      typescript: 5.9.3
+      wagmi: 2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.0))(@types/react@19.2.2)(bufferutil@4.0.9)(expo-web-browser@15.0.10(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - use-sync-external-store
+
   possible-typed-array-names@1.1.0: {}
 
   postcss-value-parser@4.2.0: {}
@@ -24533,10 +25527,21 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
 
+  react-native-is-edge-to-edge@1.3.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+    optional: true
+
   react-native-passkey@3.3.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
+
+  react-native-passkey@3.3.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
 
   react-native-reanimated@4.3.0(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0):
     dependencies:
@@ -24555,10 +25560,25 @@ snapshots:
       react-native-worklets: 0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.79.2(@babel/core@7.29.0)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       semver: 7.7.3
 
+  react-native-reanimated@4.3.0(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react-native-worklets: 0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      semver: 7.7.3
+    optional: true
+
   react-native-safe-area-context@5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
+
+  react-native-safe-area-context@5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+    optional: true
 
   react-native-screens@4.23.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0):
     dependencies:
@@ -24566,6 +25586,14 @@ snapshots:
       react-freeze: 1.0.4(react@19.2.0)
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
       warn-once: 0.1.1
+
+  react-native-screens@4.23.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-freeze: 1.0.4(react@19.2.0)
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      warn-once: 0.1.1
+    optional: true
 
   react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -24597,12 +25625,35 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  react-native-web@0.21.2(react-dom@19.2.4(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@react-native/normalize-colors': 0.74.89
+      fbjs: 3.0.5
+      inline-style-prefixer: 7.0.1
+      memoize-one: 6.0.0
+      nullthrows: 1.1.1
+      postcss-value-parser: 4.2.0
+      react: 19.2.0
+      react-dom: 19.2.4(react@19.2.0)
+      styleq: 0.1.3
+    transitivePeerDependencies:
+      - encoding
+    optional: true
+
   react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0):
     dependencies:
       escape-string-regexp: 4.0.0
       invariant: 2.2.4
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6)
+
+  react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
+    dependencies:
+      escape-string-regexp: 4.0.0
+      invariant: 2.2.4
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
 
   react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0):
     dependencies:
@@ -24644,6 +25695,27 @@ snapshots:
       semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
+
+  react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@react-native/metro-config': 0.85.0(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      convert-source-map: 2.0.0
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      semver: 7.7.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   react-native@0.79.2(@babel/core@7.29.0)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10):
     dependencies:
@@ -24730,6 +25802,54 @@ snapshots:
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
       ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      yargs: 17.7.2
+    optionalDependencies:
+      '@types/react': 19.2.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@react-native-community/cli'
+      - '@react-native/metro-config'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10):
+    dependencies:
+      '@jest/create-cache-key-function': 29.7.0
+      '@react-native/assets-registry': 0.83.4
+      '@react-native/codegen': 0.83.4(@babel/core@7.29.0)
+      '@react-native/community-cli-plugin': 0.83.4(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@react-native/gradle-plugin': 0.83.4
+      '@react-native/js-polyfills': 0.83.4
+      '@react-native/normalize-colors': 0.83.4
+      '@react-native/virtualized-lists': 0.83.4(@types/react@19.2.2)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      ansi-regex: 5.0.1
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      babel-plugin-syntax-hermes-parser: 0.32.0
+      base64-js: 1.5.1
+      commander: 12.1.0
+      flow-enums-runtime: 0.0.6
+      glob: 7.2.3
+      hermes-compiler: 0.14.1
+      invariant: 2.2.4
+      jest-environment-node: 29.7.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.83.5
+      metro-source-map: 0.83.5
+      nullthrows: 1.1.1
+      pretty-format: 29.7.0
+      promise: 8.3.0
+      react: 19.2.0
+      react-devtools-core: 6.1.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      react-refresh: 0.14.2
+      regenerator-runtime: 0.13.11
+      scheduler: 0.27.0
+      semver: 7.7.3
+      stacktrace-parser: 0.1.11
+      whatwg-fetch: 3.6.20
+      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       yargs: 17.7.2
     optionalDependencies:
       '@types/react': 19.2.2
@@ -25664,6 +26784,16 @@ snapshots:
 
   stylis@4.3.6: {}
 
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
   superstruct@1.0.4: {}
 
   superstruct@2.0.2: {}
@@ -25722,6 +26852,14 @@ snapshots:
       minimatch: 3.1.5
 
   text-encoding-utf-8@1.0.2: {}
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
 
   thread-stream@0.15.2:
     dependencies:
@@ -25793,6 +26931,8 @@ snapshots:
       typescript: 5.9.3
 
   ts-dedent@2.2.0: {}
+
+  ts-interface-checker@0.1.13: {}
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -26124,6 +27264,16 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.4(react@19.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+    optional: true
+
   vfile-location@5.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -26204,6 +27354,23 @@ snapshots:
       abitype: 1.1.0(typescript@5.9.3)(zod@3.25.76)
       isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ox: 0.9.6(typescript@5.9.3)(zod@3.25.76)
+      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.1.0(typescript@5.9.3)(zod@4.1.12)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      ox: 0.9.6(typescript@5.9.3)(zod@4.1.12)
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
@@ -26522,6 +27689,51 @@ snapshots:
       react: 19.2.0
       use-sync-external-store: 1.4.0(react@19.2.0)
       viem: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.1.12)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@tanstack/query-core'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - expo-auth-session
+      - expo-crypto
+      - expo-web-browser
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react-native
+      - supports-color
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.0))(@types/react@19.2.2)(bufferutil@4.0.9)(expo-web-browser@15.0.10(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76):
+    dependencies:
+      '@tanstack/react-query': 5.90.21(react@19.2.0)
+      '@wagmi/connectors': 6.2.0(9e47b2c1e487771edac9e1d1aff383dd)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.2)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      react: 19.2.0
+      use-sync-external-store: 1.4.0(react@19.2.0)
+      viem: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12958,7 +12958,7 @@ snapshots:
       ws: 8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.13(30ce0dec8f7e0dc4f640cd174ef65e3d)
+      expo-router: 55.0.13(195b0488edae305fc56c64cdd3311c5c)
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -13277,7 +13277,7 @@ snapshots:
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
-      metro-config: 0.83.3(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      metro-config: 0.83.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       metro-core: 0.83.3
       metro-file-map: 0.83.3
       metro-minify-terser: 0.83.3
@@ -13390,7 +13390,7 @@ snapshots:
       react: 19.2.0
     optionalDependencies:
       '@expo/metro-runtime': 55.0.10(@expo/dom-webview@55.0.3)(expo@55.0.9)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
-      expo-router: 55.0.13(30ce0dec8f7e0dc4f640cd174ef65e3d)
+      expo-router: 55.0.13(195b0488edae305fc56c64cdd3311c5c)
       react-dom: 19.2.4(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -19415,7 +19415,7 @@ snapshots:
   arraybuffer.prototype.slice@1.0.4:
     dependencies:
       array-buffer-byte-length: 1.0.2
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-abstract: 1.24.2
       es-errors: 1.3.0
@@ -20734,7 +20734,7 @@ snapshots:
       array-buffer-byte-length: 1.0.2
       arraybuffer.prototype.slice: 1.0.4
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       data-view-buffer: 1.0.2
       data-view-byte-length: 1.0.2
@@ -21384,6 +21384,17 @@ snapshots:
       - expo
       - supports-color
 
+  expo-linking@55.0.14(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
+    dependencies:
+      expo-constants: 55.0.15(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))
+      invariant: 2.2.4
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - expo
+      - supports-color
+    optional: true
+
   expo-linking@8.0.12(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
     dependencies:
       expo-constants: 18.0.13(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))
@@ -21473,7 +21484,7 @@ snapshots:
       - expo-font
       - supports-color
 
-  expo-router@55.0.13(30ce0dec8f7e0dc4f640cd174ef65e3d):
+  expo-router@55.0.13(195b0488edae305fc56c64cdd3311c5c):
     dependencies:
       '@expo/log-box': 55.0.11(@expo/dom-webview@55.0.3)(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       '@expo/metro-runtime': 55.0.10(@expo/dom-webview@55.0.3)(expo@55.0.9)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
@@ -21490,7 +21501,7 @@ snapshots:
       expo-constants: 55.0.15(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))
       expo-glass-effect: 55.0.10(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       expo-image: 55.0.9(expo@55.0.9)(react-native-web@0.21.2(react-dom@19.2.4(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
-      expo-linking: 8.0.12(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      expo-linking: 55.0.14(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       expo-server: 55.0.8
       expo-symbols: 55.0.7(expo-font@55.0.4)(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       fast-deep-equal: 3.1.3
@@ -21833,7 +21844,7 @@ snapshots:
 
   function.prototype.name@1.1.8:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
@@ -22318,7 +22329,7 @@ snapshots:
 
   is-array-buffer@3.0.5:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
@@ -22410,7 +22421,7 @@ snapshots:
 
   is-nan@1.3.2:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
 
   is-negative-zero@2.0.3: {}
@@ -23436,6 +23447,21 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  metro-config@0.83.3(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      connect: 3.7.0
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.83.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      metro-cache: 0.83.3
+      metro-core: 0.83.3
+      metro-runtime: 0.83.3
+      yaml: 2.8.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   metro-config@0.83.3(bufferutil@4.0.9)(utf-8-validate@6.0.6):
     dependencies:
       connect: 3.7.0
@@ -23936,7 +23962,7 @@ snapshots:
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
-      metro-config: 0.83.3(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      metro-config: 0.83.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       metro-core: 0.83.3
       metro-file-map: 0.83.3
       metro-resolver: 0.83.3
@@ -24685,7 +24711,7 @@ snapshots:
 
   object-is@1.1.6:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
 
   object-keys@1.1.1: {}
@@ -25979,7 +26005,7 @@ snapshots:
 
   reflect.getprototypeof@1.0.10:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-abstract: 1.24.2
       es-errors: 1.3.0
@@ -26009,7 +26035,7 @@ snapshots:
 
   regexp.prototype.flags@1.5.4:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-errors: 1.3.0
       get-proto: 1.0.1
@@ -26705,7 +26731,7 @@ snapshots:
 
   string.prototype.trim@1.2.10:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-data-property: 1.1.4
       define-properties: 1.2.1
@@ -26722,7 +26748,7 @@ snapshots:
 
   string.prototype.trimstart@1.0.8:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
@@ -26995,7 +27021,7 @@ snapshots:
 
   typed-array-byte-length@1.0.3:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       for-each: 0.3.5
       gopd: 1.2.0
       has-proto: 1.2.0
@@ -27004,7 +27030,7 @@ snapshots:
   typed-array-byte-offset@1.0.4:
     dependencies:
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       for-each: 0.3.5
       gopd: 1.2.0
       has-proto: 1.2.0
@@ -27013,7 +27039,7 @@ snapshots:
 
   typed-array-length@1.0.7:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       for-each: 0.3.5
       gopd: 1.2.0
       is-typed-array: 1.1.15
@@ -27893,7 +27919,7 @@ snapshots:
   which-typed-array@1.1.19:
     dependencies:
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       for-each: 0.3.5
       get-proto: 1.0.1


### PR DESCRIPTION
Closing FS-2193, FS-2192, FS-2191
Unfortunately, this ended up being quite a big PR as I couldn't find a way to split it up further. This PR:
- brings in the mobile modules such as `passkeyStamper`, `secureStoreStamper`, `asyncStorageAdapter` into the SDK, mainly into the `core` package
- new export paths were added for the `react-native` related code on both `core` and `react`
- it also required splitting out existing web specific code from the SDK into separate files so they're not imported inside platform agnostic files that are used on React Native as well
- started establishing a folder structure of `web`, `native` and `shared` to properly separate code based on platform specificity. To reduce the changes I didn't move files more than I absolutely needed to, so only new files were separated into specific folders. Also `shared` code can be put into the package root as well. As most code is "shared", there's no need to split it into a new folder.
- regarding the "Export wallet and private key" feature on mobile - it was added as an `ExportWebView` component instead of hooks like in the web-case. This was done because on RN the `iframe` is injected into a `react-native-webview` instance. Quite a few security features were added in this component and `react-native-webview` can be considered as the de-facto WebView library (at least according to Claude) so I decided to ship this with an implicit dependance on the package. If a need arises from product for a different export feature we can change this later.

### The main changes
#### `core`:
- `createZeroDevWallet` became `createZeroDevWalletCore` so we can ship 2 distinct parameter sets for web and native - `web/createZeroDevWallet` makes the stampers and `rpId` optional, for mobile we export `createZeroDevWalletCore` while renaming it to `createZeroDevWallet`
- Web: the `/stampers` export subpath was removed and `createIframeStamper` was added to the root `index`, since IndexedDbStamper and WebAuthnStamper are defaults and likely no one would want to change them

#### `react`:
- `exportWallet` and `exportPrivateKey` were moved from `actions.ts` into their own files under `web/`. So on mobile we don't have to install the corresponding peer deps and so we can tree-shake the web code. (The tests still live in `actions.test.ts`.) For mobile the export behaviour is shipped through `ExportWebView` (explained above).
- In `actions.ts`: new utils were added and exported for `getZeroDevWallet` and `getZeroDevStore`. This alleviates some code duplication across the codebase and let's us use these functions in new places as well (needed it for `ExportWebView`). Also, adds type-safety.
- `hooks/useAuthenticateOAuth` became a generic hook that takes a mandatory `redirectUri` and ` getSessionId`, `web/useAuthenticateOAuth` is now the web specific hook that use `getSessionIdWeb` by default, And for mobile we can use the generic hook or the `useAuthenticateOAuthWithExpoWebBrowser` hook that defaults to using `expo-web-browser` and `createOAuthGetSessionIdWithExpoWebBrowser`.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
