### PR TITLE
Update signer demo auth layout

### DIFF
--- a/apps/zerodev-signer-demo/src/app/components/Navbar.tsx
+++ b/apps/zerodev-signer-demo/src/app/components/Navbar.tsx
@@ -1,11 +1,14 @@
 /* eslint-disable @next/next/no-img-element */
 'use client'
 
-import { Check, Copy, LogOut, Wallet } from 'lucide-react'
+import { useAuth } from '@zerodev/wallet-react-kit'
+import { Check, Copy, LogOut, Settings, Wallet } from 'lucide-react'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAccount, useDisconnect } from 'wagmi'
 import { ChainSelector } from './ChainSelector'
+
+type EmailAuthMethod = 'otp' | 'magicLink'
 
 export function Navbar() {
   const router = useRouter()
@@ -44,34 +47,130 @@ export function Navbar() {
             </span>
           </div>
 
-          {isConnected && address && (
-            <div className="flex items-center gap-3">
-              <ChainSelector />
-              <div className="hidden sm:flex items-center gap-2 px-3 py-1.5 bg-gray-50 rounded-lg border border-gray-200 group cursor-pointer">
-                <Wallet className="h-4 w-4 text-gray-500" />
-                <span className="text-sm font-mono text-gray-700">{formatAddress(address)}</span>
+          <div className="flex items-center gap-3">
+            {!isConnected && <EmailMethodSettings />}
+            {isConnected && address && (
+              <>
+                <ChainSelector />
+                <div className="hidden sm:flex items-center gap-2 px-3 py-1.5 bg-gray-50 rounded-lg border border-gray-200 group cursor-pointer">
+                  <Wallet className="h-4 w-4 text-gray-500" />
+                  <span className="text-sm font-mono text-gray-700">{formatAddress(address)}</span>
+                  <button
+                    onClick={handleCopy}
+                    className="text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
+                  >
+                    {copied ? (
+                      <Check className="h-3.5 w-3.5 text-green-600" />
+                    ) : (
+                      <Copy className="h-3.5 w-3.5" />
+                    )}
+                  </button>
+                </div>
                 <button
-                  onClick={handleCopy}
-                  className="text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
+                  onClick={handleLogout}
+                  className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all cursor-pointer"
+                  title="Logout"
                 >
-                  {copied ? (
-                    <Check className="h-3.5 w-3.5 text-green-600" />
-                  ) : (
-                    <Copy className="h-3.5 w-3.5" />
-                  )}
+                  <LogOut className="h-4 w-4" />
                 </button>
-              </div>
-              <button
-                onClick={handleLogout}
-                className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all cursor-pointer"
-                title="Logout"
-              >
-                <LogOut className="h-4 w-4" />
-              </button>
-            </div>
-          )}
+              </>
+            )}
+          </div>
         </div>
       </div>
     </header>
+  )
+}
+
+function EmailMethodSettings() {
+  const {step} = useAuth()
+  const [open, setOpen] = useState(false)
+  const [method, setMethod] = useState<EmailAuthMethod>(() => {
+    if (typeof window === 'undefined') return 'otp'
+    return localStorage.getItem('zd:emailAuthMethod') === 'magicLink'
+      ? 'magicLink'
+      : 'otp'
+  })
+
+  const handleSave = (next: EmailAuthMethod) => {
+    localStorage.setItem('zd:emailAuthMethod', next)
+    window.location.reload()
+  }
+
+  const handleOpen = () => {
+    // Re-sync from storage on open so a previous Cancel doesn't leave the
+    // radios pointing at an unsaved selection.
+    setMethod(
+      localStorage.getItem('zd:emailAuthMethod') === 'magicLink'
+        ? 'magicLink'
+        : 'otp',
+    )
+    setOpen(true)
+  }
+
+  if (step === null || step === 'authenticated') return null
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleOpen}
+        aria-label="Email method settings"
+        className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
+      >
+        <Settings className="h-5 w-5" />
+      </button>
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="bg-white rounded-lg shadow-lg p-6 w-[320px] flex flex-col gap-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-base font-semibold text-gray-900">
+              Email auth method
+            </h2>
+            <label className="flex items-center gap-2 cursor-pointer text-sm">
+              <input
+                type="radio"
+                name="emailAuthMethod"
+                value="otp"
+                checked={method === 'otp'}
+                onChange={() => setMethod('otp')}
+              />
+              <span className="text-gray-700">OTP code</span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer text-sm">
+              <input
+                type="radio"
+                name="emailAuthMethod"
+                value="magicLink"
+                checked={method === 'magicLink'}
+                onChange={() => setMethod('magicLink')}
+              />
+              <span className="text-gray-700">Magic link</span>
+            </label>
+            <div className="flex justify-end gap-2 mt-2">
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => handleSave(method)}
+                className="px-3 py-1.5 text-sm bg-gray-900 text-white rounded-md hover:bg-gray-800 cursor-pointer"
+              >
+                Save and reload
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   )
 }

--- a/apps/zerodev-signer-demo/src/app/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/page.tsx
@@ -1,14 +1,11 @@
 'use client'
 
 import {AuthFlow, useAuth} from '@zerodev/wallet-react-kit'
-import {Settings} from 'lucide-react'
 import {useRouter, useSearchParams} from 'next/navigation'
 import {Suspense, useEffect, useState} from 'react'
 import {useAccount, useConnect} from 'wagmi'
 
 export const dynamic = 'force-dynamic'
