### PR TITLE
fix(react-kit): error on re-auth

### DIFF
--- a/packages/react-kit/src/auth/pages/Verifying.tsx
+++ b/packages/react-kit/src/auth/pages/Verifying.tsx
@@ -42,13 +42,25 @@ export function Verifying() {
   useEffect(() => {
     if (hasVerifiedRef.current || !code) return
 
+    // No active OTP session — most commonly the user tapped the same
+    // magic link again after a successful verify, which cleared the
+    // session. Skip the (doomed) mutation, clean the URL, and drop
+    // back to step=null so the host app's own routing handles the
+    // already-authenticated user without flashing an error.
+    if (!otpId || !otpEncryptionTargetBundle) {
+      hasVerifiedRef.current = true
+      stripMagicLinkCodeFromUrl()
+      goToStep(null)
+      return
+    }
+
     hasVerifiedRef.current = true
     verifyMagicLink({
-      otpId: otpId ?? '',
+      otpId,
       code,
-      otpEncryptionTargetBundle: otpEncryptionTargetBundle ?? '',
+      otpEncryptionTargetBundle,
     })
-  }, [otpId, otpEncryptionTargetBundle, code, verifyMagicLink])
+  }, [otpId, otpEncryptionTargetBundle, code, verifyMagicLink, goToStep])
 
   return (
     <>

--- a/packages/react-kit/src/auth/pages/Verifying.tsx
+++ b/packages/react-kit/src/auth/pages/Verifying.tsx
@@ -41,6 +41,7 @@ export function Verifying() {
 
   useEffect(() => {
     if (hasVerifiedRef.current || !code) return
+    hasVerifiedRef.current = true
 
     // No active OTP session — most commonly the user tapped the same
     // magic link again after a successful verify, which cleared the
@@ -48,18 +49,12 @@ export function Verifying() {
     // back to step=null so the host app's own routing handles the
     // already-authenticated user without flashing an error.
     if (!otpId || !otpEncryptionTargetBundle) {
-      hasVerifiedRef.current = true
       stripMagicLinkCodeFromUrl()
       goToStep(null)
       return
     }
 
-    hasVerifiedRef.current = true
-    verifyMagicLink({
-      otpId,
-      code,
-      otpEncryptionTargetBundle,
-    })
+    verifyMagicLink({ otpId, code, otpEncryptionTargetBundle })
   }, [otpId, otpEncryptionTargetBundle, code, verifyMagicLink, goToStep])
 
   return (


### PR DESCRIPTION
### Summary

This PR fixes an error where if the user tried to press on the magic link again after already being authenticated then get redirected to the verify page again, then an error briefly appears, before being redirected to the dashboard. Now if the user is already authenticated it will go to the dashboard directly.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
