### PR TITLE
fix(signing): throw UserRejectedRequestError instead of plain Error on reject

### DIFF
--- a/packages/react-kit/src/signing/SignatureRequest.test.tsx
+++ b/packages/react-kit/src/signing/SignatureRequest.test.tsx
@@ -105,7 +105,10 @@ describe('SignatureRequest', () => {
     fireEvent.click(screen.getByText('Reject'))
 
     expect(request.reject).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'User rejected the request' }),
+      expect.objectContaining({
+        name: 'UserRejectedRequestError',
+        code: 4001,
+      }),
     )
     expect(mockStore.getState().pendingRequests).toEqual([])
   })

--- a/packages/react-kit/src/signing/hooks/usePendingRequest.test.ts
+++ b/packages/react-kit/src/signing/hooks/usePendingRequest.test.ts
@@ -121,7 +121,10 @@ describe('usePendingRequest', () => {
       act(() => result.current.reject())
 
       expect(request.reject).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'User rejected the request' }),
+        expect.objectContaining({
+          name: 'UserRejectedRequestError',
+          code: 4001,
+        }),
       )
       expect(mockStore.getState().pendingRequests).toEqual([])
       expect(result.current.pendingRequest).toBeNull()
@@ -137,7 +140,10 @@ describe('usePendingRequest', () => {
       act(() => result.current.reject())
 
       expect(request1.reject).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'User rejected the request' }),
+        expect.objectContaining({
+          name: 'UserRejectedRequestError',
+          code: 4001,
+        }),
       )
       expect(request2.reject).not.toHaveBeenCalled()
       expect(result.current.pendingRequest).toBe(request2)

--- a/packages/react-kit/src/signing/hooks/usePendingRequest.ts
+++ b/packages/react-kit/src/signing/hooks/usePendingRequest.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { UserRejectedRequestError } from 'viem'
 import { useConfig } from 'wagmi'
 import type { createStore, State } from '../../store.js'
 import type { PendingRequest } from '../../types.js'
@@ -63,7 +64,9 @@ export function usePendingRequest() {
     const state = store.getState()
     const head = state.pendingRequests[0]
     if (head) {
-      head.reject(new Error('User rejected the request'))
+      head.reject(
+        new UserRejectedRequestError(new Error('User rejected the request')),
+      )
       state.removePendingRequest(head.id)
     }
   }, [])


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
