### PR TITLE
fix(react-kit): reset auth to null step on connector disconnect

### DIFF
--- a/packages/react-kit/src/connector.test.ts
+++ b/packages/react-kit/src/connector.test.ts
@@ -272,7 +272,7 @@ describe('connector', () => {
       expect(store.getState().auth.enabledMethods).toEqual(['passkey'])
     })
 
-    it('disconnect resets and reinitializes auth', async () => {
+    it('disconnect resets auth state to null step', async () => {
       const authConfig = {
         magicLinkBaseUrl: 'https://example.com/auth/verify',
         enabledMethods: ['email' as const],
@@ -282,20 +282,16 @@ describe('connector', () => {
       })
       const store = connector.getKitStore()
 
-      // Change auth state
       store.getState().auth.setEmail('test@example.com')
       store.getState().auth.goToStep('email-verification')
 
       expect(store.getState().auth.email).toBe('test@example.com')
       expect(store.getState().auth.step).toBe('email-verification')
 
-      // Disconnect
       await connector.disconnect?.()
 
-      // Auth should be reset and reinitialized, then surface the sign-up
-      // page so the user can re-authenticate.
       expect(store.getState().auth.email).toBeNull()
-      expect(store.getState().auth.step).toBe('sign-up')
+      expect(store.getState().auth.step).toBeNull()
       expect(store.getState().auth.config).toEqual(authConfig)
     })
 

--- a/packages/react-kit/src/connector.ts
+++ b/packages/react-kit/src/connector.ts
@@ -85,13 +85,8 @@ export function zeroDevWallet(
 
       async disconnect() {
         await connector.disconnect?.()
-        // Reset auth state on disconnect and surface the sign-up page so the
-        // user can immediately re-authenticate instead of seeing an empty
-        // AuthFlow (a null step renders nothing).
         if (params.config?.auth) {
           store.getState().auth.reset()
-          store.getState().auth.initialize(params.config.auth)
-          store.getState().auth.goToStep('sign-up')
         }
       },
 


### PR DESCRIPTION
Setting step to `sign-up` after disconnect is unexpected. Now we set it to `null` - if dev wants to trigger auth flow again they have to call the connect method 


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
