### PR TITLE
feat: make passkeyStamper optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,24 +81,27 @@ this SDK.
 ## React Native
 
 The SDK runs in React Native (Expo) too. The connector setup is the same, but
-the key-storage, passkey, and session-storage adapters that the web build
-defaults must be supplied explicitly via the native subpaths:
+the key-storage and session-storage adapters that the web build defaults must
+be supplied explicitly via the native subpaths. `passkeyStamper` is optional —
+omit it (and `@turnkey/react-native-passkey-stamper` from your dependencies) if
+your app doesn't use passkey auth.
 
 ```bash
 npm install @zerodev/wallet-react @zerodev/wallet-core wagmi viem \
-  expo-secure-store @turnkey/react-native-passkey-stamper \
+  expo-secure-store \
   @turnkey/api-key-stamper @turnkey/crypto \
   @react-native-async-storage/async-storage \
   react-native-get-random-values uuid
+# Add @turnkey/react-native-passkey-stamper only if you want passkey auth.
 # or
 yarn add @zerodev/wallet-react @zerodev/wallet-core wagmi viem \
-  expo-secure-store @turnkey/react-native-passkey-stamper \
+  expo-secure-store \
   @turnkey/api-key-stamper @turnkey/crypto \
   @react-native-async-storage/async-storage \
   react-native-get-random-values uuid
 # or
 pnpm add @zerodev/wallet-react @zerodev/wallet-core wagmi viem \
-  expo-secure-store @turnkey/react-native-passkey-stamper \
+  expo-secure-store \
   @turnkey/api-key-stamper @turnkey/crypto \
   @react-native-async-storage/async-storage \
   react-native-get-random-values uuid
@@ -117,7 +120,7 @@ zeroDevWallet({
   chains: [sepolia],
   rpId: RP_ID,
   apiKeyStamper: createSecureStoreStamper(),
-  passkeyStamper: createReactNativePasskeyStamper({ rpId: RP_ID }),
+  passkeyStamper: createReactNativePasskeyStamper({ rpId: RP_ID }), // optional
   sessionStorage: asyncStorageAdapter,
 })
 ```

