### PR TITLE
fix(expo-example): google oauth https redirect broken on ios on expo v56

### DIFF
--- a/apps/expo-example/src/config/auth.ts
+++ b/apps/expo-example/src/config/auth.ts
@@ -1,4 +1,5 @@
 import * as Linking from 'expo-linking'
+import { Platform } from 'react-native'
 
 // RP_ID needs to match the domain that hosts /.well-known/assetlinks.json
 // (shared across contributors; see README "Running with Passkeys on Android").
@@ -15,6 +16,13 @@ export const VERIFY_EMAIL_REDIRECT_URI = buildRedirectUri('verify-email')
 const oauthUseCustomScheme =
   process.env.EXPO_PUBLIC_OAUTH_USE_CUSTOM_SCHEME === 'true'
 
-export const OAUTH_REDIRECT_URI = oauthUseCustomScheme
-  ? Linking.createURL('oauth-callback')
-  : buildRedirectUri('oauth-callback')
+// iOS only observes https OAuth redirects through ASWebAuthenticationSession's
+// `.https(host:path:)` callback, which requires iOS 17.4+. Older versions
+// can't complete the https flow, so fall back to the custom scheme there.
+const supportsHttpsOAuthCallback =
+  Platform.OS !== 'ios' || Number.parseFloat(String(Platform.Version)) >= 17.4
+
+export const OAUTH_REDIRECT_URI =
+  oauthUseCustomScheme || !supportsHttpsOAuthCallback
+    ? Linking.createURL('oauth-callback')
+    : buildRedirectUri('oauth-callback')

