### PR TITLE
feat(core): send PoP signature on OAuth completion

### DIFF
--- a/packages/core/src/actions/auth/auth.test.ts
+++ b/packages/core/src/actions/auth/auth.test.ts
@@ -55,7 +55,7 @@ function createMockClient(
 }
 
 describe('authenticateWithOAuth', () => {
-  it('sends OAuth auth request with sessionId in body', async () => {
+  it('sends OAuth auth request with sessionId and popSignature in body', async () => {
     const mockClient = createMockClient(async () => ({
       userId: 'user-123',
       session: 'session-jwt',
@@ -65,12 +65,16 @@ describe('authenticateWithOAuth', () => {
       provider: 'google',
       projectId: 'proj-456',
       sessionId: 'test-session-id',
+      popSignature: '3045-der-hex',
     })
 
     expect(mockClient.request).toHaveBeenCalledWith({
       path: 'proj-456/auth/oauth',
       method: 'POST',
-      body: { sessionId: 'test-session-id' },
+      body: {
+        sessionId: 'test-session-id',
+        popSignature: '3045-der-hex',
+      },
     })
     expect(result).toEqual({
       userId: 'user-123',
@@ -91,6 +95,7 @@ describe('authenticateWithOAuth', () => {
       provider: 'google',
       projectId: 'proj-456',
       sessionId: 'test-session-id',
+      popSignature: '3045-der-hex',
     })
 
     expect(result).toEqual(fullResponse)
@@ -106,6 +111,7 @@ describe('authenticateWithOAuth', () => {
         provider: 'google',
         projectId: 'proj-456',
         sessionId: 'expired-session',
+        popSignature: '3045-der-hex',
       }),
     ).rejects.toThrow('OAuth session expired')
   })

--- a/packages/core/src/actions/auth/authenticateWithOAuth.ts
+++ b/packages/core/src/actions/auth/authenticateWithOAuth.ts
@@ -7,6 +7,8 @@ export type AuthenticateWithOAuthParameters = {
   projectId: string
   /** The session ID from the OAuth callback URL */
   sessionId: string
+  /** Proof-of-possession signature for `sessionId`. */
+  popSignature: string
 }
 
 export type AuthenticateWithOAuthReturnType = {
@@ -37,6 +39,7 @@ export type AuthenticateWithOAuthReturnType = {
  *   provider: 'google',
  *   projectId: 'proj_456',
  *   sessionId: 'abc123',
+ *   popSignature: '3045022100...',
  * });
  * ```
  */
@@ -44,11 +47,11 @@ export async function authenticateWithOAuth(
   client: Client,
   params: AuthenticateWithOAuthParameters,
 ): Promise<AuthenticateWithOAuthReturnType> {
-  const { projectId, sessionId } = params
+  const { projectId, sessionId, popSignature } = params
 
   return await client.request({
     path: `${projectId}/auth/oauth`,
     method: 'POST',
-    body: { sessionId },
+    body: { sessionId, popSignature },
   })
 }

--- a/packages/core/src/core/createZeroDevWallet.ts
+++ b/packages/core/src/core/createZeroDevWallet.ts
@@ -223,10 +223,12 @@ export async function createZeroDevWallet(
     async auth(params: AuthParams) {
       switch (params.type) {
         case 'oauth': {
+          const popSignature = await client.apiKeyStamper.sign(params.sessionId)
           const data = await client.authenticateWithOAuth({
             provider: params.provider,
             projectId,
             sessionId: params.sessionId,
+            popSignature,
           })
 
           if (data.session) {

--- a/packages/core/src/stampers/indexedDbStamper.ts
+++ b/packages/core/src/stampers/indexedDbStamper.ts
@@ -15,6 +15,9 @@ export async function createIndexedDbStamper(): Promise<ApiKeyStamper> {
     async stamp(payload: string) {
       return await inner.stamp(payload)
     },
+    async sign(payload: string) {
+      return await inner.sign(payload)
+    },
     async clear() {
       await inner.clear()
     },

--- a/packages/core/src/stampers/types.ts
+++ b/packages/core/src/stampers/types.ts
@@ -39,6 +39,11 @@ export type ApiKeyStamper = Stamper & {
   prepareKeyRotation: () => Promise<string>
   /** Promote the pending key to active. Call after the server accepts the new key. */
   commitKeyRotation: () => Promise<void>
+  /**
+   * Sign `payload` with the currently active key. Returns a hex-encoded
+   * ECDSA-P256 / SHA-256 signature in ASN.1 DER form.
+   */
+  sign: (payload: string) => Promise<string>
 }
 export type Attestation = {
   attestationObject: string


### PR DESCRIPTION
## Summary
- Adds `sign(payload)` to the `ApiKeyStamper` type, plumbing through to the underlying IndexedDB stamper's existing `sign` method.
- `authenticateWithOAuth` now accepts a required `popSignature` and includes it in the `POST /{projectId}/auth/oauth` body.
- `createZeroDevWallet.auth({ type: 'oauth' })` signs the incoming `sessionId` with the active session key and forwards the signature as `popSignature`.

Coordinates with the corresponding backend change. Smoke-tested locally end-to-end — Google login succeeds and the request body carries both `sessionId` and `popSignature`.

## Notes
- No public API change at the React layer — signing happens inside `wallet.auth`, so `authenticateOAuth` / `useAuthenticateOAuth` callers are unaffected.
- Backend gracefully ignores the extra field on older deployments (Gin's default JSON binding drops unknown keys), so this SDK can ship before the backend rolls out.
- Changeset to follow (will run `pnpm changeset` interactively).