--- a/apps/expo-example/docs/QUICK_START.md
+++ b/apps/expo-example/docs/QUICK_START.md
@@ -1,0 +1,323 @@
+# Quick Start (Expo / React Native)
+
+Stand up a React Native app that signs in with the ZeroDev wallet and
+shows the connected address. The path here uses **email OTP** auth plus
+an optional **Google OAuth** flow — neither needs a verified domain or
+`assetlinks.json`, so you can run end-to-end with nothing more than a
+project ID. Passkeys are out of scope for this guide (they require domain
+binding — see [`passkeys.md`](./passkeys.md)); the `passkeyStamper` is
+optional and omitted below.
+
+Expo's APIs change between SDK versions. Use `pnpm add` for ordinary JS
+dependencies, and use Expo's installer for Expo / React Native native
+modules so those package versions match your Expo SDK. With pnpm, run the
+Expo CLI through pnpm (`pnpm expo install ...`); Expo also defaults to
+pnpm when it sees a `pnpm-lock.yaml`. Check the
+[versioned Expo docs](https://docs.expo.dev/versions/latest/) for your SDK
+if anything here drifts.
+
+## 1. Create the project
+
+```
+pnpm create expo-app@latest <app_name>
+cd <app_name>
+```
+
+Add the ZeroDev SDK, wagmi and its peers, then add the native modules the
+SDK relies on. The first command is normal pnpm dependency management; the
+second lets Expo choose SDK-compatible native package versions:
+
+```
+pnpm add @zerodev/wallet-core @zerodev/wallet-react wagmi viem @tanstack/react-query
+pnpm expo install @react-native-async-storage/async-storage expo-secure-store react-native-get-random-values
+```
+
+## 2. Configure wagmi + ZeroDev
+
+Create `src/wagmi.config.ts`. The ZeroDev connector is registered as a
+wagmi connector via `zeroDevWallet()`, wired with the React Native
+stamper and storage adapter:
+
+- `apiKeyStamper: createSecureStoreStamper()` — stores the wallet's API
+  key in the device keychain (`expo-secure-store`). Required.
+- `sessionStorage` / `persistStorage` — back the wallet session with
+  `AsyncStorage` so sign-in survives app restarts.
+- `rpId` — only relevant for passkeys. Set it now so you can add passkeys
+  later without reconfiguring; OTP and OAuth ignore it.
+
+```ts
+// src/wagmi.config.ts
+import { createSecureStoreStamper } from "@zerodev/wallet-core/react-native/stampers/secure-store";
+import { asyncStorageAdapter } from "@zerodev/wallet-core/react-native/storage/async-storage";
+import { zeroDevWallet } from "@zerodev/wallet-react";
+import { createConfig, createStorage, http } from "wagmi";
+import { sepolia } from "wagmi/chains";
+
+const ZERODEV_PROJECT_ID = process.env.EXPO_PUBLIC_ZERODEV_PROJECT_ID ?? "";
+const RP_ID = "zd-wallet-quick-start";
+
+const chains = [sepolia] as const;
+
+export const wagmiConfig = createConfig({
+  chains,
+  connectors: [
+    zeroDevWallet({
+      projectId: ZERODEV_PROJECT_ID,
+      chains,
+      rpId: RP_ID,
+      apiKeyStamper: createSecureStoreStamper(),
+      sessionStorage: asyncStorageAdapter,
+      persistStorage: asyncStorageAdapter,
+    }),
+  ],
+  transports: {
+    [sepolia.id]: http(),
+  },
+  storage: createStorage({ storage: asyncStorageAdapter }),
+  multiInjectedProviderDiscovery: false,
+});
+
+declare module "wagmi" {
+  interface Register {
+    config: typeof wagmiConfig;
+  }
+}
+```
+
+## 3. Wire up the providers
+
+The `react-native-get-random-values` polyfill must be imported **before
+anything that touches crypto**, so put it on the very first line of your
+root layout. Wrap the app in `WagmiProvider` and `QueryClientProvider`:
+
+```tsx
+// src/app/_layout.tsx
+import "react-native-get-random-values";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Stack } from "expo-router";
+import { WagmiProvider } from "wagmi";
+
+import { wagmiConfig } from "@/wagmi.config";
+
+const queryClient = new QueryClient();
+
+export default function RootLayout() {
+  return (
+    <WagmiProvider config={wagmiConfig}>
+      <QueryClientProvider client={queryClient}>
+        <Stack screenOptions={{ headerShown: false }} />
+      </QueryClientProvider>
+    </WagmiProvider>
+  );
+}
+```
+
+## 4. Get a project ID
+
+1. Create a project in the ZeroDev dashboard.
+2. Enable **Sepolia**.
+3. Copy the project ID into a `.env` file in the project root:
+
+```
+EXPO_PUBLIC_ZERODEV_PROJECT_ID=<your project id>
+```
+
+The `EXPO_PUBLIC_` prefix exposes the value to the JS runtime. A project
+ID is not a secret.
+
+## 5. Add email OTP sign-in
+
+`useSendOTP` emails a one-time code and returns an `otpId` +
+`otpEncryptionTargetBundle`; `useVerifyOTP` exchanges the code for an
+authenticated wallet session. Keep those OTP fields in local state between
+the send and verify steps:
+
+```tsx
+// src/components/otp-email-flow.tsx
+import { useSendOTP, useVerifyOTP } from "@zerodev/wallet-react";
+import { useState } from "react";
+import { Button, Text, TextInput, View } from "react-native";
+import { useAccount } from "wagmi";
+
+type Pending = { otpId: string; otpEncryptionTargetBundle: string };
+
+/** Renders nothing once the wallet is connected. */
+export function OtpEmailFlow() {
+  const { status } = useAccount();
+  const [email, setEmail] = useState("");
+  const [code, setCode] = useState("");
+  const [pending, setPending] = useState<Pending | null>(null);
+  const sendOTP = useSendOTP();
+  const verifyOTP = useVerifyOTP();
+
+  if (status === "connected") return null;
+
+  return (
+    <View>
+      <Text>Sign in</Text>
+
+      {pending === null ? (
+        <>
+          <TextInput
+            value={email}
+            onChangeText={setEmail}
+            placeholder="you@example.com"
+            autoCapitalize="none"
+            keyboardType="email-address"
+          />
+          <Button
+            title={sendOTP.isPending ? "Sending..." : "Send code"}
+            disabled={sendOTP.isPending || !email}
+            onPress={() =>
+              sendOTP.mutate(
+                { email },
+                {
+                  onSuccess: ({ otpId, otpEncryptionTargetBundle }) =>
+                    setPending({ otpId, otpEncryptionTargetBundle }),
+                },
+              )
+            }
+          />
+        </>
+      ) : (
+        <>
+          <Text>Code sent to {email}</Text>
+          <TextInput
+            value={code}
+            onChangeText={setCode}
+            placeholder="123456"
+            keyboardType="number-pad"
+          />
+          <Button
+            title={verifyOTP.isPending ? "Verifying..." : "Verify"}
+            disabled={verifyOTP.isPending || !code}
+            onPress={() =>
+              verifyOTP.mutate({
+                code,
+                otpId: pending.otpId,
+                otpEncryptionTargetBundle: pending.otpEncryptionTargetBundle,
+              })
+            }
+          />
+        </>
+      )}
+
+      <Text>{sendOTP.error?.message ?? verifyOTP.error?.message}</Text>
+    </View>
+  );
+}
+```
+
+## 6. Show the connected wallet
+
+Once connected, the ZeroDev wallet is a standard wagmi account. Use
+`useAccount` to read the address and `useDisconnect` to log out:
+
+```tsx
+// src/components/wallet-actions.tsx
+import { Button, Text, View } from "react-native";
+import { useAccount, useDisconnect } from "wagmi";
+
+/** Renders nothing until the wallet is connected. */
+export function WalletActions() {
+  const { address, status } = useAccount();
+  const { disconnect } = useDisconnect();
+
+  if (status !== "connected" || !address) return null;
+
+  return (
+    <View>
+      <Text style={{ fontWeight: "600" }}>Wallet</Text>
+      <Text selectable>{address}</Text>
+      <Button title="Disconnect" onPress={() => disconnect()} />
+    </View>
+  );
+}
+```
+
+## 7. Run it
+
+```
+pnpm expo start
+```
+
+Then open the app on a simulator/emulator or device (press `a` for
+Android, `i` for iOS, `w` for web). Sign in with your email, paste the
+code, and confirm your wallet address appears.
+
+## Optional: Google OAuth
+
+OAuth bounces out to a browser and back via a deep link, so it needs two
+extra peer deps and one callback route. No domain setup is required when
+you use the custom-scheme redirect (`<scheme>://oauth-callback`).
+
+Install the OAuth peers (these may already be in the starter):
+
+```
+pnpm expo install expo-linking expo-web-browser
+```
+
+Add a sign-in component. `useAuthenticateOAuthWithExpoWebBrowser` opens
+the provider in an in-app browser and reads the `session_id` back off the
+redirect URL:
+
+```tsx
+// src/components/google-oauth-flow.tsx
+import { OAUTH_PROVIDERS } from "@zerodev/wallet-react";
+import { useAuthenticateOAuthWithExpoWebBrowser } from "@zerodev/wallet-react/react-native/oauth/with-expo-web-browser";
+import * as Linking from "expo-linking";
+import { Button, Text, View } from "react-native";
+import { useAccount } from "wagmi";
+
+/** Renders nothing once the wallet is connected. */
+export function GoogleOauthFlow() {
+  const { status } = useAccount();
+  const auth = useAuthenticateOAuthWithExpoWebBrowser({
+    redirectUri: Linking.createURL("oauth-callback"),
+  });
+
+  if (status === "connected") return null;
+
+  return (
+    <View>
+      <Text>Sign in with Google</Text>
+      <Button
+        title={auth.isPending ? "Signing in..." : "Continue with Google"}
+        disabled={auth.isPending}
+        onPress={() => auth.mutate({ provider: OAUTH_PROVIDERS.GOOGLE })}
+      />
+      <Text>{auth.error?.message}</Text>
+    </View>
+  );
+}
+```
+
+Add the callback route so expo-router doesn't show "Unmatched Route"
+when the redirect lands. The SDK reads the `session_id` off the URL via
+its own `Linking` listener, so this screen just bounces back home:
+
+```tsx
+// src/app/oauth-callback.tsx
+import { Redirect } from "expo-router";
+
+export default function OAuthCallback() {
+  return <Redirect href="/" />;
+}
+```
+
+Render `<GoogleOauthFlow />` alongside `<OtpEmailFlow />` on your home
+screen, then **allowlist the redirect URL** in the ZeroDev dashboard.
+Print what the value `Linking.createURL("oauth-callback")` resolves to (it
+depends on your app's `scheme` in `app.json` or on the fact whether you use Expo Go or a Development Build) and add it under your
+project's allowed OAuth redirects.
+
+## Where to go next
+
+- **Passkeys** — domain binding, `assetlinks.json` / AASA, signing
+  certs: [`passkeys.md`](./passkeys.md).
+- **OAuth & magic-link email over verified App Links** (instead of the
+  custom scheme): [`oauth-native.md`](./oauth-native.md).
+- **Universal Links**: [`universal-links.md`](./universal-links.md).
+- **Wallet export** (seed phrase / private key):
+  [`wallet-export.md`](./wallet-export.md).

--- a/apps/expo-example/src/wagmi/config.native.ts
+++ b/apps/expo-example/src/wagmi/config.native.ts
@@ -17,6 +17,7 @@ export const wagmiConfig = createConfig({
       chains,
       rpId: RP_ID,
       apiKeyStamper: createSecureStoreStamper(),
+      // Optional: omit passkeyStamper if your app doesn't use passkey auth.
       passkeyStamper: createReactNativePasskeyStamper({ rpId: RP_ID }),
       sessionStorage: asyncStorageAdapter,
       persistStorage: asyncStorageAdapter,

--- a/packages/core/src/core/createZeroDevWalletCore.ts
+++ b/packages/core/src/core/createZeroDevWalletCore.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_SESSION_EXPIRATION_IN_SECONDS,
   KMS_SERVER_URL,
 } from '../constants.js'
+import { createNoopPasskeyStamper } from '../stampers/noopPasskeyStamper.js'
 import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'
 import {
   createStorageManager,
@@ -32,7 +33,7 @@ export interface ZeroDevWalletConfigCore {
   sessionStorage: StorageAdapter
   rpId: string
   apiKeyStamper: ApiKeyStamper
-  passkeyStamper: PasskeyStamper
+  passkeyStamper?: PasskeyStamper
   fetchOptions?: CreateTransportOptions['fetchOptions']
 }
 
@@ -123,9 +124,9 @@ export async function createZeroDevWalletCore(
     sessionStorage,
     rpId,
     apiKeyStamper,
-    passkeyStamper,
     organizationId = DEFAULT_ORGANIZATION_ID,
   } = config
+  const passkeyStamper = config.passkeyStamper ?? createNoopPasskeyStamper()
 
   const sessionStorageManager = createStorageManager(sessionStorage)
 

--- a/packages/core/src/stampers/noopPasskeyStamper.test.ts
+++ b/packages/core/src/stampers/noopPasskeyStamper.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { createNoopPasskeyStamper } from './noopPasskeyStamper.js'
+
+describe('createNoopPasskeyStamper', () => {
+  it('throws an actionable error when stamp() is called', async () => {
+    const stamper = createNoopPasskeyStamper()
+    await expect(stamper.stamp('payload')).rejects.toThrow(
+      /passkeyStamper is not configured/,
+    )
+  })
+
+  it('throws an actionable error when register() is called', async () => {
+    const stamper = createNoopPasskeyStamper()
+    await expect(
+      stamper.register({ rp: { id: 'example.com', name: '' }, userName: 'u' }),
+    ).rejects.toThrow(/passkeyStamper is not configured/)
+  })
+
+  it('resolves clear() as a no-op', async () => {
+    const stamper = createNoopPasskeyStamper()
+    await expect(stamper.clear()).resolves.toBeUndefined()
+  })
+})

--- a/packages/core/src/stampers/noopPasskeyStamper.ts
+++ b/packages/core/src/stampers/noopPasskeyStamper.ts
@@ -1,0 +1,21 @@
+import type { PasskeyStamper } from './types.js'
+
+const NOT_CONFIGURED_MESSAGE =
+  'passkeyStamper is not configured. Pass passkeyStamper to zeroDevWallet({ ... }) — use createReactNativePasskeyStamper({ rpId }) on React Native or createWebauthnStamper({ rpId }) on web.'
+
+/**
+ * Internal fallback used when a consumer doesn't supply a `passkeyStamper`.
+ * Methods throw on use, so passkey register/login fails with an actionable
+ * message — all other flows (apiKey signing, OAuth, OTP) are unaffected.
+ */
+export function createNoopPasskeyStamper(): PasskeyStamper {
+  return {
+    async stamp() {
+      throw new Error(NOT_CONFIGURED_MESSAGE)
+    },
+    async register() {
+      throw new Error(NOT_CONFIGURED_MESSAGE)
+    },
+    async clear() {},
+  }
+}

--- a/packages/core/src/utils/exportWallet.ts
+++ b/packages/core/src/utils/exportWallet.ts
@@ -43,84 +43,79 @@ export async function exportWallet(
 ): Promise<{ exportBundle: string; walletId: string; organizationId: string }> {
   const { targetPublicKey, wallet } = params
 
-  try {
-    const session = await wallet.getSession()
-    if (!session) {
-      throw new Error('Session not found')
-    }
-    const { organizationId } = session
-
-    const listWalletsBody = JSON.stringify({
-      organizationId,
-    })
-
-    const listWalletsStamp =
-      await wallet.client[
-        session.stamperType === 'apiKey' ? 'apiKeyStamper' : 'passkeyStamper'
-      ].stamp(listWalletsBody)
-    if (!listWalletsStamp) {
-      throw new Error('Failed to stamp list wallets body')
-    }
-
-    const listWalletsResponse = await fetch(
-      'https://api.turnkey.com/public/v1/query/list_wallets',
-      {
-        method: 'POST',
-        body: listWalletsBody,
-        headers: {
-          [listWalletsStamp.stampHeaderName]: listWalletsStamp.stampHeaderValue,
-        },
-      },
-    )
-    if (!listWalletsResponse.ok) {
-      throw new Error('Failed to list wallets')
-    }
-    const listWalletsData = await listWalletsResponse.json()
-
-    const walletId = listWalletsData.wallets[0].walletId
-
-    const exportWalletBody = JSON.stringify({
-      type: 'ACTIVITY_TYPE_EXPORT_WALLET',
-      timestampMs: Date.now().toString(),
-      organizationId: organizationId,
-      parameters: {
-        walletId: walletId,
-        targetPublicKey,
-        language: 'MNEMONIC_LANGUAGE_ENGLISH',
-      },
-    })
-    const exportWalletStamp =
-      await wallet.client[
-        session.stamperType === 'apiKey' ? 'apiKeyStamper' : 'passkeyStamper'
-      ].stamp(exportWalletBody)
-    if (!exportWalletStamp) {
-      throw new Error('Failed to stamp export wallet body')
-    }
-    const exportWalletResponse = await fetch(
-      'https://api.turnkey.com/public/v1/submit/export_wallet',
-      {
-        method: 'POST',
-        body: exportWalletBody,
-        headers: {
-          [exportWalletStamp.stampHeaderName]:
-            exportWalletStamp.stampHeaderValue,
-        },
-      },
-    )
-    if (!exportWalletResponse.ok) {
-      throw new Error('Failed to export wallet')
-    }
-    const exportWalletData = await exportWalletResponse.json()
-
-    const exportBundle =
-      exportWalletData?.activity?.result?.exportWalletResult?.exportBundle
-
-    if (!exportBundle) {
-      throw new Error('Export bundle not found in response')
-    }
-
-    return { exportBundle, walletId, organizationId }
-  } catch (_) {
-    throw new Error('Error exporting wallet')
+  const session = await wallet.getSession()
+  if (!session) {
+    throw new Error('Session not found')
   }
+  const { organizationId } = session
+
+  const listWalletsBody = JSON.stringify({
+    organizationId,
+  })
+
+  const listWalletsStamp =
+    await wallet.client[
+      session.stamperType === 'apiKey' ? 'apiKeyStamper' : 'passkeyStamper'
+    ].stamp(listWalletsBody)
+  if (!listWalletsStamp) {
+    throw new Error('Failed to stamp list wallets body')
+  }
+
+  const listWalletsResponse = await fetch(
+    'https://api.turnkey.com/public/v1/query/list_wallets',
+    {
+      method: 'POST',
+      body: listWalletsBody,
+      headers: {
+        [listWalletsStamp.stampHeaderName]: listWalletsStamp.stampHeaderValue,
+      },
+    },
+  )
+  if (!listWalletsResponse.ok) {
+    throw new Error('Failed to list wallets')
+  }
+  const listWalletsData = await listWalletsResponse.json()
+
+  const walletId = listWalletsData.wallets[0].walletId
+
+  const exportWalletBody = JSON.stringify({
+    type: 'ACTIVITY_TYPE_EXPORT_WALLET',
+    timestampMs: Date.now().toString(),
+    organizationId: organizationId,
+    parameters: {
+      walletId: walletId,
+      targetPublicKey,
+      language: 'MNEMONIC_LANGUAGE_ENGLISH',
+    },
+  })
+  const exportWalletStamp =
+    await wallet.client[
+      session.stamperType === 'apiKey' ? 'apiKeyStamper' : 'passkeyStamper'
+    ].stamp(exportWalletBody)
+  if (!exportWalletStamp) {
+    throw new Error('Failed to stamp export wallet body')
+  }
+  const exportWalletResponse = await fetch(
+    'https://api.turnkey.com/public/v1/submit/export_wallet',
+    {
+      method: 'POST',
+      body: exportWalletBody,
+      headers: {
+        [exportWalletStamp.stampHeaderName]: exportWalletStamp.stampHeaderValue,
+      },
+    },
+  )
+  if (!exportWalletResponse.ok) {
+    throw new Error('Failed to export wallet')
+  }
+  const exportWalletData = await exportWalletResponse.json()
+
+  const exportBundle =
+    exportWalletData?.activity?.result?.exportWalletResult?.exportBundle
+
+  if (!exportBundle) {
+    throw new Error('Export bundle not found in response')
+  }
+
+  return { exportBundle, walletId, organizationId }
 }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -227,25 +227,30 @@ type ZeroDevWalletConnectorParams = {
 ## React Native
 
 The connector works in React Native (Expo) with the same Wagmi setup, but the
-key-storage, passkey, and session-storage adapters that the web build defaults
-have no browser equivalent — so on native they're **required** (TypeScript
-enforces it):
+key-storage and session-storage adapters that the web build defaults have no
+browser equivalent — so on native `apiKeyStamper`, `sessionStorage`, and
+`rpId` are **required** (TypeScript enforces it). `passkeyStamper` is optional:
+omit it (and drop `@turnkey/react-native-passkey-stamper` from your install) if
+your app doesn't use passkey auth. Calling `useRegisterPasskey` /
+`useLoginPasskey` against a wallet configured without one throws an actionable
+error.
 
 ```bash
 npm install @zerodev/wallet-react @zerodev/wallet-core wagmi viem \
-  expo-secure-store @turnkey/react-native-passkey-stamper \
+  expo-secure-store \
   @turnkey/api-key-stamper @turnkey/crypto \
   @react-native-async-storage/async-storage \
   react-native-get-random-values uuid
+# Add @turnkey/react-native-passkey-stamper only if you want passkey auth.
 # or
 yarn add @zerodev/wallet-react @zerodev/wallet-core wagmi viem \
-  expo-secure-store @turnkey/react-native-passkey-stamper \
+  expo-secure-store \
   @turnkey/api-key-stamper @turnkey/crypto \
   @react-native-async-storage/async-storage \
   react-native-get-random-values uuid
 # or
 pnpm add @zerodev/wallet-react @zerodev/wallet-core wagmi viem \
-  expo-secure-store @turnkey/react-native-passkey-stamper \
+  expo-secure-store \
   @turnkey/api-key-stamper @turnkey/crypto \
   @react-native-async-storage/async-storage \
   react-native-get-random-values uuid
@@ -275,7 +280,7 @@ const config = createConfig({
       chains: [sepolia],
       rpId: RP_ID,
       apiKeyStamper: createSecureStoreStamper(),
-      passkeyStamper: createReactNativePasskeyStamper({ rpId: RP_ID }),
+      passkeyStamper: createReactNativePasskeyStamper({ rpId: RP_ID }), // optional
       sessionStorage: asyncStorageAdapter,
       persistStorage: asyncStorageAdapter, // persists the wagmi connection across restarts
     }),

--- a/packages/react/src/native/connector.ts
+++ b/packages/react/src/native/connector.ts
@@ -12,12 +12,14 @@ import {
 export type { WalletMode } from '../core/connector.js'
 
 /**
- * React Native connector params. The four adapter fields are required —
- * unlike web, RN has no platform-native defaults for them. `fetchOptions`
- * is dropped from the public surface; the wrapper derives it from `rpId`
- * so both the Turnkey transport and the AA bundler/paymaster transports
- * receive `Origin: https://${rpId}`. Power users who need a different
- * Origin can drop to `zeroDevWalletCore`.
+ * React Native connector params. `apiKeyStamper`, `sessionStorage`, and
+ * `rpId` are required — unlike web, RN has no platform-native defaults for
+ * them. `passkeyStamper` is optional: omit it if your app doesn't use
+ * passkey auth (calling `useRegisterPasskey`/`useLoginPasskey` without one
+ * throws an actionable error). `fetchOptions` is dropped from the public
+ * surface; the wrapper derives it from `rpId` so both the Turnkey transport
+ * and the AA bundler/paymaster transports receive `Origin: https://${rpId}`.
+ * Power users who need a different Origin can drop to `zeroDevWalletCore`.
  */
 export type ZeroDevWalletConnectorParams = Omit<
   ConnectorCoreParams,
@@ -29,7 +31,7 @@ export type ZeroDevWalletConnectorParams = Omit<
 > & {
   rpId: string
   apiKeyStamper: ApiKeyStamper | Promise<ApiKeyStamper>
-  passkeyStamper: PasskeyStamper | Promise<PasskeyStamper>
+  passkeyStamper?: PasskeyStamper | Promise<PasskeyStamper>
   sessionStorage: StorageAdapter
 }
 


### PR DESCRIPTION

Closes FS-2252, FS-2251

If users don't need passkey sign-in they shouldn't need to pass a `passkeyStamper` on React Native. This PR makes the `passkeyStamper` param optional on the `zeroDevWallet` connector and `createZeroDevWallet` function.
I added a `noopPasskeyStamper` which is passed inside the SDK if no `passkeyStamper` is passed from the configs. This throws a descriptive error asking the user to pass a real stamper. This way we also didn't need to make any modifications to the underlying code.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