--- a/packages/react/src/native/oauth/expoWebBrowser.ts
+++ b/packages/react/src/native/oauth/expoWebBrowser.ts
@@ -49,6 +49,16 @@ export function createOAuthGetSessionIdWithExpoWebBrowser(params: {
     const fromBrowser = WebBrowser.openAuthSessionAsync(
       oauthUrl,
       params.redirectUri,
+      {
+        // iOS 17.4+: use the ASWebAuthenticationSession `.https(host:path:)`
+        // callback for https redirect URIs — without it the session falls back
+        // to callbackURLScheme "https", which never matches, and the flow
+        // dead-ends on the redirect page (expo-web-browser 56 made this
+        // opt-in; 55 applied it automatically). Requires the app to carry the
+        // Associated Domains `webcredentials:<host>` entitlement (same one
+        // passkeys use). No-op on Android and for custom-scheme redirects.
+        preferUniversalLinks: params.redirectUri.startsWith('https:'),
+      },
     ).then((r) => {
       if (r.type !== 'success') throw new Error('OAuth cancelled or failed')
       const parsed = new URL(r.url)


### PR DESCRIPTION
<!-- av pr stack begin -->
<table><tr><td><details><summary><b>Depends on #250.</b> This PR is part of a stack created with <a href="https://github.com/aviator-co/av">Aviator</a>.</summary>

* ➡️ **#251**
* **#250**
* `main`
</details></td></tr></table>
<!-- av pr stack end -->


Context:
While writing the iOS docs Claude Fable raised an issue that on Expo 56 the iOS OAuth with `https` redirect doesn't work. This PR implements the fix but since I don't have a physical device to test I can't verify neither the problem nor the solution so I need some help with it.
The previous PR in the stack migrates the `expo-example` app to Expo 56. 
So the following verification steps can be taken:
1. Test Google OAuth with Universal Links (`https` redirect url) on `main` on iOS Simulator and on a physical iOS device - it should work
2. Test the same on [the previous PR's](https://github.com/zerodevapp/zerodev-wallet-sdk/pull/250) branch. This migrates the app to Expo 56. - the Google OAuth should be broken, stuck before the redirect or on the `https` url in the web browser
3. Test on this PR's branch - the redirect should now work.

The description below is Claude's plan that describes the problem and the fix.

---
# forward `preferUniversalLinks` so iOS `https` OAuth redirects work on Expo SDK 56+

Context gathered in a docs-repo Claude Code session on 2026-06-10 (Andras). This file is
self-contained — everything an agent needs to implement and verify the fix is below.

## Problem

`createOAuthGetSessionIdWithExpoWebBrowser` calls `WebBrowser.openAuthSessionAsync(oauthUrl, redirectUri)`
with **no options** (`packages/react/src/native/oauth/expoWebBrowser.ts`, the `fromBrowser` branch).

On iOS, an `https` redirect URI (e.g. `https://zerodev-expo-example.vercel.app/oauth-callback`)
only works through `ASWebAuthenticationSession`'s iOS 17.4+ `.https(host:path:)` callback —
the session itself matches the redirect against the host/path and resolves. (It is NOT Universal
Link routing: iOS never opens an app from the server-side 302 that ends the OAuth flow, and the
expo-example AASA doesn't claim `/oauth-callback` — nor does it need to.)

Whether expo-web-browser uses that API depends on its version:

- **expo-web-browser 55.0.8+** (Expo SDK 55 — what `apps/expo-example` is pinned to):
  applies `.https(host:path:)` **automatically** whenever the redirect URL is `https` and the
  device is iOS 17.4+ (expo/expo#42695). This is why the https OAuth redirect worked in
  expo-example's iOS testing (PR #202 / Linear FS-2198).
- **expo-web-browser 56** (Expo SDK 56): the auto-behavior silently broke apps *without* the
  Associated Domains entitlement, so it became **opt-in** via `openAuthSessionAsync`'s
  `preferUniversalLinks: true` option, default `false` (expo/expo#44452 — see the v56 CHANGELOG).

Since the SDK passes no options, **every consumer on Expo SDK 56+ that passes an `https`
redirectUri gets a dead flow on iOS**: the legacy fallback is
`ASWebAuthenticationSession(callbackURLScheme: "https")`, which never matches, and the
`Linking` listener never fires (no UL claim, and iOS ignores server redirects to ULs anyway).
The user is stranded on the redirect page inside the auth sheet.

This also means **`apps/expo-example` will regress when it upgrades to Expo SDK 56+**, because
`src/config/auth.ts` defaults `OAUTH_REDIRECT_URI` to the https link on both platforms.

## Suggested fix

In `packages/react/src/native/oauth/expoWebBrowser.ts`, pass the option when the redirect is https:

```ts
const fromBrowser = WebBrowser.openAuthSessionAsync(oauthUrl, params.redirectUri, {
  // iOS 17.4+: use the ASWebAuthenticationSession `.https(host:path:)` callback for
  // https redirect URIs. Requires the app to carry the Associated Domains
  // `webcredentials:<host>` entitlement (same one passkeys use). No-op on Android
  // and for custom-scheme redirects.
  preferUniversalLinks: params.redirectUri.startsWith('https:'),
}).then(/* unchanged */)
```

Auto-detection (rather than a new public option) restores the Expo-55 behavior for SDK users:
anyone passing an `https` redirectUri has opted into domain setup. The expo-web-browser concern
that motivated the opt-in (apps without the entitlement silently failing) doesn't really apply
here — without the entitlement an https redirect was already broken through this helper.

The published docs were written against this auto-detect shape ("the hook detects the `https`
redirect — no extra option needed"). If you instead expose a `webBrowserOptions` passthrough on
`useAuthenticateOAuthWithExpoWebBrowser`, tell Andras so the docs get adjusted.

Notes / constraints:

- `preferUniversalLinks` is iOS-only and ignored on Android — safe to pass unconditionally.
- iOS < 17.4 still can't observe https callbacks; expo-web-browser falls back to the broken
  legacy path. Consider documenting (or guarding) that consumers should fall back to a
  custom-scheme redirectUri below 17.4 — the docs show a `Platform.Version` check.
- Requirements on the app side (already true for expo-example): `webcredentials:<domain>` in
  `ios.associatedDomains` + `appleTeamId` (paid Apple team), AASA hosted with
  `webcredentials.apps: ["<TEAM>.<bundleID>"]`, prebuild --clean after entitlement changes.
  No `applinks` claim is needed for `/oauth-callback`.

## How to verify

1. In `apps/expo-example`, bump expo-web-browser to 56+ (or test in any Expo 56 app wired to
   the workspace SDK, e.g. zd-wallet-demo), leave `EXPO_PUBLIC_OAUTH_USE_CUSTOM_SCHEME` unset
   so the https redirect is used.
5. Build to an iOS 17.4+ device (paid team, entitlement baked in; `?mode=developer` on the
   `webcredentials:` entry helps skip Apple's AASA CDN cache).
6. Without the fix: Google OAuth dead-ends on the redirect page inside the auth sheet.
   With the fix: the sheet closes itself and the wallet connects (the `fromBrowser` branch
   resolves with the redirect URL carrying `session_id`).
7. Regression-check Android (custom scheme and App Link redirects) and iOS with a
   custom-scheme redirectUri — all should behave exactly as before.

## Pointers

- SDK call site: `packages/react/src/native/oauth/expoWebBrowser.ts` (`fromBrowser`)
- Hook: `packages/react/src/native/oauth/useAuthenticateOAuthWithExpoWebBrowser.ts`
- expo-example OAuth wiring: `apps/expo-example/src/config/auth.ts`,
  `src/hooks/useAuthenticateOAuth.native.ts`
- expo-example iOS setup commit: `cbb31d4` (PR #202); AASA at
  `apps/expo-example/assetlinks/public/.well-known/apple-app-site-association`
- expo-web-browser behavior: compare `node_modules/expo-web-browser/ios/WebAuthSession.swift`
  between Expo 55 (auto) and 56 (gated on `options.preferUniversalLinks`); v56 CHANGELOG entry
  for expo/expo#44452 documents the flip.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"andras/chore-expo-example-migrate-to-sdk-56","parentHead":"8f9fcd530ea7e6348b7763110287f2fb02a3ccee","parentPull":250,"trunk":"main"}
```
-->
