### PR TITLE
Update signer demo auth layout

### DIFF
--- a/apps/zerodev-signer-demo/src/app/components/Navbar.tsx
+++ b/apps/zerodev-signer-demo/src/app/components/Navbar.tsx
@@ -1,20 +1,25 @@
 /* eslint-disable @next/next/no-img-element */
 'use client'
 
-import { useAuth } from '@zerodev/wallet-react-kit'
-import { Check, Copy, LogOut, Settings, Wallet } from 'lucide-react'
-import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { Check, Copy, Loader2, LogOut, Wallet } from 'lucide-react'
+import { usePathname, useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
 import { useAccount, useDisconnect } from 'wagmi'
 import { ChainSelector } from './ChainSelector'
 
-type EmailAuthMethod = 'otp' | 'magicLink'
-
 export function Navbar() {
   const router = useRouter()
+  const pathname = usePathname()
   const { address, isConnected } = useAccount()
   const { disconnectAsync } = useDisconnect()
   const [copied, setCopied] = useState(false)
+  const [loggingOut, setLoggingOut] = useState(false)
+
+  useEffect(() => {
+    if (pathname === '/') {
+      setLoggingOut(false)
+    }
+  }, [pathname])
 
   const handleCopy = async () => {
     if (!address) return
@@ -24,16 +29,37 @@ export function Navbar() {
   }
 
   const handleLogout = async () => {
+    setLoggingOut(true)
     localStorage.setItem('zd:loggedOut', 'true')
-    await disconnectAsync()
-    router.push('/')
+    try {
+      await disconnectAsync()
+    } catch {
+      setLoggingOut(false)
+      return
+    }
+    router.push('/?logged_out=true')
   }
 
   const formatAddress = (addr: string) =>
     `${addr.slice(0, 6)}...${addr.slice(-4)}`
 
   return (
-    <header className="bg-white border-b border-gray-100">
+    <>
+      <div
+        className={`fixed inset-0 z-50 flex items-center justify-center bg-white transition-opacity duration-300 ${
+          loggingOut
+            ? 'opacity-100'
+            : 'pointer-events-none opacity-0'
+        }`}
+      >
+        <div className="flex flex-col items-center gap-3 animate-[auth-transition-card_450ms_ease-out_forwards]">
+          <Loader2 className="h-10 w-10 animate-spin text-blue-500"/>
+          <p className="text-sm font-medium text-gray-500">
+            Logging out...
+          </p>
+        </div>
+      </div>
+      <header className="bg-white border-b border-gray-100">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-20">
           <div className="flex items-center gap-3">
@@ -48,7 +74,6 @@ export function Navbar() {
           </div>
 
           <div className="flex items-center gap-3">
-            {!isConnected && <EmailMethodSettings />}
             {isConnected && address && (
               <>
                 <ChainSelector />
@@ -68,6 +93,7 @@ export function Navbar() {
                 </div>
                 <button
                   onClick={handleLogout}
+                  disabled={loggingOut}
                   className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all cursor-pointer"
                   title="Logout"
                 >
@@ -78,99 +104,7 @@ export function Navbar() {
           </div>
         </div>
       </div>
-    </header>
-  )
-}
-
-function EmailMethodSettings() {
-  const {step} = useAuth()
-  const [open, setOpen] = useState(false)
-  const [method, setMethod] = useState<EmailAuthMethod>(() => {
-    if (typeof window === 'undefined') return 'otp'
-    return localStorage.getItem('zd:emailAuthMethod') === 'magicLink'
-      ? 'magicLink'
-      : 'otp'
-  })
-
-  const handleSave = (next: EmailAuthMethod) => {
-    localStorage.setItem('zd:emailAuthMethod', next)
-    window.location.reload()
-  }
-
-  const handleOpen = () => {
-    // Re-sync from storage on open so a previous Cancel doesn't leave the
-    // radios pointing at an unsaved selection.
-    setMethod(
-      localStorage.getItem('zd:emailAuthMethod') === 'magicLink'
-        ? 'magicLink'
-        : 'otp',
-    )
-    setOpen(true)
-  }
-
-  if (step === null || step === 'authenticated') return null
-
-  return (
-    <>
-      <button
-        type="button"
-        onClick={handleOpen}
-        aria-label="Email method settings"
-        className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
-      >
-        <Settings className="h-5 w-5" />
-      </button>
-      {open && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
-          onClick={() => setOpen(false)}
-        >
-          <div
-            className="bg-white rounded-lg shadow-lg p-6 w-[320px] flex flex-col gap-4"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h2 className="text-base font-semibold text-gray-900">
-              Email auth method
-            </h2>
-            <label className="flex items-center gap-2 cursor-pointer text-sm">
-              <input
-                type="radio"
-                name="emailAuthMethod"
-                value="otp"
-                checked={method === 'otp'}
-                onChange={() => setMethod('otp')}
-              />
-              <span className="text-gray-700">OTP code</span>
-            </label>
-            <label className="flex items-center gap-2 cursor-pointer text-sm">
-              <input
-                type="radio"
-                name="emailAuthMethod"
-                value="magicLink"
-                checked={method === 'magicLink'}
-                onChange={() => setMethod('magicLink')}
-              />
-              <span className="text-gray-700">Magic link</span>
-            </label>
-            <div className="flex justify-end gap-2 mt-2">
-              <button
-                type="button"
-                onClick={() => setOpen(false)}
-                className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 cursor-pointer"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={() => handleSave(method)}
-                className="px-3 py-1.5 text-sm bg-gray-900 text-white rounded-md hover:bg-gray-800 cursor-pointer"
-              >
-                Save and reload
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      </header>
     </>
   )
 }

--- a/apps/zerodev-signer-demo/src/app/components/Navbar.tsx
+++ b/apps/zerodev-signer-demo/src/app/components/Navbar.tsx
@@ -1,11 +1,14 @@
 /* eslint-disable @next/next/no-img-element */
 'use client'
 
-import { Check, Copy, LogOut, Wallet } from 'lucide-react'
+import { useAuth } from '@zerodev/wallet-react-kit'
+import { Check, Copy, LogOut, Settings, Wallet } from 'lucide-react'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAccount, useDisconnect } from 'wagmi'
 import { ChainSelector } from './ChainSelector'
+
+type EmailAuthMethod = 'otp' | 'magicLink'
 
 export function Navbar() {
   const router = useRouter()
@@ -44,34 +47,130 @@ export function Navbar() {
             </span>
           </div>
 
-          {isConnected && address && (
-            <div className="flex items-center gap-3">
-              <ChainSelector />
-              <div className="hidden sm:flex items-center gap-2 px-3 py-1.5 bg-gray-50 rounded-lg border border-gray-200 group cursor-pointer">
-                <Wallet className="h-4 w-4 text-gray-500" />
-                <span className="text-sm font-mono text-gray-700">{formatAddress(address)}</span>
+          <div className="flex items-center gap-3">
+            {!isConnected && <EmailMethodSettings />}
+            {isConnected && address && (
+              <>
+                <ChainSelector />
+                <div className="hidden sm:flex items-center gap-2 px-3 py-1.5 bg-gray-50 rounded-lg border border-gray-200 group cursor-pointer">
+                  <Wallet className="h-4 w-4 text-gray-500" />
+                  <span className="text-sm font-mono text-gray-700">{formatAddress(address)}</span>
+                  <button
+                    onClick={handleCopy}
+                    className="text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
+                  >
+                    {copied ? (
+                      <Check className="h-3.5 w-3.5 text-green-600" />
+                    ) : (
+                      <Copy className="h-3.5 w-3.5" />
+                    )}
+                  </button>
+                </div>
                 <button
-                  onClick={handleCopy}
-                  className="text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
+                  onClick={handleLogout}
+                  className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all cursor-pointer"
+                  title="Logout"
                 >
-                  {copied ? (
-                    <Check className="h-3.5 w-3.5 text-green-600" />
-                  ) : (
-                    <Copy className="h-3.5 w-3.5" />
-                  )}
+                  <LogOut className="h-4 w-4" />
                 </button>
-              </div>
-              <button
-                onClick={handleLogout}
-                className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all cursor-pointer"
-                title="Logout"
-              >
-                <LogOut className="h-4 w-4" />
-              </button>
-            </div>
-          )}
+              </>
+            )}
+          </div>
         </div>
       </div>
     </header>
+  )
+}
+
+function EmailMethodSettings() {
+  const {step} = useAuth()
+  const [open, setOpen] = useState(false)
+  const [method, setMethod] = useState<EmailAuthMethod>(() => {
+    if (typeof window === 'undefined') return 'otp'
+    return localStorage.getItem('zd:emailAuthMethod') === 'magicLink'
+      ? 'magicLink'
+      : 'otp'
+  })
+
+  const handleSave = (next: EmailAuthMethod) => {
+    localStorage.setItem('zd:emailAuthMethod', next)
+    window.location.reload()
+  }
+
+  const handleOpen = () => {
+    // Re-sync from storage on open so a previous Cancel doesn't leave the
+    // radios pointing at an unsaved selection.
+    setMethod(
+      localStorage.getItem('zd:emailAuthMethod') === 'magicLink'
+        ? 'magicLink'
+        : 'otp',
+    )
+    setOpen(true)
+  }
+
+  if (step === null || step === 'authenticated') return null
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleOpen}
+        aria-label="Email method settings"
+        className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
+      >
+        <Settings className="h-5 w-5" />
+      </button>
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="bg-white rounded-lg shadow-lg p-6 w-[320px] flex flex-col gap-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-base font-semibold text-gray-900">
+              Email auth method
+            </h2>
+            <label className="flex items-center gap-2 cursor-pointer text-sm">
+              <input
+                type="radio"
+                name="emailAuthMethod"
+                value="otp"
+                checked={method === 'otp'}
+                onChange={() => setMethod('otp')}
+              />
+              <span className="text-gray-700">OTP code</span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer text-sm">
+              <input
+                type="radio"
+                name="emailAuthMethod"
+                value="magicLink"
+                checked={method === 'magicLink'}
+                onChange={() => setMethod('magicLink')}
+              />
+              <span className="text-gray-700">Magic link</span>
+            </label>
+            <div className="flex justify-end gap-2 mt-2">
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => handleSave(method)}
+                className="px-3 py-1.5 text-sm bg-gray-900 text-white rounded-md hover:bg-gray-800 cursor-pointer"
+              >
+                Save and reload
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   )
 }

--- a/apps/zerodev-signer-demo/src/app/dashboard/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/dashboard/page.tsx
@@ -115,6 +115,10 @@ export default function DashboardPage() {
   }, [status]);
   useEffect(() => {
     if (status === 'disconnected' && hasConnected) {
+      if (localStorage.getItem('zd:loggedOut') === 'true') {
+        router.push("/?logged_out=true");
+        return;
+      }
       router.push("/?session_expired=true");
     }
   }, [status, hasConnected, router]);
@@ -140,7 +144,7 @@ export default function DashboardPage() {
       {confirmationEnabled && (
         <SignatureRequest className='fixed inset-0 z-50 sm:absolute sm:inset-auto sm:right-2 sm:top-18 sm:w-[400px] sm:h-[600px]' />
       )}
-      <div className="min-h-screen bg-white">
+      <div className="min-h-screen bg-white animate-[dashboard-enter_360ms_ease-out_both]">
         {/* Main Content */}
         <div className="max-w-5xl mx-auto px-3 sm:px-6 lg:px-8 py-4 sm:py-8">
           {/* Wallet Card */}

--- a/apps/zerodev-signer-demo/src/app/globals.css
+++ b/apps/zerodev-signer-demo/src/app/globals.css
@@ -19,3 +19,34 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@keyframes demo-progress {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes auth-transition-card {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes dashboard-enter {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/apps/zerodev-signer-demo/src/app/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/page.tsx
@@ -1,13 +1,16 @@
 'use client'
 
-import {AuthFlow, useAuth} from '@zerodev/wallet-react-kit'
+import {AuthFlow} from '@zerodev/wallet-react-kit'
+import {ArrowRight, CheckCircle2, CircleHelp, Mail, Settings} from 'lucide-react'
 import {useRouter, useSearchParams} from 'next/navigation'
+import type {FormEvent} from 'react'
 import {Suspense, useEffect, useState} from 'react'
 import {useAccount, useConnect} from 'wagmi'
 
 export const dynamic = 'force-dynamic'
 
 type DemoMode = 'prebuilt' | 'whiteLabel'
+type EmailAuthMethod = 'otp' | 'magicLink'
 
 export default function LandingPage() {
   return (
@@ -21,35 +24,49 @@ function LandingPageInner() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const sessionExpired = searchParams.get('session_expired') === 'true'
+  const loggedOutSuccess = searchParams.get('logged_out') === 'true'
   const [demoMode, setDemoMode] = useState<DemoMode>('prebuilt')
+  const [authTransitioning, setAuthTransitioning] = useState(false)
+  const [showLogoutToast, setShowLogoutToast] = useState(loggedOutSuccess)
 
-  const [loggedOut] = useState(() => {
-    if (typeof window === 'undefined') return false
-    const value = localStorage.getItem('zd:loggedOut') === 'true'
-    if (value) localStorage.removeItem('zd:loggedOut')
-    return value
-  })
-
-  const skipAutoConnect = sessionExpired || loggedOut
   const {connect, connectors, status: connectStatus} = useConnect()
   const {isConnected, status: accountStatus} = useAccount()
-  const {step: authStep} = useAuth()
-  const showReconnect =
-    !isConnected &&
-    authStep === null &&
-    (skipAutoConnect || connectStatus !== 'idle')
 
   const handleReconnect = () => {
     if (connectors[0]) connect({connector: connectors[0]})
   }
 
   useEffect(() => {
+    localStorage.removeItem('zd:loggedOut')
+  }, [])
+
+  useEffect(() => {
+    if (!loggedOutSuccess) return
+    setShowLogoutToast(true)
+
+    const hideTimer = window.setTimeout(() => {
+      setShowLogoutToast(false)
+    }, 3000)
+    const cleanUrlTimer = window.setTimeout(() => {
+      router.replace('/')
+    }, 3500)
+
+    return () => {
+      window.clearTimeout(hideTimer)
+      window.clearTimeout(cleanUrlTimer)
+    }
+  }, [loggedOutSuccess, router])
+
+  useEffect(() => {
     if (isConnected) {
-      router.push('/dashboard')
-      return
+      setAuthTransitioning(true)
+      const timer = window.setTimeout(() => {
+        router.push('/dashboard')
+      }, 450)
+
+      return () => window.clearTimeout(timer)
     }
     if (demoMode === 'whiteLabel') return
-    if (skipAutoConnect) return
     if (
       accountStatus === 'disconnected' &&
       connectStatus === 'idle' &&
@@ -65,49 +82,64 @@ function LandingPageInner() {
     connect,
     connectors,
     demoMode,
-    skipAutoConnect,
   ])
 
   return (
-    <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-4 py-6 sm:px-6 sm:py-10 lg:flex-row lg:items-start lg:justify-between lg:gap-14">
-      <DemoIntroPanel mode={demoMode} onModeChange={setDemoMode}/>
-      {sessionExpired && (
-        <div
-          className="px-4 py-3 rounded-lg text-sm text-center bg-yellow-50 text-yellow-700 border border-yellow-200 lg:hidden">
-          Your session has expired. Please log in again.
+    <>
+      <div
+        className={`fixed left-1/2 top-24 z-40 flex -translate-x-1/2 items-center gap-2 rounded-full border border-green-100 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-lg transition-all duration-300 ${
+          showLogoutToast
+            ? 'translate-y-0 opacity-100'
+            : 'pointer-events-none -translate-y-2 opacity-0'
+        }`}
+      >
+        <CheckCircle2 className="h-4 w-4 text-green-600"/>
+        Logged out successfully
+      </div>
+      <div
+        className={`fixed inset-0 z-50 flex items-center justify-center bg-white transition-opacity duration-300 ${
+          authTransitioning
+            ? 'opacity-100'
+            : 'pointer-events-none opacity-0'
+        }`}
+      >
+        <div className="flex flex-col items-center gap-3 animate-[auth-transition-card_450ms_ease-out_forwards]">
+          <div className="h-10 w-10 rounded-full border-2 border-blue-100 border-t-blue-500 animate-spin"/>
+          <p className="text-sm font-medium text-gray-500">
+            Opening wallet...
+          </p>
         </div>
-      )}
-      <div className="relative mx-auto flex w-full max-w-[430px] flex-col sm:h-[688px] lg:mx-0 lg:shrink-0">
+      </div>
+      <div className="mx-auto grid w-full max-w-7xl flex-1 grid-cols-1 gap-8 px-4 py-5 sm:px-6 sm:py-7 lg:grid-cols-[minmax(0,500px)_390px] lg:items-start lg:justify-between lg:gap-12">
+        <DemoIntroPanel/>
         {sessionExpired && (
           <div
-            className="mb-4 hidden px-4 py-3 rounded-lg text-sm text-center bg-yellow-50 text-yellow-700 border border-yellow-200 lg:block">
+            className="order-3 px-4 py-3 rounded-lg text-sm text-center bg-yellow-50 text-yellow-700 border border-yellow-200 lg:hidden">
             Your session has expired. Please log in again.
           </div>
         )}
-        {demoMode === 'prebuilt' ? (
-          <div className="w-full flex flex-col sm:w-[500px] sm:h-[800px] sm:origin-top sm:scale-[0.86]">
-            <AuthFlow/>
-          </div>
-        ) : (
-          <WhiteLabelWalletPreview onConnect={handleReconnect}/>
-        )}
-        {demoMode === 'prebuilt' && showReconnect && (
-          <div className="flex-1 flex items-center justify-center p-6">
-            <button
-              type="button"
-              onClick={handleReconnect}
-              className="px-8 py-4 rounded-3xl bg-gray-900 text-white text-body1 font-semibold hover:bg-gray-800 cursor-pointer"
-            >
-              Reconnect
-            </button>
-          </div>
-        )}
+        <div className="relative order-first mx-auto flex w-full max-w-[390px] flex-col lg:order-none lg:mx-0 lg:pt-3">
+          <ModeSelector mode={demoMode} onModeChange={setDemoMode}/>
+          {sessionExpired && (
+            <div
+              className="mb-4 hidden px-4 py-3 rounded-lg text-sm text-center bg-yellow-50 text-yellow-700 border border-yellow-200 lg:block">
+              Your session has expired. Please log in again.
+            </div>
+          )}
+          {demoMode === 'prebuilt' ? (
+            <div className="w-full flex flex-col sm:w-[500px] sm:h-[800px] sm:origin-top-left sm:scale-[0.78]">
+              <AuthFlow/>
+            </div>
+          ) : (
+            <WhiteLabelWalletPreview onConnect={handleReconnect}/>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   )
 }
 
-function DemoIntroPanel({
+function ModeSelector({
   mode,
   onModeChange,
 }: {
@@ -115,134 +147,444 @@ function DemoIntroPanel({
   onModeChange: (mode: DemoMode) => void
 }) {
   return (
-    <aside className="w-full max-w-2xl pt-2 lg:pt-8">
-      <p className="mb-4 text-sm font-semibold uppercase text-blue-500">
-        Wallet Demo
+    <div className="mb-4">
+      <p className="mb-2 text-sm font-medium text-gray-500">
+        Experience
       </p>
-      <h1 className="max-w-[620px] text-4xl font-semibold leading-tight text-gray-950">
-        The first AA native embedded wallet
-      </h1>
-      <p className="mt-5 max-w-[620px] text-lg leading-8 text-gray-500">
-        ZeroDev Wallet combines embedded authentication with smart accounts by
-        default, so account abstraction features are native to the wallet
-        experience.
-      </p>
-
-      <div className="mt-10 inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
-        {demoModes.map((item) => (
-          <button
-            key={item.value}
-            type="button"
-            onClick={() => onModeChange(item.value)}
-            className={`rounded-md px-4 py-2 text-sm font-semibold transition-colors cursor-pointer ${
-              mode === item.value
-                ? 'bg-white text-gray-950 shadow-sm'
-                : 'text-gray-500 hover:text-gray-800'
-            }`}
-          >
-            {item.label}
-          </button>
-        ))}
-      </div>
-
-      <div className="mt-16 divide-y divide-gray-200 border-y border-gray-200">
-        {demoValueProps.map((item) => (
-          <div key={item.title} className="py-6">
-            <div className="flex items-center justify-between gap-4">
-              <h2 className="font-mono text-2xl font-semibold text-gray-900">
-                {item.title}
-              </h2>
-              <span className="h-2 w-2 rounded-full bg-gray-400"/>
-            </div>
-            <p className="mt-4 max-w-[620px] text-base leading-7 text-gray-500">
-              {item.description}
-            </p>
-          </div>
-        ))}
-      </div>
-    </aside>
-  )
-}
-
-function WhiteLabelWalletPreview({onConnect}: {onConnect: () => void}) {
-  return (
-    <div className="flex min-h-[620px] w-full flex-col rounded-[34px] border border-gray-200 bg-[#101828] p-1.5 text-white shadow-2xl sm:h-[688px]">
-      <div className="flex flex-1 flex-col rounded-[30px] bg-white px-6 py-7 text-gray-950">
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-sm font-medium text-gray-500">Acme Finance</p>
-            <h2 className="mt-1 text-2xl font-semibold">Create your wallet</h2>
-          </div>
-          <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-blue-600 text-sm font-semibold text-white">
-            A
-          </div>
+      <div className="flex items-center gap-3">
+        <div className="grid flex-1 grid-cols-2 rounded-lg border border-gray-200 bg-gray-50 p-1">
+          {demoModes.map((item) => (
+            <button
+              key={item.value}
+              type="button"
+              onClick={() => onModeChange(item.value)}
+              className={`rounded-md px-3 py-2 text-sm font-semibold transition-colors cursor-pointer ${
+                mode === item.value
+                  ? 'bg-blue-50 text-blue-600 shadow-sm'
+                  : 'text-gray-500 hover:text-gray-800'
+              }`}
+            >
+              <span className="flex items-center justify-center gap-1.5">
+                {item.label}
+                <InfoTooltip text={item.description}/>
+              </span>
+            </button>
+          ))}
         </div>
-
-        <div className="mt-12 rounded-2xl bg-gray-50 p-5">
-          <p className="text-sm font-semibold text-gray-900">
-            Powered by ZeroDev Wallet Core
-          </p>
-          <p className="mt-2 text-sm leading-6 text-gray-500">
-            Keep the authentication, key management, and smart account APIs
-            underneath while your app owns every pixel of the wallet UI.
-          </p>
-        </div>
-
-        <div className="mt-8 flex flex-col gap-3">
-          <button
-            type="button"
-            onClick={onConnect}
-            className="rounded-2xl bg-blue-600 px-5 py-4 text-base font-semibold text-white hover:bg-blue-700 cursor-pointer"
-          >
-            Continue with passkey
-          </button>
-          <button
-            type="button"
-            onClick={onConnect}
-            className="rounded-2xl border border-gray-200 px-5 py-4 text-base font-semibold text-gray-900 hover:bg-gray-50 cursor-pointer"
-          >
-            Continue with Google
-          </button>
-          <button
-            type="button"
-            onClick={onConnect}
-            className="rounded-2xl border border-gray-200 px-5 py-4 text-base font-semibold text-gray-900 hover:bg-gray-50 cursor-pointer"
-          >
-            Continue with email
-          </button>
-        </div>
-
-        <div className="mt-auto border-t border-gray-100 pt-6">
-          <p className="text-xs leading-5 text-gray-500">
-            This mode demonstrates a white-label integration: your design
-            system owns the interface, while ZeroDev provides the wallet
-            primitive underneath.
-          </p>
-        </div>
+        <EmailMethodSettings/>
       </div>
     </div>
   )
 }
 
-const demoModes: {value: DemoMode; label: string}[] = [
-  {value: 'prebuilt', label: 'Pre-built UI'},
-  {value: 'whiteLabel', label: 'White-label'},
+function EmailMethodSettings() {
+  const [open, setOpen] = useState(false)
+  const [method, setMethod] = useState<EmailAuthMethod>(() => {
+    if (typeof window === 'undefined') return 'otp'
+    return localStorage.getItem('zd:emailAuthMethod') === 'magicLink'
+      ? 'magicLink'
+      : 'otp'
+  })
+
+  const handleSave = (next: EmailAuthMethod) => {
+    localStorage.setItem('zd:emailAuthMethod', next)
+    window.location.reload()
+  }
+
+  const handleOpen = () => {
+    setMethod(
+      localStorage.getItem('zd:emailAuthMethod') === 'magicLink'
+        ? 'magicLink'
+        : 'otp',
+    )
+    setOpen(true)
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleOpen}
+        aria-label="Email method settings"
+        className="inline-flex h-8 w-8 items-center justify-center text-gray-500 transition-colors hover:text-gray-900 cursor-pointer"
+      >
+        <Settings className="h-4 w-4"/>
+      </button>
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="flex w-[320px] flex-col gap-4 rounded-lg bg-white p-6 shadow-lg"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <h2 className="text-base font-semibold text-gray-900">
+              Email auth method
+            </h2>
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input
+                type="radio"
+                name="emailAuthMethod"
+                value="otp"
+                checked={method === 'otp'}
+                onChange={() => setMethod('otp')}
+              />
+              <span className="text-gray-700">OTP code</span>
+            </label>
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input
+                type="radio"
+                name="emailAuthMethod"
+                value="magicLink"
+                checked={method === 'magicLink'}
+                onChange={() => setMethod('magicLink')}
+              />
+              <span className="text-gray-700">Magic link</span>
+            </label>
+            <div className="mt-2 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => handleSave(method)}
+                className="rounded-md bg-gray-900 px-3 py-1.5 text-sm text-white hover:bg-gray-800 cursor-pointer"
+              >
+                Save and reload
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+function InfoTooltip({text}: {text: string}) {
+  return (
+    <span className="group relative inline-flex">
+      <span
+        tabIndex={0}
+        aria-label={text}
+        className="inline-flex h-4 w-4 items-center justify-center rounded-full text-gray-400 outline-none transition-colors hover:text-gray-700 focus-visible:text-gray-700"
+      >
+        <CircleHelp className="h-3.5 w-3.5"/>
+      </span>
+      <span className="pointer-events-none absolute left-1/2 top-6 z-20 w-56 -translate-x-1/2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-left text-xs font-medium leading-5 text-gray-600 opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
+        {text}
+      </span>
+    </span>
+  )
+}
+
+function DemoIntroPanel() {
+  const [activeValueIndex, setActiveValueIndex] = useState(0)
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setActiveValueIndex((index) => (index + 1) % demoValueProps.length)
+    }, 5000)
+
+    return () => window.clearInterval(timer)
+  }, [])
+
+  return (
+    <aside className="w-full max-w-[500px] pt-1 lg:pt-3">
+      <p className="mb-3 text-sm font-medium text-blue-500">
+        Wallet Demo
+      </p>
+      <h1 className="max-w-[500px] text-3xl font-semibold leading-tight text-gray-950">
+        One-click smart wallets
+      </h1>
+      <p className="mt-3 max-w-[500px] text-base leading-7 text-gray-500">
+        Give users a self-custodial wallet with the login method they already
+        know. ZeroDev handles the wallet complexity behind the scenes.
+      </p>
+
+      <div className="mt-8 divide-y divide-gray-200 border-y border-gray-200">
+        {demoValueProps.map((item, index) => {
+          const active = index === activeValueIndex
+
+          return (
+            <div key={item.title} className="py-4">
+              <button
+                type="button"
+                onClick={() => setActiveValueIndex(index)}
+                className="block w-full text-left cursor-pointer"
+              >
+                <div className="flex items-center justify-between gap-4">
+                  <h2 className="text-base font-semibold text-gray-900">
+                    {item.title}
+                  </h2>
+                  <ProgressIndicator active={active}/>
+                </div>
+              </button>
+              <div
+                className={`grid transition-all duration-500 ease-out ${
+                  active
+                    ? 'grid-rows-[1fr] opacity-100'
+                    : 'grid-rows-[0fr] opacity-0'
+                }`}
+              >
+                <div className="overflow-hidden">
+                  <p className="mb-3 max-w-[500px] text-sm leading-6 text-gray-500">
+                    {item.description}
+                  </p>
+                  <CodeSnippet label={item.codeLabel} code={item.code}/>
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </aside>
+  )
+}
+
+function ProgressIndicator({
+  active,
+}: {
+  active: boolean
+}) {
+  return (
+    <span className="flex items-center gap-2">
+      <span className="h-1 w-10 overflow-hidden rounded-full bg-gray-100">
+        {active && (
+          <span
+            className="block h-full origin-left animate-[demo-progress_5s_linear_forwards] rounded-full bg-blue-500"
+          />
+        )}
+      </span>
+    </span>
+  )
+}
+
+function CodeSnippet({code, label}: {code: string; label: string}) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-gray-950 p-4 text-gray-100">
+      <div className="mb-3 flex items-center justify-between gap-4">
+        <p className="text-sm font-semibold text-white">{label}</p>
+        <span className="text-xs text-gray-400">React</span>
+      </div>
+      <pre className="max-h-[148px] overflow-x-auto overflow-y-hidden text-sm leading-6">
+        <code>{highlightCode(code)}</code>
+      </pre>
+    </div>
+  )
+}
+
+function highlightCode(code: string) {
+  return code.split('\n').map((line, lineIndex) => (
+    <span key={`${line}-${lineIndex}`}>
+      {highlightLine(line)}
+      {lineIndex < code.split('\n').length - 1 && '\n'}
+    </span>
+  ))
+}
+
+function highlightLine(line: string) {
+  const tokens = line.split(/('[^']*'|"[^"]*"|\/\/.*|\b(?:await|const|export|function|import|return|from)\b|[{}()[\].,<>/=])/g)
+
+  return tokens.map((token, index) => {
+    if (!token) return null
+
+    let className = 'text-gray-200'
+    if (/^['"]/.test(token)) className = 'text-emerald-300'
+    else if (/^\/\//.test(token)) className = 'text-gray-500'
+    else if (/^(await|const|export|function|import|return|from)$/.test(token)) {
+      className = 'text-blue-300'
+    } else if (/^[{}()[\].,<>/=]$/.test(token)) {
+      className = 'text-gray-400'
+    }
+
+    return (
+      <span key={`${token}-${index}`} className={className}>
+        {token}
+      </span>
+    )
+  })
+}
+
+function WhiteLabelWalletPreview({onConnect}: {onConnect: () => void}) {
+  const [email, setEmail] = useState('')
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    onConnect()
+  }
+
+  return (
+    <div className="flex min-h-[620px] w-full flex-col rounded-[34px] border border-zinc-800 bg-[#111111] p-1.5 text-white shadow-2xl sm:h-[624px]">
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-1 flex-col overflow-hidden rounded-[30px] bg-[#151515]"
+      >
+        <div className="relative overflow-hidden px-6 py-5">
+          <div className="absolute inset-0 bg-[linear-gradient(145deg,#0b0f14_0%,#111111_48%,#17131f_100%)]"/>
+          <div className="absolute inset-x-0 top-0 h-px bg-[linear-gradient(90deg,transparent,rgba(177,132,255,0.85),transparent)]"/>
+          <div className="absolute -right-10 -top-20 h-44 w-44 rounded-full bg-[#b184ff]/16 blur-3xl"/>
+          <div className="absolute -left-20 bottom-0 h-36 w-36 rounded-full bg-[#6dd8ff]/10 blur-3xl"/>
+
+          <div className="relative flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="grid h-12 w-12 place-items-center rounded-2xl bg-[#f6f2ff] text-2xl font-black italic text-[#111111] shadow-[0_18px_50px_rgba(177,132,255,0.22)]">
+                N
+              </div>
+              <div>
+                <p className="text-2xl font-semibold tracking-normal text-white">
+                  NOVA
+                </p>
+                <p className="text-xs font-medium text-zinc-500">
+                  Banking and wallets
+                </p>
+              </div>
+            </div>
+            <span className="rounded-full border border-[#b184ff]/30 bg-[#b184ff]/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[#ccb6ff]">
+              Demo
+            </span>
+          </div>
+        </div>
+
+        <div className="flex flex-1 flex-col justify-center px-6 py-7">
+          <div className="mb-7 text-center">
+            <h2 className="text-3xl font-semibold text-zinc-100">
+              Welcome back
+            </h2>
+            <p className="mt-2 text-sm text-zinc-500">
+              Sign in to continue to your account.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-[1fr_auto] gap-3">
+            <label className="relative">
+              <Mail className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-zinc-600"/>
+              <input
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                placeholder="you@company.com"
+                className="h-12 w-full rounded-xl border border-zinc-800 bg-[#1b1b1b] pl-12 pr-4 text-sm text-zinc-100 outline-none placeholder:text-zinc-600 focus:border-[#b184ff]"
+              />
+            </label>
+            <button
+              type="submit"
+              className="flex h-12 items-center gap-2 rounded-xl bg-[#f6f2ff] px-4 text-sm font-semibold text-[#111111] hover:bg-white cursor-pointer"
+            >
+              Continue
+              <ArrowRight className="h-4 w-4"/>
+            </button>
+          </div>
+
+          <div className="my-5 flex items-center gap-4">
+            <div className="h-px flex-1 bg-zinc-800"/>
+            <span className="text-xs font-semibold text-zinc-600">OR</span>
+            <div className="h-px flex-1 bg-zinc-800"/>
+          </div>
+
+          <button
+            type="button"
+            onClick={onConnect}
+            className="flex h-12 items-center justify-center gap-3 rounded-xl border border-zinc-800 bg-[#1b1b1b] px-4 text-sm font-medium text-zinc-200 hover:border-[#b184ff]/60 cursor-pointer"
+          >
+            <GoogleLogo/>
+            Continue with Google
+          </button>
+
+          <p className="mt-5 text-center text-xs leading-5 text-zinc-600">
+            By continuing you agree to NOVA&apos;s Terms of Service and Privacy Policy.
+          </p>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+function GoogleLogo() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      className="h-5 w-5"
+    >
+      <path
+        fill="#4285F4"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      />
+      <path
+        fill="#34A853"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M5.84 14.1c-.22-.66-.35-1.36-.35-2.1s.13-1.44.35-2.1V7.06H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.94l3.66-2.84z"
+      />
+      <path
+        fill="#EA4335"
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.06L5.84 9.9C6.71 7.3 9.14 5.38 12 5.38z"
+      />
+    </svg>
+  )
+}
+
+const demoModes: {value: DemoMode; label: string; description: string}[] = [
+  {
+    value: 'prebuilt',
+    label: 'Pre-built UI',
+    description:
+      'Start quickly with ready-made wallet components and optional state management, then customize as much or as little as you need over time.',
+  },
+  {
+    value: 'whiteLabel',
+    label: 'White-label',
+    description:
+      'Build a branded flow around the same wallet infrastructure so the experience meets customers where they are.',
+  },
 ]
 
 const demoValueProps = [
   {
-    title: '<SmartByDefault/>',
+    title: 'Any login method',
     description:
-      'Use EIP-7702 and ERC-4337 smart accounts as the default wallet model, not as a secondary add-on.',
+      'Support passkeys, email, social login, or your own authentication flow without rebuilding wallet infrastructure.',
+    codeLabel: 'Add Google OAuth',
+    code: `import {
+  OAUTH_PROVIDERS,
+  useAuthenticateOAuth,
+} from '@zerodev/wallet-react'
+
+const authenticateOAuth = useAuthenticateOAuth()
+
+authenticateOAuth.mutateAsync({
+  provider: OAUTH_PROVIDERS.GOOGLE,
+})`,
   },
   {
-    title: '<NativeAA/>',
+    title: 'Smart wallets by default',
     description:
-      'Build with gas sponsorship, transaction batching, automation, and chain abstraction as native APIs.',
+      'Every user gets a smart wallet ready for sponsored gas, batching, automation, and smoother transactions.',
+    codeLabel: 'Use the component kit',
+    code: `import { AuthFlow } from '@zerodev/wallet-react-kit'
+
+export function SignIn() {
+  return <AuthFlow />
+}`,
   },
   {
-    title: '<HybridSecurity/>',
+    title: 'Your brand, your UI',
     description:
-      'Combine off-chain key management with on-chain smart account controls for a self-custodial wallet flow.',
+      'Use the pre-built wallet UI or build a white-label experience with your own screens and components.',
+    codeLabel: 'Own the UI',
+    code: `const authenticateEmail = useAuthenticateEmail()
+
+async function signIn(email: string) {
+  await authenticateEmail.mutateAsync({ email })
+}
+
+return <EmailForm onSubmit={signIn} />`,
   },
 ]

--- a/apps/zerodev-signer-demo/src/app/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/page.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import {AuthFlow, useAuth} from '@zerodev/wallet-react-kit'
-import {Settings} from 'lucide-react'
 import {useRouter, useSearchParams} from 'next/navigation'
 import {Suspense, useEffect, useState} from 'react'
 import {useAccount, useConnect} from 'wagmi'
 
 export const dynamic = 'force-dynamic'
 
-type EmailAuthMethod = 'otp' | 'magicLink'
+type DemoMode = 'prebuilt' | 'whiteLabel'
 
 export default function LandingPage() {
   return (
@@ -22,6 +21,7 @@ function LandingPageInner() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const sessionExpired = searchParams.get('session_expired') === 'true'
+  const [demoMode, setDemoMode] = useState<DemoMode>('prebuilt')
 
   const [loggedOut] = useState(() => {
     if (typeof window === 'undefined') return false
@@ -48,6 +48,7 @@ function LandingPageInner() {
       router.push('/dashboard')
       return
     }
+    if (demoMode === 'whiteLabel') return
     if (skipAutoConnect) return
     if (
       accountStatus === 'disconnected' &&
@@ -63,22 +64,34 @@ function LandingPageInner() {
     router,
     connect,
     connectors,
+    demoMode,
     skipAutoConnect,
   ])
 
   return (
-    <div
-      className="mx-auto w-full max-w-[500px] flex flex-col flex-1 sm:max-w-none sm:flex-row sm:items-center sm:justify-center">
+    <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-4 py-6 sm:px-6 sm:py-10 lg:flex-row lg:items-start lg:justify-between lg:gap-14">
+      <DemoIntroPanel mode={demoMode} onModeChange={setDemoMode}/>
       {sessionExpired && (
         <div
-          className="m-4 px-4 py-3 rounded-lg text-sm text-center bg-yellow-50 text-yellow-700 border border-yellow-200">
+          className="px-4 py-3 rounded-lg text-sm text-center bg-yellow-50 text-yellow-700 border border-yellow-200 lg:hidden">
           Your session has expired. Please log in again.
         </div>
       )}
-      <div className="flex-1 w-full flex flex-col sm:flex-none sm:w-[500px] sm:h-[800px]">
-        <EmailMethodSettings/>
-        <AuthFlow/>
-        {showReconnect && (
+      <div className="relative mx-auto flex w-full max-w-[430px] flex-col sm:h-[688px] lg:mx-0 lg:shrink-0">
+        {sessionExpired && (
+          <div
+            className="mb-4 hidden px-4 py-3 rounded-lg text-sm text-center bg-yellow-50 text-yellow-700 border border-yellow-200 lg:block">
+            Your session has expired. Please log in again.
+          </div>
+        )}
+        {demoMode === 'prebuilt' ? (
+          <div className="w-full flex flex-col sm:w-[500px] sm:h-[800px] sm:origin-top sm:scale-[0.86]">
+            <AuthFlow/>
+          </div>
+        ) : (
+          <WhiteLabelWalletPreview onConnect={handleReconnect}/>
+        )}
+        {demoMode === 'prebuilt' && showReconnect && (
           <div className="flex-1 flex items-center justify-center p-6">
             <button
               type="button"
@@ -94,95 +107,142 @@ function LandingPageInner() {
   )
 }
 
-function EmailMethodSettings() {
-  const {step} = useAuth()
-  const [open, setOpen] = useState(false)
-  const [method, setMethod] = useState<EmailAuthMethod>(() => {
-    if (typeof window === 'undefined') return 'otp'
-    return localStorage.getItem('zd:emailAuthMethod') === 'magicLink'
-      ? 'magicLink'
-      : 'otp'
-  })
-
-  const handleSave = (next: EmailAuthMethod) => {
-    localStorage.setItem('zd:emailAuthMethod', next)
-    window.location.reload()
-  }
-
-  const handleOpen = () => {
-    // Re-sync from storage on open so a previous Cancel doesn't leave the
-    // radios pointing at an unsaved selection.
-    setMethod(
-      localStorage.getItem('zd:emailAuthMethod') === 'magicLink'
-        ? 'magicLink'
-        : 'otp',
-    )
-    setOpen(true)
-  }
-
-  if (step === null || step === 'authenticated') return null
-
+function DemoIntroPanel({
+  mode,
+  onModeChange,
+}: {
+  mode: DemoMode
+  onModeChange: (mode: DemoMode) => void
+}) {
   return (
-    <div className="flex justify-end pb-2">
-      <button
-        type="button"
-        onClick={handleOpen}
-        aria-label="Email method settings"
-        className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
-      >
-        <Settings className="h-6 w-6"/>
-      </button>
-      {open && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
-          onClick={() => setOpen(false)}
-        >
-          <div
-            className="bg-white rounded-lg shadow-lg p-6 w-[320px] flex flex-col gap-4"
-            onClick={(e) => e.stopPropagation()}
+    <aside className="w-full max-w-2xl pt-2 lg:pt-8">
+      <p className="mb-4 text-sm font-semibold uppercase text-blue-500">
+        Wallet Demo
+      </p>
+      <h1 className="max-w-[620px] text-4xl font-semibold leading-tight text-gray-950">
+        The first AA native embedded wallet
+      </h1>
+      <p className="mt-5 max-w-[620px] text-lg leading-8 text-gray-500">
+        ZeroDev Wallet combines embedded authentication with smart accounts by
+        default, so account abstraction features are native to the wallet
+        experience.
+      </p>
+
+      <div className="mt-10 inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
+        {demoModes.map((item) => (
+          <button
+            key={item.value}
+            type="button"
+            onClick={() => onModeChange(item.value)}
+            className={`rounded-md px-4 py-2 text-sm font-semibold transition-colors cursor-pointer ${
+              mode === item.value
+                ? 'bg-white text-gray-950 shadow-sm'
+                : 'text-gray-500 hover:text-gray-800'
+            }`}
           >
-            <h2 className="text-base font-semibold text-gray-900">
-              Email auth method
-            </h2>
-            <label className="flex items-center gap-2 cursor-pointer text-sm">
-              <input
-                type="radio"
-                name="emailAuthMethod"
-                value="otp"
-                checked={method === 'otp'}
-                onChange={() => setMethod('otp')}
-              />
-              <span className="text-gray-700">OTP code</span>
-            </label>
-            <label className="flex items-center gap-2 cursor-pointer text-sm">
-              <input
-                type="radio"
-                name="emailAuthMethod"
-                value="magicLink"
-                checked={method === 'magicLink'}
-                onChange={() => setMethod('magicLink')}
-              />
-              <span className="text-gray-700">Magic link</span>
-            </label>
-            <div className="flex justify-end gap-2 mt-2">
-              <button
-                type="button"
-                onClick={() => setOpen(false)}
-                className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 cursor-pointer"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={() => handleSave(method)}
-                className="px-3 py-1.5 text-sm bg-gray-900 text-white rounded-md hover:bg-gray-800 cursor-pointer"
-              >
-                Save and reload
-              </button>
+            {item.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-16 divide-y divide-gray-200 border-y border-gray-200">
+        {demoValueProps.map((item) => (
+          <div key={item.title} className="py-6">
+            <div className="flex items-center justify-between gap-4">
+              <h2 className="font-mono text-2xl font-semibold text-gray-900">
+                {item.title}
+              </h2>
+              <span className="h-2 w-2 rounded-full bg-gray-400"/>
             </div>
+            <p className="mt-4 max-w-[620px] text-base leading-7 text-gray-500">
+              {item.description}
+            </p>
+          </div>
+        ))}
+      </div>
+    </aside>
+  )
+}
+
+function WhiteLabelWalletPreview({onConnect}: {onConnect: () => void}) {
+  return (
+    <div className="flex min-h-[620px] w-full flex-col rounded-[34px] border border-gray-200 bg-[#101828] p-1.5 text-white shadow-2xl sm:h-[688px]">
+      <div className="flex flex-1 flex-col rounded-[30px] bg-white px-6 py-7 text-gray-950">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-gray-500">Acme Finance</p>
+            <h2 className="mt-1 text-2xl font-semibold">Create your wallet</h2>
+          </div>
+          <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-blue-600 text-sm font-semibold text-white">
+            A
           </div>
         </div>
-      )}
+
+        <div className="mt-12 rounded-2xl bg-gray-50 p-5">
+          <p className="text-sm font-semibold text-gray-900">
+            Powered by ZeroDev Wallet Core
+          </p>
+          <p className="mt-2 text-sm leading-6 text-gray-500">
+            Keep the authentication, key management, and smart account APIs
+            underneath while your app owns every pixel of the wallet UI.
+          </p>
+        </div>
+
+        <div className="mt-8 flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={onConnect}
+            className="rounded-2xl bg-blue-600 px-5 py-4 text-base font-semibold text-white hover:bg-blue-700 cursor-pointer"
+          >
+            Continue with passkey
+          </button>
+          <button
+            type="button"
+            onClick={onConnect}
+            className="rounded-2xl border border-gray-200 px-5 py-4 text-base font-semibold text-gray-900 hover:bg-gray-50 cursor-pointer"
+          >
+            Continue with Google
+          </button>
+          <button
+            type="button"
+            onClick={onConnect}
+            className="rounded-2xl border border-gray-200 px-5 py-4 text-base font-semibold text-gray-900 hover:bg-gray-50 cursor-pointer"
+          >
+            Continue with email
+          </button>
+        </div>
+
+        <div className="mt-auto border-t border-gray-100 pt-6">
+          <p className="text-xs leading-5 text-gray-500">
+            This mode demonstrates a white-label integration: your design
+            system owns the interface, while ZeroDev provides the wallet
+            primitive underneath.
+          </p>
+        </div>
+      </div>
     </div>
   )
 }
+
+const demoModes: {value: DemoMode; label: string}[] = [
+  {value: 'prebuilt', label: 'Pre-built UI'},
+  {value: 'whiteLabel', label: 'White-label'},
+]
+
+const demoValueProps = [
+  {
+    title: '<SmartByDefault/>',
+    description:
+      'Use EIP-7702 and ERC-4337 smart accounts as the default wallet model, not as a secondary add-on.',
+  },
+  {
+    title: '<NativeAA/>',
+    description:
+      'Build with gas sponsorship, transaction batching, automation, and chain abstraction as native APIs.',
+  },
+  {
+    title: '<HybridSecurity/>',
+    description:
+      'Combine off-chain key management with on-chain smart account controls for a self-custodial wallet flow.',
+  },
+]

--- a/apps/zerodev-signer-demo/src/app/verify/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/verify/page.tsx
@@ -26,9 +26,11 @@ function VerifyPageInner() {
   }, [isConnected, router])
 
   return (
-    <div className="mx-auto w-full max-w-[500px] min-h-screen flex flex-col sm:max-w-none sm:h-screen sm:min-h-0 sm:flex-row sm:items-center sm:justify-center">
-      <div className="flex-1 w-full flex flex-col sm:flex-none sm:w-[500px] sm:h-[800px]">
-        <AuthFlow />
+    <div className="mx-auto w-full max-w-[500px] flex flex-col flex-1 px-4 py-6 sm:max-w-none sm:flex-row sm:items-start sm:justify-center sm:px-6 sm:py-10">
+      <div className="w-full flex flex-col sm:w-[430px] sm:h-[688px]">
+        <div className="w-full flex flex-col sm:w-[500px] sm:h-[800px] sm:origin-top sm:scale-[0.86]">
+          <AuthFlow />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Updates the signer demo auth layout so the wallet panel is smaller and positioned higher on desktop.

Moves the email auth settings control into the external app navbar on the top-right side. No React kit package source changes are included.

## Validation

- `npx -y pnpm@10.17.1 --filter @zerodev/signer-demo build`

Note: the build completed with an existing warning about an unused eslint-disable directive in `src/app/dashboard/page.tsx`.