### PR TITLE
release(core/react/react-kit): @zerodev/wallet-core@0.0.1-alpha.21, @zerodev/wallet-react@0.0.1-alpha.24, @zerodev/wallet-react-kit@0.0.1-alpha.1

### DIFF
--- a/.changeset/fluffy-tools-know.md
+++ b/.changeset/fluffy-tools-know.md
@@ -1,0 +1,6 @@
+---
+"@zerodev/wallet-core": patch
+"@zerodev/wallet-react": patch
+---
+
+feat: Add React Native modules and platform-specific exports

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -15,6 +15,7 @@
     "eighty-suns-write",
     "every-stars-drum",
     "floppy-glasses-attack",
+    "fluffy-tools-know",
     "free-grapes-teach",
     "funky-pillows-fall",
     "funny-sheep-retire",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,11 +1,16 @@
 # @zerodev/wallet-core
 
+## 0.0.1-alpha.21
+
+### Patch Changes
+
+- feat: Add React Native modules and platform-specific exports
+
 ## 0.0.1-alpha.20
 
 ### Patch Changes
 
 - feat: send PoP signature on OAuth completion
-
 
 ## 0.0.1-alpha.19
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@zerodev/wallet-core",
-  "version": "0.0.1-alpha.20",
+  "version": "0.0.1-alpha.21",
   "description": "ZeroDev Wallet SDK built on Turnkey",
-  "type": "module",
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",
@@ -156,5 +155,6 @@
     "expo-secure-store": "55.0.9",
     "typescript": "5.9.3",
     "uuid": "^13.0.0"
-  }
+  },
+  "type": "module"
 }

--- a/packages/react-kit/CHANGELOG.md
+++ b/packages/react-kit/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Patch Changes
 
+- Updated dependencies
+  - @zerodev/wallet-core@0.0.1-alpha.21
+  - @zerodev/wallet-react@0.0.1-alpha.24
+
+## 0.0.1-alpha.0
+
+### Patch Changes
+
 - feat: initial react-kit release
 - Updated dependencies
   - @zerodev/wallet-core@0.0.1-alpha.20

--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-react-kit",
-  "version": "0.0.1-alpha.0",
+  "version": "0.0.1-alpha.1",
   "description": "React UI components for ZeroDev Wallet SDK",
   "sideEffects": [
     "**/*.css"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @zerodev/wallet-react
 
+## 0.0.1-alpha.24
+
+### Patch Changes
+
+- feat: Add React Native modules and platform-specific exports
+- Updated dependencies
+  - @zerodev/wallet-core@0.0.1-alpha.21
+
 ## 0.0.1-alpha.23
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@zerodev/wallet-react",
-  "version": "0.0.1-alpha.23",
+  "version": "0.0.1-alpha.24",
   "description": "React hooks for ZeroDev Wallet SDK",
-  "type": "module",
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",
@@ -114,5 +113,6 @@
     "react-native-webview": "13.16.0",
     "typescript": "5.9.3",
     "uuid": "^13.0.0"
-  }
+  },
+  "type": "module"
 }


### PR DESCRIPTION
## Versions

- `@zerodev/wallet-core` → **0.0.1-alpha.21**
  - feat: Add React Native modules and platform-specific exports (#210)
- `@zerodev/wallet-react` → **0.0.1-alpha.24**
  - feat: Add React Native modules and platform-specific exports (#210)
  - Updated dependency on `@zerodev/wallet-core@0.0.1-alpha.21`
- `@zerodev/wallet-react-kit` → **0.0.1-alpha.1** (first npm publish; alpha.0 was published earlier)
  - Updated dependencies on `@zerodev/wallet-core@0.0.1-alpha.21` and `@zerodev/wallet-react@0.0.1-alpha.24`