### PR TITLE
fix(react-kit): `Input` border radius

### DIFF
--- a/packages/react-kit/src/auth/pages/SignUp.tsx
+++ b/packages/react-kit/src/auth/pages/SignUp.tsx
@@ -252,7 +252,7 @@ export function SignUp() {
               autoComplete="email"
               disabled={anyPending}
               variant="listItemStyle"
-              className="rounded-3xl"
+              containerClassName="rounded-3xl"
               onKeyDown={(e) => {
                 if (e.key === 'Enter' && emailInput && !anyPending) {
                   handleEmailSubmit()

--- a/packages/react-kit/src/shared/components/Input/index.tsx
+++ b/packages/react-kit/src/shared/components/Input/index.tsx
@@ -16,6 +16,7 @@ export interface InputProps
   multiline?: boolean
   iconName?: IconName
   children?: React.ReactNode
+  containerClassName?: string
 }
 
 function getHeightClass(multiline: boolean | undefined, variant: Variant) {
@@ -50,6 +51,7 @@ export function Input({
   iconName,
   children,
   className,
+  containerClassName,
   onFocus,
   onBlur,
   ...inputProps
@@ -119,6 +121,7 @@ export function Input({
         'flex w-full rounded-2xl items-center gap-3 pr-2',
         heightClass,
         paddingLeft,
+        containerClassName,
       )}
       variant={isFocused ? 'solid' : 'soft'}
     >


### PR DESCRIPTION
### Summary

This PR fixes `Input` component border radius on the sign-up page.

It adds an additional `containerClassName` to the `Input` component (the default `className` is applied to the input itself)