-
-type EmailAuthMethod = 'otp' | 'magicLink'
 
 export default function LandingPage() {
   return (
@@ -68,16 +65,17 @@ function LandingPageInner() {
 
   return (
     <div
-      className="mx-auto w-full max-w-[500px] flex flex-col flex-1 sm:max-w-none sm:flex-row sm:items-center sm:justify-center">
+      className="mx-auto w-full max-w-[500px] flex flex-col flex-1 px-4 py-6 sm:max-w-none sm:flex-row sm:items-start sm:justify-center sm:px-6 sm:py-10">
       {sessionExpired && (
         <div
           className="m-4 px-4 py-3 rounded-lg text-sm text-center bg-yellow-50 text-yellow-700 border border-yellow-200">
           Your session has expired. Please log in again.
         </div>
       )}
-      <div className="flex-1 w-full flex flex-col sm:flex-none sm:w-[500px] sm:h-[800px]">
-        <EmailMethodSettings/>
-        <AuthFlow/>
+      <div className="relative w-full flex flex-col sm:w-[430px] sm:h-[688px]">
+        <div className="w-full flex flex-col sm:w-[500px] sm:h-[800px] sm:origin-top sm:scale-[0.86]">
+          <AuthFlow/>
+        </div>
         {showReconnect && (
           <div className="flex-1 flex items-center justify-center p-6">
             <button
@@ -90,99 +88,6 @@ function LandingPageInner() {
           </div>
         )}
       </div>
-    </div>
-  )
-}
-
-function EmailMethodSettings() {
-  const {step} = useAuth()
-  const [open, setOpen] = useState(false)
-  const [method, setMethod] = useState<EmailAuthMethod>(() => {
-    if (typeof window === 'undefined') return 'otp'
-    return localStorage.getItem('zd:emailAuthMethod') === 'magicLink'
-      ? 'magicLink'
-      : 'otp'
-  })
-
-  const handleSave = (next: EmailAuthMethod) => {
-    localStorage.setItem('zd:emailAuthMethod', next)
-    window.location.reload()
-  }
-
-  const handleOpen = () => {
-    // Re-sync from storage on open so a previous Cancel doesn't leave the
-    // radios pointing at an unsaved selection.
-    setMethod(
-      localStorage.getItem('zd:emailAuthMethod') === 'magicLink'
-        ? 'magicLink'
-        : 'otp',
-    )
-    setOpen(true)
-  }
-
-  if (step === null || step === 'authenticated') return null
-
-  return (
-    <div className="flex justify-end pb-2">
-      <button
-        type="button"
-        onClick={handleOpen}
-        aria-label="Email method settings"
-        className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
-      >
-        <Settings className="h-6 w-6"/>
-      </button>
-      {open && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
-          onClick={() => setOpen(false)}
-        >
-          <div
-            className="bg-white rounded-lg shadow-lg p-6 w-[320px] flex flex-col gap-4"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h2 className="text-base font-semibold text-gray-900">
-              Email auth method
-            </h2>
-            <label className="flex items-center gap-2 cursor-pointer text-sm">
-              <input
-                type="radio"
-                name="emailAuthMethod"
-                value="otp"
-                checked={method === 'otp'}
-                onChange={() => setMethod('otp')}
-              />
-              <span className="text-gray-700">OTP code</span>
-            </label>
-            <label className="flex items-center gap-2 cursor-pointer text-sm">
-              <input
-                type="radio"
-                name="emailAuthMethod"
-                value="magicLink"
-                checked={method === 'magicLink'}
-                onChange={() => setMethod('magicLink')}
-              />
-              <span className="text-gray-700">Magic link</span>
-            </label>
-            <div className="flex justify-end gap-2 mt-2">
-              <button
-                type="button"
-                onClick={() => setOpen(false)}
-                className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 cursor-pointer"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={() => handleSave(method)}
-                className="px-3 py-1.5 text-sm bg-gray-900 text-white rounded-md hover:bg-gray-800 cursor-pointer"
-              >
-                Save and reload
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/apps/zerodev-signer-demo/src/app/verify/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/verify/page.tsx
@@ -26,9 +26,11 @@ function VerifyPageInner() {
   }, [isConnected, router])
 
   return (
-    <div className="mx-auto w-full max-w-[500px] min-h-screen flex flex-col sm:max-w-none sm:h-screen sm:min-h-0 sm:flex-row sm:items-center sm:justify-center">
-      <div className="flex-1 w-full flex flex-col sm:flex-none sm:w-[500px] sm:h-[800px]">
-        <AuthFlow />
+    <div className="mx-auto w-full max-w-[500px] flex flex-col flex-1 px-4 py-6 sm:max-w-none sm:flex-row sm:items-start sm:justify-center sm:px-6 sm:py-10">
+      <div className="w-full flex flex-col sm:w-[430px] sm:h-[688px]">
+        <div className="w-full flex flex-col sm:w-[500px] sm:h-[800px] sm:origin-top sm:scale-[0.86]">
+          <AuthFlow />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Updates the signer demo auth layout so the wallet panel is smaller and positioned higher on desktop.

Also moves the email auth settings control into the auth panel's top-right area and hides the close button from the example app only. No React kit package source changes are included.
