### PR TITLE
feat(react-kit): `usePendingRequests` hook

### DIFF
--- a/packages/react-kit/docs/pages/react-kit/hooks/use-pending-request.mdx
+++ b/packages/react-kit/docs/pages/react-kit/hooks/use-pending-request.mdx
@@ -1,8 +1,11 @@
 # usePendingRequest
 
-Access the pending signing request state. Use this to build a custom
-confirmation UI instead of the default `<SignatureRequest />`, or to
-show a count of queued requests in your own UI.
+Access the pending signing request state and register as the confirmation
+listener. Use this to build a custom confirmation UI instead of the default
+`<SignatureRequest />`.
+
+If you only need to read the queue (without registering as the listener),
+use [`usePendingRequests`](/react-kit/hooks/use-pending-requests) instead.
 
 ## Import
 

--- a/packages/react-kit/docs/pages/react-kit/hooks/use-pending-request.mdx
+++ b/packages/react-kit/docs/pages/react-kit/hooks/use-pending-request.mdx
@@ -36,6 +36,8 @@ function MyCustomConfirmation() {
 | Property | Type | Description |
 | --- | --- | --- |
 | `pendingRequest` | `PendingRequest \| null` | The head of the pending queue — the request currently awaiting user action. `null` when the queue is empty. |
-| `pendingRequests` | `PendingRequest[]` | The full pending queue. |
 | `confirm` | `() => void` | Resolves the active request and removes it from the queue, letting the underlying RPC call proceed. |
 | `reject` | `() => void` | Rejects the active request with `User rejected the request` and removes it from the queue. |
+
+To read the full queue (for example to show a count of additional pending
+requests), use [`usePendingRequests`](/react-kit/hooks/use-pending-requests).

--- a/packages/react-kit/docs/pages/react-kit/hooks/use-pending-requests.mdx
+++ b/packages/react-kit/docs/pages/react-kit/hooks/use-pending-requests.mdx
@@ -44,8 +44,8 @@ function Dashboard() {
 
 | | `usePendingRequest` | `usePendingRequests` |
 | --- | --- | --- |
+| Returns | Head request + `confirm` / `reject` | Full queue (array) |
 | Registers as confirmation listener | Yes | No |
-| Returns `confirm` / `reject` actions | Yes | No |
 | Rejects in-flight requests on unmount | Yes | No |
 | Safe to call alongside `<SignatureRequest />` | No — both would manage the listener flag | Yes |
 

--- a/packages/react-kit/docs/pages/react-kit/hooks/use-pending-requests.mdx
+++ b/packages/react-kit/docs/pages/react-kit/hooks/use-pending-requests.mdx
@@ -1,0 +1,54 @@
+# usePendingRequests
+
+Read-only subscription to the pending signing request queue. Use this when
+you need to observe the queue from outside the confirmation UI — for
+example, to hide or rearrange other parts of your layout while a request
+is pending — without registering as the confirmation listener.
+
+If you need to confirm or reject requests, use
+[`usePendingRequest`](/react-kit/hooks/use-pending-request) instead.
+
+## Import
+
+```tsx
+import { usePendingRequests } from '@zerodev/wallet-react-kit'
+```
+
+## Usage
+
+```tsx
+import { SignatureRequest, usePendingRequests } from '@zerodev/wallet-react-kit'
+
+function Dashboard() {
+  const pendingRequests = usePendingRequests()
+  const hasPending = pendingRequests.length > 0
+
+  return (
+    <>
+      <SignatureRequest />
+      <main className={hasPending ? 'hidden sm:block' : undefined}>
+        {/* dashboard content */}
+      </main>
+    </>
+  )
+}
+```
+
+## Return value
+
+| Type | Description |
+| --- | --- |
+| `PendingRequest[]` | The full pending queue. Empty array when no requests are pending. |
+
+## Difference from `usePendingRequest`
+
+| | `usePendingRequest` | `usePendingRequests` |
+| --- | --- | --- |
+| Registers as confirmation listener | Yes | No |
+| Returns `confirm` / `reject` actions | Yes | No |
+| Rejects in-flight requests on unmount | Yes | No |
+| Safe to call alongside `<SignatureRequest />` | No — both would manage the listener flag | Yes |
+
+`<SignatureRequest />` calls `usePendingRequest` internally. Calling it
+again in your own tree would double-manage the listener flag, so reach
+for `usePendingRequests` when you only need to read state.

--- a/packages/react-kit/docs/vocs.config.ts
+++ b/packages/react-kit/docs/vocs.config.ts
@@ -64,6 +64,10 @@ export default defineConfig({
               text: 'usePendingRequest',
               link: '/react-kit/hooks/use-pending-request',
             },
+            {
+              text: 'usePendingRequests',
+              link: '/react-kit/hooks/use-pending-requests',
+            },
           ],
         },
       ],

