### PR TITLE
fix(react-kit): ScreenWrapper fixed 500px width on desktop

### DIFF
--- a/packages/react-kit/src/shared/components/ScreenWrapper/index.tsx
+++ b/packages/react-kit/src/shared/components/ScreenWrapper/index.tsx
@@ -19,7 +19,7 @@ export function ScreenWrapper({
   return (
     <div
       className={cn(
-        'flex-1 flex flex-col relative overflow-hidden min-h-screen w-full rounded-[34px] sm:min-h-0 sm:h-full',
+        'flex-1 flex flex-col relative overflow-hidden min-h-screen w-full sm:w-[500px] rounded-[34px] sm:min-h-0 sm:h-full',
         className,
       )}
       style={style}


### PR DESCRIPTION
`w-full` on desktop makes it look broken as it stretches across the screen. `w-[500px]` looks more intentional - devs can change it with className override if they want anyway.

(it's not seen in zerodev app demo because we override className to 500px there)


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
