### PR TITLE
fix: encode large base64url buffers safely

### DIFF
--- a/packages/core/src/utils/utils.test.ts
+++ b/packages/core/src/utils/utils.test.ts
@@ -202,6 +202,17 @@ describe('base64UrlEncode', () => {
 
     expect(result).toBe('')
   })
+
+  it('encodes large buffers without exceeding the argument limit', () => {
+    const data = new Uint8Array(150_000)
+    for (let i = 0; i < data.length; i++) {
+      data[i] = i % 256
+    }
+
+    const result = base64UrlEncode(data.buffer)
+
+    expect(result).toBe(Buffer.from(data).toString('base64url'))
+  })
 })
 
 describe('pointEncode', () => {

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -70,7 +70,12 @@ export const generateRandomBuffer = (): ArrayBuffer => {
  */
 export const base64UrlEncode = (challenge: ArrayBuffer): string => {
   const bytes = new Uint8Array(challenge)
-  const binary = String.fromCharCode(...bytes)
+  let binary = ''
+
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!)
+  }
+
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
 }
 


### PR DESCRIPTION
## Summary
- avoid spreading every byte into `String.fromCharCode` when base64url-encoding buffers
- add coverage for encoding a large buffer that previously exceeded the JavaScript argument limit

## Why
`base64UrlEncode` is used for WebAuthn challenges and accepted any `ArrayBuffer`, but `String.fromCharCode(...bytes)` throws a `RangeError` once the buffer is large enough because it passes every byte as a function argument. Building the binary string incrementally keeps the behavior the same for normal inputs while avoiding that argument-limit failure.

## Test
- `corepack pnpm vitest run packages/core/src/utils/utils.test.ts`
- `corepack pnpm biome check packages/core/src/utils/utils.ts packages/core/src/utils/utils.test.ts`
