### PR TITLE
release(core/react/react-kit): @zerodev/wallet-core@0.0.1-alpha.20, @zerodev/wallet-react@0.0.1-alpha.23, @zerodev/wallet-react-kit@0.0.1-alpha.1

### DIFF
--- a/.changeset/funny-sheep-retire.md
+++ b/.changeset/funny-sheep-retire.md
@@ -1,0 +1,6 @@
+---
+"@zerodev/wallet-core": patch
+"@zerodev/wallet-react-kit": patch
+---
+
+feat: initial react-kit release

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -17,6 +17,7 @@
     "floppy-glasses-attack",
     "free-grapes-teach",
     "funky-pillows-fall",
+    "funny-sheep-retire",
     "gentle-adults-talk",
     "giant-garlics-make",
     "humble-sheep-kiss",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @zerodev/wallet-core
 
+## 0.0.1-alpha.20
+
+### Patch Changes
+
+- feat: send PoP signature on OAuth completion
+
+
 ## 0.0.1-alpha.19
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-core",
-  "version": "0.0.1-alpha.19",
+  "version": "0.0.1-alpha.20",
   "description": "ZeroDev Wallet SDK built on Turnkey",
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",

--- a/packages/react-kit/CHANGELOG.md
+++ b/packages/react-kit/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @zerodev/wallet-react-kit
+
+## 0.0.1-alpha.1
+
+### Patch Changes
+
+- feat: initial react-kit release
+- Updated dependencies
+  - @zerodev/wallet-core@0.0.1-alpha.20
+  - @zerodev/wallet-react@0.0.1-alpha.23

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @zerodev/wallet-react
 
+## 0.0.1-alpha.23
+
+### Patch Changes
+
+- Updated dependencies
+  - @zerodev/wallet-core@0.0.1-alpha.20
+
 ## 0.0.1-alpha.22
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-react",
-  "version": "0.0.1-alpha.22",
+  "version": "0.0.1-alpha.23",
   "description": "React hooks for ZeroDev Wallet SDK",
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",


### PR DESCRIPTION
## Versions

- `@zerodev/wallet-core` → **0.0.1-alpha.20**
  - feat: send PoP signature on OAuth completion (#227)
- `@zerodev/wallet-react` → **0.0.1-alpha.23**
  - Updated dependency on `@zerodev/wallet-core@0.0.1-alpha.20`
- `@zerodev/wallet-react-kit` → **0.0.1-alpha.1** (initial release)