### PR TITLE
chore(react-kit): exclude tsbuildinfo from dist package & make it public

### DIFF
--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@zerodev/wallet-react-kit",
-  "private": true,
   "version": "0.0.1-alpha.0",
   "description": "React UI components for ZeroDev Wallet SDK",
   "sideEffects": [

--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -21,7 +21,7 @@
     "dist",
     "./src/**/*.ts",
     "./src/**/*.tsx",
-    "!dist/_types/**/*.tsbuildinfo",
+    "!dist/**/*.tsbuildinfo",
     "!.env",
     "!./**/*.test.ts",
     "!./**/*.test.tsx",


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