--- a/packages/react-kit/src/index.ts
+++ b/packages/react-kit/src/index.ts
@@ -20,5 +20,6 @@ export { zeroDevWallet } from './connector.js'
 export type { SignatureRequestProps } from './signing'
 export { SignatureRequest } from './signing'
 export { usePendingRequest } from './signing/hooks/usePendingRequest.js'
+export { usePendingRequests } from './signing/hooks/usePendingRequests.js'
 
 export type { PendingRequest, Request, RequestMethod } from './types.js'

--- a/packages/react-kit/src/shared/utils/store.ts
+++ b/packages/react-kit/src/shared/utils/store.ts
@@ -1,0 +1,9 @@
+import type { useConfig } from 'wagmi'
+import type { Store } from '../../types.js'
+
+export function getStore(config: ReturnType<typeof useConfig>): Store | null {
+  const connector = config.connectors.find((c) => c.id === 'zerodev-wallet')
+  if (!connector || !('getKitStore' in connector)) return null
+  // @ts-expect-error - getKitStore is a custom method on the kit connector
+  return connector.getKitStore()
+}

--- a/packages/react-kit/src/signing/hooks/usePendingRequest.test.ts
+++ b/packages/react-kit/src/signing/hooks/usePendingRequest.test.ts
@@ -100,7 +100,7 @@ describe('usePendingRequest', () => {
       expect(request1.resolve).toHaveBeenCalled()
       expect(request2.resolve).not.toHaveBeenCalled()
       expect(result.current.pendingRequest).toBe(request2)
-      expect(result.current.pendingRequests).toEqual([request2])
+      expect(mockStore.getState().pendingRequests).toEqual([request2])
     })
 
     it('is a no-op when no pending requests', () => {
@@ -147,7 +147,7 @@ describe('usePendingRequest', () => {
       )
       expect(request2.reject).not.toHaveBeenCalled()
       expect(result.current.pendingRequest).toBe(request2)
-      expect(result.current.pendingRequests).toEqual([request2])
+      expect(mockStore.getState().pendingRequests).toEqual([request2])
     })
 
     it('is a no-op when no pending requests', () => {
@@ -159,18 +159,17 @@ describe('usePendingRequest', () => {
     })
   })
 
-  describe('pendingRequests state', () => {
-    it('syncs initial pending requests from store', () => {
+  describe('pendingRequest state', () => {
+    it('syncs initial head request from store', () => {
       const request = createMockPendingRequest()
       mockStore.getState().addPendingRequest(request)
 
       const { result } = renderHook(() => usePendingRequest())
 
       expect(result.current.pendingRequest).toBe(request)
-      expect(result.current.pendingRequests).toEqual([request])
     })
 
-    it('updates when a new request is added to an empty queue', () => {
+    it('updates head when a new request is added to an empty queue', () => {
       const { result } = renderHook(() => usePendingRequest())
       expect(result.current.pendingRequest).toBeNull()
 
@@ -178,10 +177,9 @@ describe('usePendingRequest', () => {
       act(() => mockStore.getState().addPendingRequest(request))
 
       expect(result.current.pendingRequest).toBe(request)
-      expect(result.current.pendingRequests).toEqual([request])
     })
 
-    it('updates when a new request is added while one is pending', () => {
+    it('keeps the existing head when another request is queued behind it', () => {
       const request1 = createMockPendingRequest()
       mockStore.getState().addPendingRequest(request1)
       const { result } = renderHook(() => usePendingRequest())
@@ -190,10 +188,9 @@ describe('usePendingRequest', () => {
       act(() => mockStore.getState().addPendingRequest(request2))
 
       expect(result.current.pendingRequest).toBe(request1)
-      expect(result.current.pendingRequests).toEqual([request1, request2])
     })
 
-    it('updates when a request is removed while others are pending', () => {
+    it('advances head when the current one is removed', () => {
       const request1 = createMockPendingRequest()
       const request2 = createMockPendingRequest()
       mockStore.getState().addPendingRequest(request1)
@@ -203,10 +200,9 @@ describe('usePendingRequest', () => {
       act(() => mockStore.getState().removePendingRequest(request1.id))
 
       expect(result.current.pendingRequest).toBe(request2)
-      expect(result.current.pendingRequests).toEqual([request2])
     })
 
-    it('clears when last request is removed', () => {
+    it('clears head when last request is removed', () => {
       const request = createMockPendingRequest()
       mockStore.getState().addPendingRequest(request)
       const { result } = renderHook(() => usePendingRequest())
@@ -214,7 +210,6 @@ describe('usePendingRequest', () => {
       act(() => mockStore.getState().removePendingRequest(request.id))
 
       expect(result.current.pendingRequest).toBeNull()
-      expect(result.current.pendingRequests).toEqual([])
     })
   })
 })

--- a/packages/react-kit/src/signing/hooks/usePendingRequest.ts
+++ b/packages/react-kit/src/signing/hooks/usePendingRequest.ts
@@ -65,5 +65,5 @@ export function usePendingRequest() {
 
   const pendingRequest = pendingRequests[0] ?? null
 
-  return { pendingRequest, pendingRequests, confirm, reject }
+  return { pendingRequest, confirm, reject }
 }

--- a/packages/react-kit/src/signing/hooks/usePendingRequest.ts
+++ b/packages/react-kit/src/signing/hooks/usePendingRequest.ts
@@ -3,17 +3,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { UserRejectedRequestError } from 'viem'
 import { useConfig } from 'wagmi'
-import type { createStore, State } from '../../store.js'
-import type { PendingRequest } from '../../types.js'
-
-export type Store = ReturnType<typeof createStore>
-
-export function getStore(config: ReturnType<typeof useConfig>): Store | null {
-  const connector = config.connectors.find((c) => c.id === 'zerodev-wallet')
-  if (!connector || !('getKitStore' in connector)) return null
-  // @ts-expect-error - getKitStore is a custom method on the kit connector
-  return connector.getKitStore()
-}
+import { getStore } from '../../shared/utils/store.js'
+import type { State } from '../../store.js'
+import type { PendingRequest, Store } from '../../types.js'
 
 export function usePendingRequest() {
   const config = useConfig()

--- a/packages/react-kit/src/signing/hooks/usePendingRequest.ts
+++ b/packages/react-kit/src/signing/hooks/usePendingRequest.ts
@@ -6,9 +6,9 @@ import { useConfig } from 'wagmi'
 import type { createStore, State } from '../../store.js'
 import type { PendingRequest } from '../../types.js'
 
-type Store = ReturnType<typeof createStore>
+export type Store = ReturnType<typeof createStore>
 
-function getStore(config: ReturnType<typeof useConfig>): Store | null {
+export function getStore(config: ReturnType<typeof useConfig>): Store | null {
   const connector = config.connectors.find((c) => c.id === 'zerodev-wallet')
   if (!connector || !('getKitStore' in connector)) return null
   // @ts-expect-error - getKitStore is a custom method on the kit connector

--- a/packages/react-kit/src/signing/hooks/usePendingRequests.test.ts
+++ b/packages/react-kit/src/signing/hooks/usePendingRequests.test.ts
@@ -120,7 +120,7 @@ describe('usePendingRequests', () => {
       expect(mockStore.getState().userConfirmationListenerActive).toBe(true)
     })
 
-    it('reads the same queue as usePendingRequest', () => {
+    it('sees the same head as usePendingRequest', () => {
       const request = createMockPendingRequest()
       mockStore.getState().addPendingRequest(request)
 
@@ -129,7 +129,7 @@ describe('usePendingRequests', () => {
         b: usePendingRequests(),
       }))
 
-      expect(result.current.a.pendingRequests).toEqual([request])
+      expect(result.current.a.pendingRequest).toBe(request)
       expect(result.current.b).toEqual([request])
     })
   })

--- a/packages/react-kit/src/signing/hooks/usePendingRequests.test.ts
+++ b/packages/react-kit/src/signing/hooks/usePendingRequests.test.ts
@@ -1,0 +1,136 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createStore } from '../../store'
+import type { PendingRequest } from '../../types'
+
+// Mock wagmi's useConfig to return a connector with getKitStore.
+// Must be a stable reference (like real wagmi) so the effect doesn't re-run on every render.
+const mockStore = createStore()
+const mockConfig = {
+  connectors: [
+    {
+      id: 'zerodev-wallet',
+      getKitStore: () => mockStore,
+    },
+  ],
+}
+
+vi.mock('wagmi', () => ({
+  useConfig: () => mockConfig,
+}))
+
+import { usePendingRequest } from './usePendingRequest'
+import { usePendingRequests } from './usePendingRequests'
+
+function createMockPendingRequest(
+  overrides?: Partial<PendingRequest>,
+): PendingRequest {
+  return {
+    id: crypto.randomUUID(),
+    method: 'eth_sendTransaction',
+    params: [{ to: '0x1234', value: '0x0' }],
+    resolve: vi.fn(),
+    reject: vi.fn(),
+    ...overrides,
+  } as PendingRequest
+}
+
+afterEach(() => {
+  cleanup()
+  mockStore.getState().clearPendingRequests()
+  mockStore.getState().setUserConfirmationListenerActive(false)
+})
+
+describe('usePendingRequests', () => {
+  describe('lifecycle', () => {
+    it('does NOT set userConfirmationListenerActive on mount', () => {
+      renderHook(() => usePendingRequests())
+
+      expect(mockStore.getState().userConfirmationListenerActive).toBe(false)
+    })
+
+    it('does NOT reject pending requests on unmount', () => {
+      const request = createMockPendingRequest()
+      mockStore.getState().addPendingRequest(request)
+      const { unmount } = renderHook(() => usePendingRequests())
+
+      unmount()
+
+      expect(request.reject).not.toHaveBeenCalled()
+      expect(mockStore.getState().pendingRequests).toEqual([request])
+    })
+  })
+
+  describe('state', () => {
+    it('syncs initial pending requests from store', () => {
+      const request = createMockPendingRequest()
+      mockStore.getState().addPendingRequest(request)
+
+      const { result } = renderHook(() => usePendingRequests())
+
+      expect(result.current).toEqual([request])
+    })
+
+    it('returns an empty array when the queue is empty', () => {
+      const { result } = renderHook(() => usePendingRequests())
+
+      expect(result.current).toEqual([])
+    })
+
+    it('updates when a new request is added', () => {
+      const { result } = renderHook(() => usePendingRequests())
+
+      const request = createMockPendingRequest()
+      act(() => mockStore.getState().addPendingRequest(request))
+
+      expect(result.current).toEqual([request])
+    })
+
+    it('updates when a request is removed', () => {
+      const request1 = createMockPendingRequest()
+      const request2 = createMockPendingRequest()
+      mockStore.getState().addPendingRequest(request1)
+      mockStore.getState().addPendingRequest(request2)
+      const { result } = renderHook(() => usePendingRequests())
+
+      act(() => mockStore.getState().removePendingRequest(request1.id))
+
+      expect(result.current).toEqual([request2])
+    })
+
+    it('reflects multiple queued requests in order', () => {
+      const request1 = createMockPendingRequest()
+      const request2 = createMockPendingRequest()
+      mockStore.getState().addPendingRequest(request1)
+      mockStore.getState().addPendingRequest(request2)
+
+      const { result } = renderHook(() => usePendingRequests())
+
+      expect(result.current).toEqual([request1, request2])
+    })
+  })
+
+  describe('coexistence with usePendingRequest', () => {
+    it('does not interfere with usePendingRequest activating the listener', () => {
+      renderHook(() => {
+        usePendingRequest()
+        usePendingRequests()
+      })
+
+      expect(mockStore.getState().userConfirmationListenerActive).toBe(true)
+    })
+
+    it('reads the same queue as usePendingRequest', () => {
+      const request = createMockPendingRequest()
+      mockStore.getState().addPendingRequest(request)
+
+      const { result } = renderHook(() => ({
+        a: usePendingRequest(),
+        b: usePendingRequests(),
+      }))
+
+      expect(result.current.a.pendingRequests).toEqual([request])
+      expect(result.current.b).toEqual([request])
+    })
+  })
+})

--- a/packages/react-kit/src/signing/hooks/usePendingRequests.ts
+++ b/packages/react-kit/src/signing/hooks/usePendingRequests.ts
@@ -1,0 +1,31 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useConfig } from 'wagmi'
+import type { State } from '../../store.js'
+import type { PendingRequest } from '../../types.js'
+import { getStore } from './usePendingRequest.js'
+
+// Pure subscription to the pending request queue. Does NOT register as a
+// confirmation listener — use this when you only need to read state (e.g. to
+// drive overlay layout from a parent component). For interactive UIs that
+// confirm/reject requests, use `usePendingRequest`, which both registers the
+// listener and exposes `confirm` / `reject`.
+export function usePendingRequests(): PendingRequest[] {
+  const config = useConfig()
+  const [pendingRequests, setPendingRequests] = useState<PendingRequest[]>([])
+
+  useEffect(() => {
+    const store = getStore(config)
+    if (!store) return
+
+    setPendingRequests(store.getState().pendingRequests)
+
+    return store.subscribe(
+      (state: State) => state.pendingRequests,
+      (reqs: PendingRequest[]) => setPendingRequests(reqs),
+    )
+  }, [config])
+
+  return pendingRequests
+}

--- a/packages/react-kit/src/signing/hooks/usePendingRequests.ts
+++ b/packages/react-kit/src/signing/hooks/usePendingRequests.ts
@@ -2,9 +2,9 @@
 
 import { useEffect, useState } from 'react'
 import { useConfig } from 'wagmi'
+import { getStore } from '../../shared/utils/store.js'
 import type { State } from '../../store.js'
 import type { PendingRequest } from '../../types.js'
-import { getStore } from './usePendingRequest.js'
 
 // Pure subscription to the pending request queue. Does NOT register as a
 // confirmation listener — use this when you only need to read state (e.g. to

--- a/packages/react-kit/src/signing/index.tsx
+++ b/packages/react-kit/src/signing/index.tsx
@@ -3,6 +3,7 @@ import { ScreenWrapper } from '../shared/components/ScreenWrapper'
 import type { PendingRequest, Request } from '../types.js'
 import { renderRequestContent } from './components/renderRequestContent.js'
 import { usePendingRequest } from './hooks/usePendingRequest.js'
+import { usePendingRequests } from './hooks/usePendingRequests.js'
 
 type RenderPropArgs = {
   pendingRequest: PendingRequest | null
@@ -76,8 +77,8 @@ function UncontrolledSignatureRequest({
 }: {
   children: ((args: RenderPropArgs) => ReactNode) | undefined
 } & StyleProps) {
-  const { pendingRequest, pendingRequests, confirm, reject } =
-    usePendingRequest()
+  const { pendingRequest, confirm, reject } = usePendingRequest()
+  const pendingRequests = usePendingRequests()
 
   if (typeof children === 'function') {
     return children({ pendingRequest, confirm, reject })

--- a/packages/react-kit/src/types.ts
+++ b/packages/react-kit/src/types.ts
@@ -1,4 +1,7 @@
 import type { Address, Hex, RpcTransactionRequest } from 'viem'
+import type { createStore } from './store.js'
+
+export type Store = ReturnType<typeof createStore>
 
 export type BatchCall = {
   to?: Address


### PR DESCRIPTION
### Summary

This PR adds a `usePendingRequests` hook which is a read-only subscription to the pending signing request queue without side effects

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
