### PR TITLE
feat(react-kit): add `useSmartRoutingAddress` hook + connector config

### DIFF
--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -88,6 +88,7 @@
     "vocs": "^1.4.1"
   },
   "dependencies": {
+    "@zerodev/smart-routing-address": "^0.1.9",
     "clsx": "^2.1.1",
     "tailwind-merge": "^3.5.0"
   },

--- a/packages/react-kit/src/connector.ts
+++ b/packages/react-kit/src/connector.ts
@@ -8,6 +8,7 @@ import {
   NotAuthenticatedError,
 } from '@zerodev/wallet-react'
 import type { AuthConfig } from './auth/types'
+import type { SmartRoutingAddressConfig } from './smart-routing/types'
 import { createStore } from './store.js'
 import type { Request, RequestMethod } from './types.js'
 
@@ -26,6 +27,7 @@ export type SigningConfig =
 export type ZeroDevKitConfig = {
   signing?: SigningConfig
   auth?: AuthConfig
+  smartRoutingAddress?: SmartRoutingAddressConfig
 }
 
 export type ZeroDevKitConnectorParams = ZeroDevWalletConnectorParams & {
@@ -78,6 +80,11 @@ export function zeroDevWallet(
   // Initialize auth config if provided
   if (params.config?.auth) {
     store.getState().auth.initialize(params.config.auth)
+  }
+
+  // Initialize smart routing address config if provided
+  if (params.config?.smartRoutingAddress) {
+    store.getState().smartRouting.initialize(params.config.smartRoutingAddress)
   }
 
   return (wagmiConfig) => {

--- a/packages/react-kit/src/index.ts
+++ b/packages/react-kit/src/index.ts
@@ -25,7 +25,7 @@ export { usePendingRequests } from './signing/hooks/usePendingRequests.js'
 // Smart Routing Address
 export type {
   SmartRoutingAddressConfig,
-  SmartRoutingAddressOverrides,
+  UseSmartRoutingAddressParams,
 } from './smart-routing/types.js'
 export { useSmartRoutingAddress } from './smart-routing/useSmartRoutingAddress.js'
 

--- a/packages/react-kit/src/index.ts
+++ b/packages/react-kit/src/index.ts
@@ -22,4 +22,11 @@ export { SignatureRequest } from './signing'
 export { usePendingRequest } from './signing/hooks/usePendingRequest.js'
 export { usePendingRequests } from './signing/hooks/usePendingRequests.js'
 
+// Smart Routing Address
+export type {
+  SmartRoutingAddressConfig,
+  SmartRoutingAddressOverrides,
+} from './smart-routing/types.js'
+export { useSmartRoutingAddress } from './smart-routing/useSmartRoutingAddress.js'
+
 export type { PendingRequest, Request, RequestMethod } from './types.js'

--- a/packages/react-kit/src/smart-routing/smartRoutingStoreSlice.ts
+++ b/packages/react-kit/src/smart-routing/smartRoutingStoreSlice.ts
@@ -1,0 +1,25 @@
+import type { StateCreator } from 'zustand'
+import type { SmartRoutingAddressConfig } from './types'
+
+export interface SmartRoutingStoreSlice {
+  smartRouting: {
+    config: SmartRoutingAddressConfig | null
+    initialize: (config: SmartRoutingAddressConfig) => void
+  }
+}
+
+export const createSmartRoutingStoreSlice: StateCreator<
+  SmartRoutingStoreSlice,
+  [],
+  [],
+  SmartRoutingStoreSlice
+> = (set) => ({
+  smartRouting: {
+    config: null,
+    initialize: (config: SmartRoutingAddressConfig) => {
+      set((state) => ({
+        smartRouting: { ...state.smartRouting, config },
+      }))
+    },
+  },
+})

--- a/packages/react-kit/src/smart-routing/types.ts
+++ b/packages/react-kit/src/smart-routing/types.ts
@@ -1,0 +1,43 @@
+import type { CreateSmartRoutingAddressParams } from '@zerodev/smart-routing-address'
+import type { Address, Chain } from 'viem'
+
+/**
+ * Connector-level config for the Smart Routing Address (SRA) feature.
+ * Consumers pass this on `zeroDevWallet({ config: { smartRoutingAddress: ... } })`.
+ *
+ * All fields are optional; per-call overrides on the hook / components win
+ * over these defaults.
+ */
+export interface SmartRoutingAddressConfig {
+  /**
+   * When false, the SRA UI / hook short-circuits (returns nothing). Defaults
+   * to true if the `smartRoutingAddress` block is present at all.
+   */
+  enabled?: boolean
+  /**
+   * Maximum slippage in basis points (BPS). Default: `100` (1%).
+   */
+  maxSlippage?: number
+  /**
+   * Destination chains the user can route funds to. The first entry is used
+   * as the default destination when the consumer does not override it.
+   */
+  destinationChains?: Chain[]
+  /**
+   * Source chains the user can fund from. Surfaced by `<ChainSelector>` in
+   * the SRA card.
+   */
+  sourceChains?: Chain[]
+}
+
+/**
+ * Per-call overrides accepted by `useSmartRoutingAddress` and the SRA card.
+ * Anything passed here takes precedence over the connector config.
+ */
+export interface SmartRoutingAddressOverrides {
+  owner?: Address
+  destChain?: CreateSmartRoutingAddressParams['destChain']
+  srcTokens?: CreateSmartRoutingAddressParams['srcTokens']
+  maxSlippage?: number
+  actions?: CreateSmartRoutingAddressParams['actions']
+}

--- a/packages/react-kit/src/smart-routing/types.ts
+++ b/packages/react-kit/src/smart-routing/types.ts
@@ -44,9 +44,4 @@ export interface UseSmartRoutingAddressParams {
   srcTokens: NonNullable<CreateSmartRoutingAddressParams['srcTokens']>
   /** Maximum slippage in basis points. Defaults to `100` (1%). */
   slippage?: number
-  /**
-   * Override the per-tokenType action map. Defaults to NATIVE + ERC-20
-   * deposit-to-owner actions built per unique src `tokenType`.
-   */
-  actions?: CreateSmartRoutingAddressParams['actions']
 }

--- a/packages/react-kit/src/smart-routing/types.ts
+++ b/packages/react-kit/src/smart-routing/types.ts
@@ -2,42 +2,51 @@ import type { CreateSmartRoutingAddressParams } from '@zerodev/smart-routing-add
 import type { Address, Chain } from 'viem'
 
 /**
+ * Steps in the Smart Routing Address flow. Mirrors the `AuthStep` pattern:
+ * the entry component dispatches each step to its page, and steps push/pop
+ * a history so the TopNav back button works.
+ */
+export type SmartRoutingStep = 'transfer-from-wallet'
+
+/**
  * Connector-level config for the Smart Routing Address (SRA) feature.
  * Consumers pass this on `zeroDevWallet({ config: { smartRoutingAddress: ... } })`.
  *
- * All fields are optional; per-call overrides on the hook / components win
- * over these defaults.
+ * Fields here are *UI metadata + feature flag*, not defaults for the hook.
+ * Per-call params on `useSmartRoutingAddress` are not derived from this.
  */
 export interface SmartRoutingAddressConfig {
   /**
-   * When false, the SRA UI / hook short-circuits (returns nothing). Defaults
-   * to true if the `smartRoutingAddress` block is present at all.
+   * When false, `useSmartRoutingAddress` short-circuits (query disabled).
+   * Defaults to `true` if the `smartRoutingAddress` block is present at all.
    */
   enabled?: boolean
   /**
-   * Maximum slippage in basis points (BPS). Default: `100` (1%).
-   */
-  maxSlippage?: number
-  /**
-   * Destination chains the user can route funds to. The first entry is used
-   * as the default destination when the consumer does not override it.
+   * Destination chains the SRA UI may surface (e.g. in a chain selector).
+   * Informational — the hook requires an explicit `destChain` per call.
    */
   destinationChains?: Chain[]
   /**
-   * Source chains the user can fund from. Surfaced by `<ChainSelector>` in
-   * the SRA card.
+   * Source chains the SRA UI may surface (e.g. in a chain selector).
+   * Informational — the hook requires explicit `srcTokens` per call.
    */
   sourceChains?: Chain[]
 }
 
 /**
- * Per-call overrides accepted by `useSmartRoutingAddress` and the SRA card.
- * Anything passed here takes precedence over the connector config.
+ * Inputs to `useSmartRoutingAddress`. All three core fields are required —
+ * the hook computes a Smart Routing Address from exactly what's passed in
+ * and doesn't infer defaults from wagmi state or the connector config.
  */
-export interface SmartRoutingAddressOverrides {
-  owner?: Address
-  destChain?: CreateSmartRoutingAddressParams['destChain']
-  srcTokens?: CreateSmartRoutingAddressParams['srcTokens']
-  maxSlippage?: number
+export interface UseSmartRoutingAddressParams {
+  owner: Address
+  destChain: CreateSmartRoutingAddressParams['destChain']
+  srcTokens: NonNullable<CreateSmartRoutingAddressParams['srcTokens']>
+  /** Maximum slippage in basis points. Defaults to `100` (1%). */
+  slippage?: number
+  /**
+   * Override the per-tokenType action map. Defaults to NATIVE + ERC-20
+   * deposit-to-owner actions built per unique src `tokenType`.
+   */
   actions?: CreateSmartRoutingAddressParams['actions']
 }

--- a/packages/react-kit/src/smart-routing/useSmartRoutingAddress.test.tsx
+++ b/packages/react-kit/src/smart-routing/useSmartRoutingAddress.test.tsx
@@ -36,15 +36,9 @@ const mockConfig = {
     getKitStore?: () => unknown
   }>,
 }
-let mockChainId = mainnet.id
-const mockChains = [mainnet, optimism]
-const mockAccount = { address: WALLET as `0x${string}` | undefined }
 
 vi.mock('wagmi', () => ({
   useConfig: () => mockConfig,
-  useAccount: () => mockAccount,
-  useChainId: () => mockChainId,
-  useChains: () => mockChains,
 }))
 
 function makeWrapper() {
@@ -56,11 +50,15 @@ function makeWrapper() {
   )
 }
 
+const baseParams = {
+  owner: WALLET,
+  destChain: mainnet,
+  srcTokens: [{ tokenType: 'USDC' as const, chain: optimism }],
+}
+
 beforeEach(() => {
   mockCreateSmartRoutingAddress.mockReset()
   mockCreateCall.mockClear()
-  mockChainId = mainnet.id
-  mockAccount.address = WALLET
   mockConfig.connectors = [mockConnector]
   mockConnector.getKitStore.mockReset()
 })
@@ -74,7 +72,7 @@ describe('useSmartRoutingAddress', () => {
     mockConfig.connectors = []
     const wrapper = makeWrapper()
     expect(() =>
-      renderHook(() => useSmartRoutingAddress(), { wrapper }),
+      renderHook(() => useSmartRoutingAddress(baseParams), { wrapper }),
     ).toThrow(
       /useSmartRoutingAddress must be used with zeroDevWallet connector/,
     )
@@ -85,13 +83,7 @@ describe('useSmartRoutingAddress', () => {
     mockConnector.getKitStore.mockReturnValue(store)
 
     const wrapper = makeWrapper()
-    renderHook(
-      () =>
-        useSmartRoutingAddress({
-          srcTokens: [{ tokenType: 'ERC20', chain: optimism }],
-        }),
-      { wrapper },
-    )
+    renderHook(() => useSmartRoutingAddress(baseParams), { wrapper })
 
     expect(mockCreateSmartRoutingAddress).not.toHaveBeenCalled()
   })
@@ -102,43 +94,31 @@ describe('useSmartRoutingAddress', () => {
     mockConnector.getKitStore.mockReturnValue(store)
 
     const wrapper = makeWrapper()
-    renderHook(
-      () =>
-        useSmartRoutingAddress({
-          srcTokens: [{ tokenType: 'ERC20', chain: optimism }],
-        }),
-      { wrapper },
-    )
+    renderHook(() => useSmartRoutingAddress(baseParams), { wrapper })
 
     expect(mockCreateSmartRoutingAddress).not.toHaveBeenCalled()
   })
 
-  it('does not fire when srcTokens is empty', () => {
-    const store = createStore()
-    store.getState().smartRouting.initialize({})
-    mockConnector.getKitStore.mockReturnValue(store)
-
-    const wrapper = makeWrapper()
-    renderHook(() => useSmartRoutingAddress({ srcTokens: [] }), { wrapper })
-
-    expect(mockCreateSmartRoutingAddress).not.toHaveBeenCalled()
-  })
-
-  it('computes the SRA with connector defaults (owner, destChain, slippage, actions)', async () => {
+  it('forwards inputs verbatim and applies the default slippage + actions', async () => {
     mockCreateSmartRoutingAddress.mockResolvedValue({
       smartRoutingAddress: '0xSRA',
       estimatedFees: [],
     })
 
     const store = createStore()
-    store.getState().smartRouting.initialize({}) // no overrides; defaults take over
+    store.getState().smartRouting.initialize({})
     mockConnector.getKitStore.mockReturnValue(store)
 
     const wrapper = makeWrapper()
     const { result } = renderHook(
       () =>
         useSmartRoutingAddress({
-          srcTokens: [{ tokenType: 'ERC20', chain: optimism }],
+          owner: WALLET,
+          destChain: mainnet,
+          srcTokens: [
+            { tokenType: 'NATIVE', chain: optimism },
+            { tokenType: 'USDC', chain: optimism },
+          ],
         }),
       { wrapper },
     )
@@ -149,92 +129,48 @@ describe('useSmartRoutingAddress', () => {
 
     const args = mockCreateSmartRoutingAddress.mock.calls[0]?.[0]
     expect(args.owner).toBe(WALLET)
-    expect(args.destChain.id).toBe(mainnet.id) // matches useChainId default
-    expect(args.slippage).toBe(100) // default 1%
+    expect(args.destChain.id).toBe(mainnet.id)
+    expect(args.slippage).toBe(100) // hook default
     expect(args.actions).toBeDefined()
+    // Actions are built per unique src tokenType.
     expect(args.actions.NATIVE).toBeDefined()
-    expect(args.actions.ERC20).toBeDefined()
+    expect(args.actions.USDC).toBeDefined()
+    expect(args.actions.ERC20).toBeUndefined()
   })
 
-  it('uses the first destinationChains entry from connector config as destChain', async () => {
+  it('honors explicit slippage and actions overrides', async () => {
     mockCreateSmartRoutingAddress.mockResolvedValue({
       smartRoutingAddress: '0xSRA',
       estimatedFees: [],
     })
-
-    const store = createStore()
-    store
-      .getState()
-      .smartRouting.initialize({ destinationChains: [optimism, mainnet] })
-    mockConnector.getKitStore.mockReturnValue(store)
-
-    const wrapper = makeWrapper()
-    renderHook(
-      () =>
-        useSmartRoutingAddress({
-          srcTokens: [{ tokenType: 'ERC20', chain: mainnet }],
-        }),
-      { wrapper },
-    )
-
-    await waitFor(() => {
-      expect(mockCreateSmartRoutingAddress).toHaveBeenCalledTimes(1)
-    })
-    const args = mockCreateSmartRoutingAddress.mock.calls[0]?.[0]
-    expect(args.destChain.id).toBe(optimism.id)
-  })
-
-  it('per-call overrides win over connector config defaults', async () => {
-    mockCreateSmartRoutingAddress.mockResolvedValue({
-      smartRoutingAddress: '0xSRA',
-      estimatedFees: [],
-    })
-
-    const store = createStore()
-    store.getState().smartRouting.initialize({
-      maxSlippage: 50,
-      destinationChains: [mainnet],
-    })
-    mockConnector.getKitStore.mockReturnValue(store)
-
-    const wrapper = makeWrapper()
-    const customOwner = '0x2222222222222222222222222222222222222222' as const
-    renderHook(
-      () =>
-        useSmartRoutingAddress({
-          owner: customOwner,
-          destChain: optimism,
-          maxSlippage: 200,
-          srcTokens: [{ tokenType: 'NATIVE', chain: mainnet }],
-        }),
-      { wrapper },
-    )
-
-    await waitFor(() => {
-      expect(mockCreateSmartRoutingAddress).toHaveBeenCalledTimes(1)
-    })
-    const args = mockCreateSmartRoutingAddress.mock.calls[0]?.[0]
-    expect(args.owner).toBe(customOwner)
-    expect(args.destChain.id).toBe(optimism.id)
-    expect(args.slippage).toBe(200)
-  })
-
-  it('does not fire when no wallet is connected', () => {
-    mockAccount.address = undefined
 
     const store = createStore()
     store.getState().smartRouting.initialize({})
     mockConnector.getKitStore.mockReturnValue(store)
 
+    const customActions = {
+      NATIVE: { action: [{ __custom: true }], fallBack: [] },
+    } as never
+
     const wrapper = makeWrapper()
     renderHook(
       () =>
         useSmartRoutingAddress({
-          srcTokens: [{ tokenType: 'ERC20', chain: optimism }],
+          owner: WALLET,
+          destChain: optimism,
+          srcTokens: [{ tokenType: 'NATIVE', chain: mainnet }],
+          slippage: 200,
+          actions: customActions,
         }),
       { wrapper },
     )
 
-    expect(mockCreateSmartRoutingAddress).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(mockCreateSmartRoutingAddress).toHaveBeenCalledTimes(1)
+    })
+    const args = mockCreateSmartRoutingAddress.mock.calls[0]?.[0]
+    expect(args.destChain.id).toBe(optimism.id)
+    expect(args.slippage).toBe(200)
+    expect(args.actions).toBe(customActions)
   })
 })

--- a/packages/react-kit/src/smart-routing/useSmartRoutingAddress.test.tsx
+++ b/packages/react-kit/src/smart-routing/useSmartRoutingAddress.test.tsx
@@ -11,18 +11,20 @@ import { createStore } from '../store'
 import { useSmartRoutingAddress } from './useSmartRoutingAddress'
 
 const mockCreateSmartRoutingAddress = vi.fn()
-const mockCreateCall = vi.fn((args) => ({ __call: args }))
 
-vi.mock('@zerodev/smart-routing-address', () => ({
-  createSmartRoutingAddress: (params: unknown) =>
-    mockCreateSmartRoutingAddress(params),
-  createCall: (args: unknown) => mockCreateCall(args),
-  FLEX: {
-    TOKEN_ADDRESS: 'TOKEN_ADDRESS',
-    AMOUNT: 'AMOUNT',
-    NATIVE_AMOUNT: 'NATIVE_AMOUNT',
-  },
-}))
+// Mock only the network-touching call. `createCall` and `FLEX` are pure
+// helpers/constants — using the real ones keeps the test honest, otherwise
+// we'd be asserting against our own mock's behavior.
+vi.mock('@zerodev/smart-routing-address', async () => {
+  const actual = await vi.importActual<
+    typeof import('@zerodev/smart-routing-address')
+  >('@zerodev/smart-routing-address')
+  return {
+    ...actual,
+    createSmartRoutingAddress: (params: unknown) =>
+      mockCreateSmartRoutingAddress(params),
+  }
+})
 
 const WALLET = '0x1111111111111111111111111111111111111111' as const
 
@@ -58,7 +60,6 @@ const baseParams = {
 
 beforeEach(() => {
   mockCreateSmartRoutingAddress.mockReset()
-  mockCreateCall.mockClear()
   mockConfig.connectors = [mockConnector]
   mockConnector.getKitStore.mockReset()
 })

--- a/packages/react-kit/src/smart-routing/useSmartRoutingAddress.test.tsx
+++ b/packages/react-kit/src/smart-routing/useSmartRoutingAddress.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { mainnet, optimism } from 'viem/chains'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createStore } from '../store'
+import { useSmartRoutingAddress } from './useSmartRoutingAddress'
+
+const mockCreateSmartRoutingAddress = vi.fn()
+const mockCreateCall = vi.fn((args) => ({ __call: args }))
+
+vi.mock('@zerodev/smart-routing-address', () => ({
+  createSmartRoutingAddress: (params: unknown) =>
+    mockCreateSmartRoutingAddress(params),
+  createCall: (args: unknown) => mockCreateCall(args),
+  FLEX: {
+    TOKEN_ADDRESS: 'TOKEN_ADDRESS',
+    AMOUNT: 'AMOUNT',
+    NATIVE_AMOUNT: 'NATIVE_AMOUNT',
+  },
+}))
+
+const WALLET = '0x1111111111111111111111111111111111111111' as const
+
+const mockConnector = {
+  id: 'zerodev-wallet',
+  getKitStore: vi.fn(),
+}
+const mockConfig = {
+  connectors: [mockConnector] as Array<{
+    id: string
+    getKitStore?: () => unknown
+  }>,
+}
+let mockChainId = mainnet.id
+const mockChains = [mainnet, optimism]
+const mockAccount = { address: WALLET as `0x${string}` | undefined }
+
+vi.mock('wagmi', () => ({
+  useConfig: () => mockConfig,
+  useAccount: () => mockAccount,
+  useChainId: () => mockChainId,
+  useChains: () => mockChains,
+}))
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  mockCreateSmartRoutingAddress.mockReset()
+  mockCreateCall.mockClear()
+  mockChainId = mainnet.id
+  mockAccount.address = WALLET
+  mockConfig.connectors = [mockConnector]
+  mockConnector.getKitStore.mockReset()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('useSmartRoutingAddress', () => {
+  it('throws when used outside the kit connector', () => {
+    mockConfig.connectors = []
+    const wrapper = makeWrapper()
+    expect(() =>
+      renderHook(() => useSmartRoutingAddress(), { wrapper }),
+    ).toThrow(
+      /useSmartRoutingAddress must be used with zeroDevWallet connector/,
+    )
+  })
+
+  it('does not fire the query when no SRA config is set', () => {
+    const store = createStore()
+    mockConnector.getKitStore.mockReturnValue(store)
+
+    const wrapper = makeWrapper()
+    renderHook(
+      () =>
+        useSmartRoutingAddress({
+          srcTokens: [{ tokenType: 'ERC20', chain: optimism }],
+        }),
+      { wrapper },
+    )
+
+    expect(mockCreateSmartRoutingAddress).not.toHaveBeenCalled()
+  })
+
+  it('does not fire when explicitly disabled', () => {
+    const store = createStore()
+    store.getState().smartRouting.initialize({ enabled: false })
+    mockConnector.getKitStore.mockReturnValue(store)
+
+    const wrapper = makeWrapper()
+    renderHook(
+      () =>
+        useSmartRoutingAddress({
+          srcTokens: [{ tokenType: 'ERC20', chain: optimism }],
+        }),
+      { wrapper },
+    )
+
+    expect(mockCreateSmartRoutingAddress).not.toHaveBeenCalled()
+  })
+
+  it('does not fire when srcTokens is empty', () => {
+    const store = createStore()
+    store.getState().smartRouting.initialize({})
+    mockConnector.getKitStore.mockReturnValue(store)
+
+    const wrapper = makeWrapper()
+    renderHook(() => useSmartRoutingAddress({ srcTokens: [] }), { wrapper })
+
+    expect(mockCreateSmartRoutingAddress).not.toHaveBeenCalled()
+  })
+
+  it('computes the SRA with connector defaults (owner, destChain, slippage, actions)', async () => {
+    mockCreateSmartRoutingAddress.mockResolvedValue({
+      smartRoutingAddress: '0xSRA',
+      estimatedFees: [],
+    })
+
+    const store = createStore()
+    store.getState().smartRouting.initialize({}) // no overrides; defaults take over
+    mockConnector.getKitStore.mockReturnValue(store)
+
+    const wrapper = makeWrapper()
+    const { result } = renderHook(
+      () =>
+        useSmartRoutingAddress({
+          srcTokens: [{ tokenType: 'ERC20', chain: optimism }],
+        }),
+      { wrapper },
+    )
+
+    await waitFor(() => {
+      expect(result.current.data?.smartRoutingAddress).toBe('0xSRA')
+    })
+
+    const args = mockCreateSmartRoutingAddress.mock.calls[0]?.[0]
+    expect(args.owner).toBe(WALLET)
+    expect(args.destChain.id).toBe(mainnet.id) // matches useChainId default
+    expect(args.slippage).toBe(100) // default 1%
+    expect(args.actions).toBeDefined()
+    expect(args.actions.NATIVE).toBeDefined()
+    expect(args.actions.ERC20).toBeDefined()
+  })
+
+  it('uses the first destinationChains entry from connector config as destChain', async () => {
+    mockCreateSmartRoutingAddress.mockResolvedValue({
+      smartRoutingAddress: '0xSRA',
+      estimatedFees: [],
+    })
+
+    const store = createStore()
+    store
+      .getState()
+      .smartRouting.initialize({ destinationChains: [optimism, mainnet] })
+    mockConnector.getKitStore.mockReturnValue(store)
+
+    const wrapper = makeWrapper()
+    renderHook(
+      () =>
+        useSmartRoutingAddress({
+          srcTokens: [{ tokenType: 'ERC20', chain: mainnet }],
+        }),
+      { wrapper },
+    )
+
+    await waitFor(() => {
+      expect(mockCreateSmartRoutingAddress).toHaveBeenCalledTimes(1)
+    })
+    const args = mockCreateSmartRoutingAddress.mock.calls[0]?.[0]
+    expect(args.destChain.id).toBe(optimism.id)
+  })
+
+  it('per-call overrides win over connector config defaults', async () => {
+    mockCreateSmartRoutingAddress.mockResolvedValue({
+      smartRoutingAddress: '0xSRA',
+      estimatedFees: [],
+    })
+
+    const store = createStore()
+    store.getState().smartRouting.initialize({
+      maxSlippage: 50,
+      destinationChains: [mainnet],
+    })
+    mockConnector.getKitStore.mockReturnValue(store)
+
+    const wrapper = makeWrapper()
+    const customOwner = '0x2222222222222222222222222222222222222222' as const
+    renderHook(
+      () =>
+        useSmartRoutingAddress({
+          owner: customOwner,
+          destChain: optimism,
+          maxSlippage: 200,
+          srcTokens: [{ tokenType: 'NATIVE', chain: mainnet }],
+        }),
+      { wrapper },
+    )
+
+    await waitFor(() => {
+      expect(mockCreateSmartRoutingAddress).toHaveBeenCalledTimes(1)
+    })
+    const args = mockCreateSmartRoutingAddress.mock.calls[0]?.[0]
+    expect(args.owner).toBe(customOwner)
+    expect(args.destChain.id).toBe(optimism.id)
+    expect(args.slippage).toBe(200)
+  })
+
+  it('does not fire when no wallet is connected', () => {
+    mockAccount.address = undefined
+
+    const store = createStore()
+    store.getState().smartRouting.initialize({})
+    mockConnector.getKitStore.mockReturnValue(store)
+
+    const wrapper = makeWrapper()
+    renderHook(
+      () =>
+        useSmartRoutingAddress({
+          srcTokens: [{ tokenType: 'ERC20', chain: optimism }],
+        }),
+      { wrapper },
+    )
+
+    expect(mockCreateSmartRoutingAddress).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react-kit/src/smart-routing/useSmartRoutingAddress.test.tsx
+++ b/packages/react-kit/src/smart-routing/useSmartRoutingAddress.test.tsx
@@ -100,7 +100,7 @@ describe('useSmartRoutingAddress', () => {
     expect(mockCreateSmartRoutingAddress).not.toHaveBeenCalled()
   })
 
-  it('forwards inputs verbatim and applies the default slippage + actions', async () => {
+  it('forwards inputs verbatim and applies the default slippage + builds actions per src tokenType', async () => {
     mockCreateSmartRoutingAddress.mockResolvedValue({
       smartRoutingAddress: '0xSRA',
       estimatedFees: [],
@@ -139,7 +139,7 @@ describe('useSmartRoutingAddress', () => {
     expect(args.actions.ERC20).toBeUndefined()
   })
 
-  it('honors explicit slippage and actions overrides', async () => {
+  it('honors explicit slippage overrides', async () => {
     mockCreateSmartRoutingAddress.mockResolvedValue({
       smartRoutingAddress: '0xSRA',
       estimatedFees: [],
@@ -149,10 +149,6 @@ describe('useSmartRoutingAddress', () => {
     store.getState().smartRouting.initialize({})
     mockConnector.getKitStore.mockReturnValue(store)
 
-    const customActions = {
-      NATIVE: { action: [{ __custom: true }], fallBack: [] },
-    } as never
-
     const wrapper = makeWrapper()
     renderHook(
       () =>
@@ -161,7 +157,6 @@ describe('useSmartRoutingAddress', () => {
           destChain: optimism,
           srcTokens: [{ tokenType: 'NATIVE', chain: mainnet }],
           slippage: 200,
-          actions: customActions,
         }),
       { wrapper },
     )
@@ -172,6 +167,5 @@ describe('useSmartRoutingAddress', () => {
     const args = mockCreateSmartRoutingAddress.mock.calls[0]?.[0]
     expect(args.destChain.id).toBe(optimism.id)
     expect(args.slippage).toBe(200)
-    expect(args.actions).toBe(customActions)
   })
 })

--- a/packages/react-kit/src/smart-routing/useSmartRoutingAddress.ts
+++ b/packages/react-kit/src/smart-routing/useSmartRoutingAddress.ts
@@ -1,0 +1,125 @@
+import { useQuery } from '@tanstack/react-query'
+import {
+  type CreateSmartRoutingAddressParams,
+  createCall,
+  createSmartRoutingAddress,
+  FLEX,
+} from '@zerodev/smart-routing-address'
+import { type Address, erc20Abi } from 'viem'
+import { useAccount, useChainId, useChains, useConfig } from 'wagmi'
+import { useStore } from 'zustand'
+import type { createStore } from '../store'
+import type {
+  SmartRoutingAddressConfig,
+  SmartRoutingAddressOverrides,
+} from './types'
+
+type Store = ReturnType<typeof createStore>
+
+const DEFAULT_SLIPPAGE_BPS = 100 // 1%
+
+function getKitStore(config: ReturnType<typeof useConfig>): Store | null {
+  const connector = config.connectors.find((c) => c.id === 'zerodev-wallet')
+  if (!connector || !('getKitStore' in connector)) return null
+  // @ts-expect-error - getKitStore is a custom method on the kit connector
+  return connector.getKitStore()
+}
+
+function buildDefaultActions(
+  owner: Address,
+): CreateSmartRoutingAddressParams['actions'] {
+  const nativeCall = createCall({
+    target: owner,
+    value: FLEX.NATIVE_AMOUNT,
+  })
+  const erc20Call = createCall({
+    target: FLEX.TOKEN_ADDRESS,
+    value: 0n,
+    abi: erc20Abi,
+    functionName: 'transfer',
+    args: [owner, FLEX.AMOUNT],
+  })
+  return {
+    NATIVE: { action: [nativeCall], fallBack: [] },
+    ERC20: { action: [erc20Call], fallBack: [] },
+  }
+}
+
+/**
+ * Computes a Smart Routing Address from the connector's `smartRoutingAddress`
+ * config and optional per-call overrides. Returns a React Query state object.
+ *
+ * Defaults applied when `overrides` does not specify them:
+ *   - `owner`: connected wallet address (`useAccount`)
+ *   - `destChain`: first chain in `config.destinationChains`, else the chain
+ *      matching the wallet's current `chainId` (`useChainId`/`useChains`)
+ *   - `maxSlippage`: `config.maxSlippage`, else 100 BPS (1%)
+ *   - `actions`: NATIVE + ERC-20 deposit-to-owner (mirror of doorway)
+ *
+ * The query is disabled when the feature is not enabled, when no owner is
+ * connected, when no destination chain is resolvable, or when `srcTokens` is
+ * empty — in those cases the hook returns `{ data: undefined, isPending: false }`.
+ */
+export function useSmartRoutingAddress(
+  overrides: SmartRoutingAddressOverrides = {},
+) {
+  const wagmiConfig = useConfig()
+  const store = getKitStore(wagmiConfig)
+  if (!store) {
+    throw new Error(
+      'useSmartRoutingAddress must be used with zeroDevWallet connector',
+    )
+  }
+
+  const config = useStore(
+    store,
+    (state) => state.smartRouting.config,
+  ) as SmartRoutingAddressConfig | null
+
+  const { address: connectedAddress } = useAccount()
+  const currentChainId = useChainId()
+  const availableChains = useChains()
+
+  const owner = overrides.owner ?? connectedAddress
+  const destChain =
+    overrides.destChain ??
+    config?.destinationChains?.[0] ??
+    availableChains.find((c) => c.id === currentChainId)
+  const slippage =
+    overrides.maxSlippage ?? config?.maxSlippage ?? DEFAULT_SLIPPAGE_BPS
+  const srcTokens = overrides.srcTokens
+  const actions =
+    overrides.actions ?? (owner ? buildDefaultActions(owner) : undefined)
+
+  const enabled =
+    config?.enabled !== false &&
+    !!config &&
+    !!owner &&
+    !!destChain &&
+    !!srcTokens &&
+    srcTokens.length > 0 &&
+    !!actions
+
+  return useQuery({
+    queryKey: [
+      'zerodev-wallet-kit',
+      'smartRoutingAddress',
+      owner,
+      destChain?.id,
+      slippage,
+      srcTokens?.map((t) => [t.tokenType, t.chain.id, t.minAmount?.toString()]),
+    ],
+    enabled,
+    queryFn: async () => {
+      if (!owner || !destChain || !srcTokens || !actions) return null
+      return createSmartRoutingAddress({
+        owner,
+        destChain,
+        slippage,
+        srcTokens,
+        actions,
+      })
+    },
+    meta: { persist: false },
+  })
+}

--- a/packages/react-kit/src/smart-routing/useSmartRoutingAddress.ts
+++ b/packages/react-kit/src/smart-routing/useSmartRoutingAddress.ts
@@ -6,13 +6,10 @@ import {
   FLEX,
 } from '@zerodev/smart-routing-address'
 import { type Address, erc20Abi } from 'viem'
-import { useAccount, useChainId, useChains, useConfig } from 'wagmi'
+import { useConfig } from 'wagmi'
 import { useStore } from 'zustand'
 import type { createStore } from '../store'
-import type {
-  SmartRoutingAddressConfig,
-  SmartRoutingAddressOverrides,
-} from './types'
+import type { UseSmartRoutingAddressParams } from './types'
 
 type Store = ReturnType<typeof createStore>
 
@@ -27,6 +24,7 @@ function getKitStore(config: ReturnType<typeof useConfig>): Store | null {
 
 function buildDefaultActions(
   owner: Address,
+  srcTokens: UseSmartRoutingAddressParams['srcTokens'],
 ): CreateSmartRoutingAddressParams['actions'] {
   const nativeCall = createCall({
     target: owner,
@@ -39,30 +37,35 @@ function buildDefaultActions(
     functionName: 'transfer',
     args: [owner, FLEX.AMOUNT],
   })
-  return {
-    NATIVE: { action: [nativeCall], fallBack: [] },
-    ERC20: { action: [erc20Call], fallBack: [] },
+  // Build one action per unique src tokenType. Across needs to know the
+  // concrete token on the destination chain; using a generic "ERC20" key
+  // would resolve to a FLEX placeholder (0xff…ff) and fail simulation.
+  const actions: CreateSmartRoutingAddressParams['actions'] = {}
+  const seen = new Set<string>()
+  for (const { tokenType } of srcTokens) {
+    if (seen.has(tokenType)) continue
+    seen.add(tokenType)
+    actions[tokenType] =
+      tokenType === 'NATIVE'
+        ? { action: [nativeCall], fallBack: [] }
+        : { action: [erc20Call], fallBack: [] }
   }
+  return actions
 }
 
 /**
- * Computes a Smart Routing Address from the connector's `smartRoutingAddress`
- * config and optional per-call overrides. Returns a React Query state object.
+ * Computes a Smart Routing Address. Returns a React Query result.
  *
- * Defaults applied when `overrides` does not specify them:
- *   - `owner`: connected wallet address (`useAccount`)
- *   - `destChain`: first chain in `config.destinationChains`, else the chain
- *      matching the wallet's current `chainId` (`useChainId`/`useChains`)
- *   - `maxSlippage`: `config.maxSlippage`, else 100 BPS (1%)
- *   - `actions`: NATIVE + ERC-20 deposit-to-owner (mirror of doorway)
- *
- * The query is disabled when the feature is not enabled, when no owner is
- * connected, when no destination chain is resolvable, or when `srcTokens` is
- * empty — in those cases the hook returns `{ data: undefined, isPending: false }`.
+ * The query is disabled when the SRA feature flag is off
+ * (`config.smartRoutingAddress.enabled === false`).
  */
-export function useSmartRoutingAddress(
-  overrides: SmartRoutingAddressOverrides = {},
-) {
+export function useSmartRoutingAddress({
+  owner,
+  destChain,
+  srcTokens,
+  slippage = DEFAULT_SLIPPAGE_BPS,
+  actions,
+}: UseSmartRoutingAddressParams) {
   const wagmiConfig = useConfig()
   const store = getKitStore(wagmiConfig)
   if (!store) {
@@ -71,54 +74,36 @@ export function useSmartRoutingAddress(
     )
   }
 
-  const config = useStore(
-    store,
-    (state) => state.smartRouting.config,
-  ) as SmartRoutingAddressConfig | null
+  const config = useStore(store, (state) => state.smartRouting.config)
+  const enabled = !!config && config.enabled !== false
 
-  const { address: connectedAddress } = useAccount()
-  const currentChainId = useChainId()
-  const availableChains = useChains()
-
-  const owner = overrides.owner ?? connectedAddress
-  const destChain =
-    overrides.destChain ??
-    config?.destinationChains?.[0] ??
-    availableChains.find((c) => c.id === currentChainId)
-  const slippage =
-    overrides.maxSlippage ?? config?.maxSlippage ?? DEFAULT_SLIPPAGE_BPS
-  const srcTokens = overrides.srcTokens
-  const actions =
-    overrides.actions ?? (owner ? buildDefaultActions(owner) : undefined)
-
-  const enabled =
-    config?.enabled !== false &&
-    !!config &&
-    !!owner &&
-    !!destChain &&
-    !!srcTokens &&
-    srcTokens.length > 0 &&
-    !!actions
+  const resolvedActions = actions ?? buildDefaultActions(owner, srcTokens)
 
   return useQuery({
     queryKey: [
       'zerodev-wallet-kit',
       'smartRoutingAddress',
       owner,
-      destChain?.id,
+      destChain.id,
       slippage,
-      srcTokens?.map((t) => [t.tokenType, t.chain.id, t.minAmount?.toString()]),
+      srcTokens.map((t) => [t.tokenType, t.chain.id, t.minAmount?.toString()]),
     ],
     enabled,
     queryFn: async () => {
-      if (!owner || !destChain || !srcTokens || !actions) return null
-      return createSmartRoutingAddress({
+      const result = await createSmartRoutingAddress({
         owner,
         destChain,
         slippage,
         srcTokens,
-        actions,
+        actions: resolvedActions,
       })
+      // The SDK currently swallows JSON-RPC error bodies (200 OK with `error`
+      // instead of `result`) and returns `undefined`. React Query forbids
+      // undefined data, so promote it to a proper error.
+      if (!result) {
+        throw new Error('Smart routing address service returned no result')
+      }
+      return result
     },
     meta: { persist: false },
   })

--- a/packages/react-kit/src/smart-routing/useSmartRoutingAddress.ts
+++ b/packages/react-kit/src/smart-routing/useSmartRoutingAddress.ts
@@ -22,7 +22,7 @@ function getKitStore(config: ReturnType<typeof useConfig>): Store | null {
   return connector.getKitStore()
 }
 
-function buildDefaultActions(
+function buildActions(
   owner: Address,
   srcTokens: UseSmartRoutingAddressParams['srcTokens'],
 ): CreateSmartRoutingAddressParams['actions'] {
@@ -64,7 +64,6 @@ export function useSmartRoutingAddress({
   destChain,
   srcTokens,
   slippage = DEFAULT_SLIPPAGE_BPS,
-  actions,
 }: UseSmartRoutingAddressParams) {
   const wagmiConfig = useConfig()
   const store = getKitStore(wagmiConfig)
@@ -76,8 +75,6 @@ export function useSmartRoutingAddress({
 
   const config = useStore(store, (state) => state.smartRouting.config)
   const enabled = !!config && config.enabled !== false
-
-  const resolvedActions = actions ?? buildDefaultActions(owner, srcTokens)
 
   return useQuery({
     queryKey: [
@@ -95,7 +92,7 @@ export function useSmartRoutingAddress({
         destChain,
         slippage,
         srcTokens,
-        actions: resolvedActions,
+        actions: buildActions(owner, srcTokens),
       })
       // The SDK currently swallows JSON-RPC error bodies (200 OK with `error`
       // instead of `result`) and returns `undefined`. React Query forbids

--- a/packages/react-kit/src/store.ts
+++ b/packages/react-kit/src/store.ts
@@ -4,6 +4,10 @@ import {
   type AuthStoreSlice,
   createAuthStoreSlice,
 } from './auth/authStoreSlice'
+import {
+  createSmartRoutingStoreSlice,
+  type SmartRoutingStoreSlice,
+} from './smart-routing/smartRoutingStoreSlice'
 import type { PendingRequest } from './types.js'
 
 export type State = {
@@ -13,7 +17,8 @@ export type State = {
   removePendingRequest: (id: string) => void
   clearPendingRequests: () => void
   setUserConfirmationListenerActive: (active: boolean) => void
-} & AuthStoreSlice
+} & AuthStoreSlice &
+  SmartRoutingStoreSlice
 
 export const createStore = () =>
   create<State>()(
@@ -33,5 +38,6 @@ export const createStore = () =>
         set({ userConfirmationListenerActive: active }),
 
       ...createAuthStoreSlice(set, get, store),
+      ...createSmartRoutingStoreSlice(set, get, store),
     })),
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,9 @@ importers:
       '@wagmi/core':
         specifier: ^2.22.0
         version: 2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.2)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.0))(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@zerodev/smart-routing-address':
+        specifier: ^0.1.9
+        version: 0.1.9(typescript@5.9.3)(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@zerodev/wallet-core':
         specifier: workspace:*
         version: link:../core
@@ -5208,6 +5211,12 @@ packages:
     resolution: {integrity: sha512-QB/YfemrHEyR0/B2l4ya+LOXLfLmkUvTjS2FEzhQ0hvfPtcS5wf3v7eZHy7qNjsBC4M/wYG7RQf3ZCbKMh4ZLw==}
     peerDependencies:
       viem: ^2.28.0
+
+  '@zerodev/smart-routing-address@0.1.9':
+    resolution: {integrity: sha512-EL9RZMuFTytOhnOHe4X7WpLrdT+0FBiAvOJtGGPfBTBNDUsElCNpBaSRDGVeK5wUFKCFpyzorknWo07WcpJD2g==}
+    peerDependencies:
+      typescript: ^5.0.0
+      viem: ^2.41.2
 
   abitype@1.0.6:
     resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
@@ -13277,7 +13286,7 @@ snapshots:
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
-      metro-config: 0.83.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      metro-config: 0.83.3(bufferutil@4.0.9)(utf-8-validate@6.0.6)
       metro-core: 0.83.3
       metro-file-map: 0.83.3
       metro-minify-terser: 0.83.3
@@ -13286,7 +13295,7 @@ snapshots:
       metro-source-map: 0.83.3
       metro-symbolicate: 0.83.3
       metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      metro-transform-worker: 0.83.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -19233,6 +19242,11 @@ snapshots:
       semver: 7.7.3
       viem: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
 
+  '@zerodev/smart-routing-address@0.1.9(typescript@5.9.3)(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+    dependencies:
+      typescript: 5.9.3
+      viem: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+
   abitype@1.0.6(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.9.3
@@ -23447,21 +23461,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro-config@0.83.3(bufferutil@4.0.9)(utf-8-validate@5.0.10):
-    dependencies:
-      connect: 3.7.0
-      flow-enums-runtime: 0.0.6
-      jest-validate: 29.7.0
-      metro: 0.83.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      metro-cache: 0.83.3
-      metro-core: 0.83.3
-      metro-runtime: 0.83.3
-      yaml: 2.8.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   metro-config@0.83.3(bufferutil@4.0.9)(utf-8-validate@6.0.6):
     dependencies:
       connect: 3.7.0
@@ -23809,6 +23808,26 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  metro-transform-worker@0.83.3(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      flow-enums-runtime: 0.0.6
+      metro: 0.83.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-minify-terser: 0.83.3
+      metro-source-map: 0.83.3
+      metro-transform-plugins: 0.83.3
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   metro-transform-worker@0.83.3(bufferutil@4.0.9)(utf-8-validate@6.0.6):
     dependencies:
       '@babel/core': 7.29.0
@@ -23962,7 +23981,7 @@ snapshots:
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
-      metro-config: 0.83.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      metro-config: 0.83.3(bufferutil@4.0.9)(utf-8-validate@6.0.6)
       metro-core: 0.83.3
       metro-file-map: 0.83.3
       metro-resolver: 0.83.3
@@ -23970,7 +23989,7 @@ snapshots:
       metro-source-map: 0.83.3
       metro-symbolicate: 0.83.3
       metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      metro-transform-worker: 0.83.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       mime-types: 2.1.35
       nullthrows: 1.1.1
       serialize-error: 2.1.0
@@ -24718,7 +24737,7 @@ snapshots:
 
   object.assign@4.1.7:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1


### PR DESCRIPTION
Closes [FS-2261](https://linear.app/offchain-labs/issue/FS-2261/connector-config-usesmartroutingaddress-hook)

### Summary

Foundation for the SRA UI, no components in this PR.

-  Adds `@zerodev/smart-routing-address` and a new smartRoutingAddress block on zeroDevWallet({ config }) (enabled, maxSlippage, destinationChains, sourceChains).
- Adds a smartRouting slice to the kit store.  
-  Adds `useSmartRoutingAddress(overrides?)` wraps createSmartRoutingAddress in React Query

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
