### PR TITLE
fix(react-kit): force text-left on ScreenWrapper root

### DIFF
--- a/packages/react-kit/src/shared/components/ScreenWrapper/index.tsx
+++ b/packages/react-kit/src/shared/components/ScreenWrapper/index.tsx
@@ -19,7 +19,7 @@ export function ScreenWrapper({
   return (
     <div
       className={cn(
-        'flex-1 flex flex-col relative overflow-hidden min-h-screen w-full sm:w-[500px] rounded-[34px] sm:min-h-0 sm:h-full',
+        'flex-1 flex flex-col relative overflow-hidden min-h-screen w-full sm:w-[500px] rounded-[34px] text-left sm:min-h-0 sm:h-full',
         className,
       )}
       style={style}


### PR DESCRIPTION
If we don't specify it then default styles in dev's app could set different alignment here

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
