### PR TITLE
Signer demo: permissions + signing flows and wallet UI polish

### DIFF
--- a/apps/zerodev-signer-demo/package.json
+++ b/apps/zerodev-signer-demo/package.json
@@ -14,6 +14,7 @@
     "@tanstack/react-query": "^5.0.0",
     "@wagmi/core": "^2.22.0",
     "@zerodev/ecdsa-validator": "^5.4.9",
+    "@zerodev/permissions": "^5.6.3",
     "@zerodev/sdk": "^5.0.0",
     "@zerodev/wallet-core": "workspace:*",
     "@zerodev/wallet-react": "workspace:*",

--- a/apps/zerodev-signer-demo/src/app/components/ChainSelector.tsx
+++ b/apps/zerodev-signer-demo/src/app/components/ChainSelector.tsx
@@ -10,10 +10,8 @@ export function ChainSelector() {
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const { chain } = useAccount();
-  console.log("chain", chain);
   const { switchChain, isPending } = useSwitchChain();
   const chains = useChains();
-  console.log("chains", chains);
 
   // Close dropdown when clicking outside
   useEffect(() => {

--- a/apps/zerodev-signer-demo/src/app/components/FaucetLink.tsx
+++ b/apps/zerodev-signer-demo/src/app/components/FaucetLink.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import { Check } from "lucide-react";
+
+/**
+ * A faucet link that first copies the user's wallet address to the clipboard,
+ * briefly confirms it ("Address copied"), then opens the faucet — so the address
+ * is ready to paste. While in the copied state the control stays clickable, which
+ * doubles as a fallback if the browser blocks the delayed popup.
+ */
+export function FaucetLink({
+  address,
+  children,
+  className,
+  href,
+}: {
+  address?: string | null
+  children: ReactNode
+  className?: string
+  href: string
+}) {
+  const [copied, setCopied] = useState(false);
+  const resetTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimer.current) window.clearTimeout(resetTimer.current);
+    };
+  }, []);
+
+  const openFaucet = () => {
+    window.open(href, "_blank", "noopener,noreferrer");
+  };
+
+  const handleClick = async () => {
+    if (copied) {
+      // Second click (or fallback if the auto-open was blocked): just open.
+      openFaucet();
+      return;
+    }
+    if (address) {
+      try {
+        await navigator.clipboard.writeText(address);
+      } catch {
+        /* clipboard may be unavailable; still open the faucet below */
+      }
+    }
+    setCopied(true);
+    if (resetTimer.current) window.clearTimeout(resetTimer.current);
+    resetTimer.current = window.setTimeout(() => {
+      openFaucet();
+      resetTimer.current = window.setTimeout(() => setCopied(false), 800);
+    }, 1000);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={className}
+      title={
+        copied
+          ? "Wallet address copied — opening faucet"
+          : "Copies your wallet address, then opens the faucet"
+      }
+    >
+      {copied ? (
+        <>
+          <Check className="h-3.5 w-3.5" />
+          Address copied
+        </>
+      ) : (
+        children
+      )}
+    </button>
+  );
+}

--- a/apps/zerodev-signer-demo/src/app/components/Navbar.tsx
+++ b/apps/zerodev-signer-demo/src/app/components/Navbar.tsx
@@ -47,14 +47,15 @@ export function Navbar() {
   return (
     <>
       <LogoutOverlay visible={loggingOut}/>
-      <header className="bg-white border-b border-gray-100">
+      <header className="sticky top-0 z-40 border-b border-white/50 bg-white/55 backdrop-blur-xl supports-[backdrop-filter]:bg-white/45">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-20">
             <div className="flex items-center gap-3">
-              <img src="/images/zerodev-logo.png" alt="ZeroDev Logo" className="w-10 h-10" />
-              <div className="flex flex-col">
-                <span className="text-xl font-semibold text-gray-900 leading-tight">ZeroDev</span>
-                <span className="text-xs text-gray-500">By Offchain Labs</span>
+              <div className="flex items-center gap-2.5">
+                <img src="/images/zerodev-logo.png" alt="ZeroDev Logo" className="h-10 w-10" />
+                <span className="text-2xl font-semibold leading-none tracking-tight text-gray-900">
+                  ZeroDev
+                </span>
               </div>
               <span className="text-sm px-3 py-1.5 bg-blue-50 text-blue-500 rounded-full font-medium border border-blue-100">
                 Wallet Demo
@@ -62,6 +63,35 @@ export function Navbar() {
             </div>
 
             <div className="flex items-center gap-3">
+              <nav
+                aria-label="Primary navigation"
+                className="hidden items-center gap-6 md:flex"
+              >
+                <a
+                  href="https://docs.zerodev.app"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-950"
+                >
+                  Documentation
+                </a>
+                <a
+                  href="https://dashboard.zerodev.app"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-950"
+                >
+                  Get your API keys
+                </a>
+                <a
+                  href="https://zerodev.app/book-a-demo"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex h-9 items-center rounded-full bg-gray-950 px-4 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-gray-800"
+                >
+                  Contact sales
+                </a>
+              </nav>
               {isConnected && address && (
                 <>
                   <ChainSelector />

--- a/apps/zerodev-signer-demo/src/app/components/Navbar.tsx
+++ b/apps/zerodev-signer-demo/src/app/components/Navbar.tsx
@@ -1,128 +1,53 @@
 /* eslint-disable @next/next/no-img-element */
-'use client'
-
-import { useEffect, useState } from 'react'
-import { Check, Copy, LogOut, Wallet } from 'lucide-react'
-import { usePathname, useRouter } from 'next/navigation'
-import { useAccount, useDisconnect } from 'wagmi'
-import { ChainSelector } from './ChainSelector'
-import { LogoutOverlay } from './LogoutOverlay'
 
 export function Navbar() {
-  const router = useRouter()
-  const pathname = usePathname()
-  const { address, isConnected } = useAccount()
-  const { disconnectAsync } = useDisconnect()
-  const [copied, setCopied] = useState(false)
-  const [loggingOut, setLoggingOut] = useState(false)
-
-  useEffect(() => {
-    if (pathname === '/') {
-      setLoggingOut(false)
-    }
-  }, [pathname])
-
-  const handleCopy = async () => {
-    if (!address) return
-    await navigator.clipboard.writeText(address)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
-  }
-
-  const handleLogout = async () => {
-    setLoggingOut(true)
-    localStorage.setItem('zd:loggedOut', 'true')
-    try {
-      await disconnectAsync()
-    } catch {
-      setLoggingOut(false)
-      return
-    }
-    router.push('/?logged_out=true')
-  }
-
-  const formatAddress = (addr: string) =>
-    `${addr.slice(0, 6)}...${addr.slice(-4)}`
-
   return (
-    <>
-      <LogoutOverlay visible={loggingOut}/>
-      <header className="sticky top-0 z-40 border-b border-white/50 bg-white/55 backdrop-blur-xl supports-[backdrop-filter]:bg-white/45">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-20">
-            <div className="flex items-center gap-3">
-              <div className="flex items-center gap-2.5">
-                <img src="/images/zerodev-logo.png" alt="ZeroDev Logo" className="h-10 w-10" />
-                <span className="text-2xl font-semibold leading-none tracking-tight text-gray-900">
-                  ZeroDev
-                </span>
-              </div>
-              <span className="text-sm px-3 py-1.5 bg-blue-50 text-blue-500 rounded-full font-medium border border-blue-100">
-                Wallet Demo
+    <header className="sticky top-0 z-40 border-b border-white/50 bg-white/55 backdrop-blur-xl supports-[backdrop-filter]:bg-white/45">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between h-20">
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2.5">
+              <img src="/images/zerodev-logo.png" alt="ZeroDev Logo" className="h-10 w-10" />
+              <span className="text-2xl font-semibold leading-none tracking-tight text-gray-900">
+                ZeroDev
               </span>
             </div>
-
-            <div className="flex items-center gap-3">
-              <nav
-                aria-label="Primary navigation"
-                className="hidden items-center gap-6 md:flex"
-              >
-                <a
-                  href="https://docs.zerodev.app"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-950"
-                >
-                  Documentation
-                </a>
-                <a
-                  href="https://dashboard.zerodev.app"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-950"
-                >
-                  Get your API keys
-                </a>
-                <a
-                  href="https://zerodev.app/book-a-demo"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex h-9 items-center rounded-full bg-gray-950 px-4 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-gray-800"
-                >
-                  Contact sales
-                </a>
-              </nav>
-              {isConnected && address && (
-                <>
-                  <ChainSelector />
-                  <div className="hidden sm:flex items-center gap-2 px-3 py-1.5 bg-gray-50 rounded-lg border border-gray-200 group cursor-pointer">
-                    <Wallet className="h-4 w-4 text-gray-500" />
-                    <span className="text-sm font-mono text-gray-700">{formatAddress(address)}</span>
-                    <button
-                      onClick={handleCopy}
-                      className="text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
-                    >
-                      {copied ? (
-                        <Check className="h-3.5 w-3.5 text-green-600" />
-                      ) : (
-                        <Copy className="h-3.5 w-3.5" />
-                      )}
-                    </button>
-                  </div>
-                  <button
-                    onClick={handleLogout}
-                    disabled={loggingOut}
-                    className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all cursor-pointer"
-                    title="Logout"
-                  >
-                    <LogOut className="h-4 w-4" />
-                  </button>
-                </>
-              )}
-            </div>
+            <span className="text-sm px-3 py-1.5 bg-blue-50 text-blue-500 rounded-full font-medium border border-blue-100">
+              Wallet Demo
+            </span>
           </div>
+
+          <nav
+            aria-label="Primary navigation"
+            className="hidden items-center gap-6 md:flex"
+          >
+            <a
+              href="https://docs.zerodev.app"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-950"
+            >
+              Documentation
+            </a>
+            <a
+              href="https://dashboard.zerodev.app"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-950"
+            >
+              Get your API keys
+            </a>
+            <a
+              href="https://zerodev.app/book-a-demo"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex h-9 items-center rounded-full bg-gray-950 px-4 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-gray-800"
+            >
+              Contact sales
+            </a>
+          </nav>
         </div>
-      </header>
-    </>
+      </div>
+    </header>
   )
 }

--- a/apps/zerodev-signer-demo/src/app/components/Navbar.tsx
+++ b/apps/zerodev-signer-demo/src/app/components/Navbar.tsx
@@ -2,8 +2,8 @@
 
 export function Navbar() {
   return (
-    <header className="sticky top-0 z-40 border-b border-white/50 bg-white/55 backdrop-blur-xl supports-[backdrop-filter]:bg-white/45">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <header className="sticky top-0 z-40 border-b border-gray-200 bg-white shadow-sm">
+      <div className="w-full px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-20">
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-2.5">

--- a/apps/zerodev-signer-demo/src/app/components/SendTransactionTest.tsx
+++ b/apps/zerodev-signer-demo/src/app/components/SendTransactionTest.tsx
@@ -1,18 +1,22 @@
 "use client";
 
 import { type ReactNode, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Sparkles, AlertCircle, Loader2, Check, ChevronDown, Code2, ExternalLink, Trash2, Shuffle } from "lucide-react";
 import { cn } from "../lib/utils";
 import {
   type Address,
+  type PublicClient,
+  createPublicClient,
   encodeFunctionData,
+  http,
   parseAbi,
   parseEventLogs,
   parseAbiItem,
   zeroAddress,
 } from "viem";
 import { getZeroDevConnector, getZeroDevStore } from "@zerodev/wallet-react";
-import { sepolia } from "wagmi/chains";
+import { arbitrumSepolia, sepolia } from "wagmi/chains";
 import { useAccount, useConfig, usePublicClient } from "wagmi";
 
 // Per-chain NFT contract addresses
@@ -33,7 +37,44 @@ const NFT_TRANSFER_EVENT = parseAbiItem(
   "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)"
 );
 
+// Public archive RPCs used ONLY for the read-only Transfer-log scan that
+// rebuilds the gallery from chain history. The wallet's configured RPC is a
+// bundler endpoint and may not support (or may range-limit) eth_getLogs, so we
+// scan against a known-good full node instead. Verified to handle a
+// topic-filtered fromBlock:0 query.
+const LOG_SCAN_CHAINS = {
+  [arbitrumSepolia.id]: arbitrumSepolia,
+  [sepolia.id]: sepolia,
+} as const;
+
+const LOG_SCAN_RPC_URLS: Record<number, string> = {
+  [arbitrumSepolia.id]: "https://sepolia-rollup.arbitrum.io/rpc",
+  [sepolia.id]: "https://ethereum-sepolia-rpc.publicnode.com",
+};
+
+const logScanClientCache = new Map<number, PublicClient>();
+
+function getLogScanClient(chainId?: number): PublicClient | undefined {
+  if (!chainId) return undefined;
+  const cached = logScanClientCache.get(chainId);
+  if (cached) return cached;
+
+  const chain = LOG_SCAN_CHAINS[chainId as keyof typeof LOG_SCAN_CHAINS];
+  const url = LOG_SCAN_RPC_URLS[chainId];
+  if (!chain || !url) return undefined;
+
+  const client = createPublicClient({ chain, transport: http(url) }) as PublicClient;
+  logScanClientCache.set(chainId, client);
+  return client;
+}
+
 const DEAD_ADDRESS = "0x000000000000000000000000000000000000dEaD" as const;
+
+// How far back to scan Transfer logs when there's no localStorage cache.
+// Arbitrum Sepolia produces blocks roughly every ~0.25s, so 8,000 blocks is
+// comfortably more than the ~10 minutes of recent history we care about, while
+// staying under the ~10k block-range cap common to public RPC providers.
+const RECENT_TRANSFER_BLOCK_WINDOW = BigInt(8000);
 
 type MintedNft = {
   blockNumber?: bigint
@@ -321,6 +362,7 @@ export function SendTransactionTest({
   nftFocusRequest?: number
   onNftCountChange?: (count: number) => void
 }) {
+  const [mounted, setMounted] = useState(false);
   const [error, setError] = useState<string>("");
   const [mintedNfts, setMintedNfts] = useState<MintedNft[]>([]);
   const [mintStatus, setMintStatus] = useState<MintStatus>("idle");
@@ -345,6 +387,16 @@ export function SendTransactionTest({
   const [latestBurnedTokenId, setLatestBurnedTokenId] = useState<string | null>(null);
   const [latestMintedTokenId, setLatestMintedTokenId] = useState<string | null>(null);
   const selectedImageByTokenIdRef = useRef<Record<string, string>>({});
+  const galleryScrollRef = useRef<HTMLDivElement>(null);
+  // Always-current snapshot of the gallery, so mutators can compute the next
+  // array synchronously and persist exactly what they set — no reactive effect
+  // that could race the async load and clobber the cache with stale state.
+  const mintedNftsRef = useRef<MintedNft[]>([]);
+  mintedNftsRef.current = mintedNfts;
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   // Wagmi hooks
   const { address, isConnected, chain } = useAccount();
@@ -362,32 +414,6 @@ export function SendTransactionTest({
   const nftActionInProgress = mintInProgress || Boolean(burningTokenId);
   const checkoutImageUrl = getPicsumImageUrl(previewImageSeed);
   const nextMintLabel = nextMintTokenId === "preview" ? "Next" : `#${nextMintTokenId}`;
-  const mintStatusSteps = [
-    {
-      key: "submitting",
-      label: "Submitting",
-      done: mintStatus !== "idle",
-      active: mintStatus === "submitting",
-    },
-    {
-      key: "submitted",
-      label: "Tx submitted",
-      done: ["submitted", "confirmed", "syncing"].includes(mintStatus),
-      active: mintStatus === "submitted",
-    },
-    {
-      key: "confirmed",
-      label: "Confirmed",
-      done: ["confirmed", "syncing"].includes(mintStatus),
-      active: mintStatus === "confirmed",
-    },
-    {
-      key: "syncing",
-      label: "Wallet updated",
-      done: mintStatus === "syncing",
-      active: mintStatus === "syncing",
-    },
-  ];
 
   const randomizePreviewImage = () => {
     if (nftActionInProgress) return;
@@ -468,46 +494,121 @@ export function SendTransactionTest({
       : new Error("Transaction was submitted but the receipt is still indexing.");
   };
 
-  const setGallery = (nextNfts: MintedNft[]) => {
-    setMintedNfts(nextNfts);
-  };
-
-  const addGalleryNft = (nft: MintedNft) => {
-    setMintedNfts((current) => {
-      const withoutDuplicate = current.filter((item) => item.tokenId !== nft.tokenId);
-      return [nft, ...withoutDuplicate].sort((a, b) =>
-        compareBlockNumbers(a.blockNumber, b.blockNumber),
-      );
-    });
-  };
-
-  const removeGalleryNft = (tokenId: string) => {
-    setMintedNfts((current) => {
-      return current.filter((nft) => nft.tokenId !== tokenId);
-    });
-  };
-
-  useEffect(() => {
-    onNftCountChange?.(mintedNfts.length);
-
+  // Persist the exact array we're about to render. Called explicitly by the
+  // mutators and the rebuild path — never as a reactive effect — so a stale
+  // empty state can't race the async load and overwrite a good cache.
+  const persistGallery = (nfts: MintedNft[]) => {
     if (!activeAddress || !hasUsableAddress || !nftContractAddress) return;
-
     writeCachedNftGallery(
       {
         chainId: chain?.id,
         contractAddress: nftContractAddress,
         ownerAddress: activeAddress,
       },
-      mintedNfts,
+      nfts,
     );
-  }, [
-    activeAddress,
-    chain?.id,
-    hasUsableAddress,
-    mintedNfts,
-    nftContractAddress,
-    onNftCountChange,
-  ]);
+  };
+
+  const setGallery = (nextNfts: MintedNft[]) => {
+    setMintedNfts(nextNfts);
+    persistGallery(nextNfts);
+  };
+
+  const addGalleryNft = (nft: MintedNft) => {
+    const withoutDuplicate = mintedNftsRef.current.filter(
+      (item) => item.tokenId !== nft.tokenId,
+    );
+    const next = [nft, ...withoutDuplicate].sort((a, b) =>
+      compareBlockNumbers(a.blockNumber, b.blockNumber),
+    );
+    setMintedNfts(next);
+    persistGallery(next);
+  };
+
+  const removeGalleryNft = (tokenId: string) => {
+    const next = mintedNftsRef.current.filter((nft) => nft.tokenId !== tokenId);
+    setMintedNfts(next);
+    persistGallery(next);
+  };
+
+  useEffect(() => {
+    onNftCountChange?.(mintedNfts.length);
+  }, [mintedNfts.length, onNftCountChange]);
+
+  // Fetch only transfers that involve this owner by filtering on the indexed
+  // `to`/`from` topics. Filtering keeps the result set tiny (just this wallet's
+  // transfers), so we can scan the full chain history in a single query without
+  // tripping the ~10k-result limit that public RPCs enforce on unfiltered scans.
+  // The scan runs against a dedicated public full node (the wallet RPC is a
+  // bundler endpoint that may not support eth_getLogs); from block 0 first to
+  // recover full history, falling back to a recent window if the range is
+  // rejected, and finally to the wallet client if the public node is down.
+  const fetchOwnerTransferLogs = async () => {
+    if (!nftContractAddress || !activeAddress || !chain?.id) return [];
+    const owner = activeAddress as Address;
+
+    const queryFromBlock = async (client: PublicClient, fromBlock: bigint) => {
+      const [received, sent] = await Promise.all([
+        client.getLogs({
+          address: nftContractAddress,
+          event: NFT_TRANSFER_EVENT,
+          args: { to: owner },
+          fromBlock,
+          toBlock: "latest",
+        }),
+        client.getLogs({
+          address: nftContractAddress,
+          event: NFT_TRANSFER_EVENT,
+          args: { from: owner },
+          fromBlock,
+          toBlock: "latest",
+        }),
+      ]);
+
+      // Merge and replay chronologically so the final owned set reflects the
+      // latest transfer per token (mint -> burn -> re-mint all resolve correctly).
+      return [...received, ...sent].sort((a, b) => {
+        if (a.blockNumber !== b.blockNumber) {
+          if (a.blockNumber == null) return 1;
+          if (b.blockNumber == null) return -1;
+          return a.blockNumber < b.blockNumber ? -1 : 1;
+        }
+        return (a.logIndex ?? 0) - (b.logIndex ?? 0);
+      });
+    };
+
+    const scanClient = getLogScanClient(chain.id) ?? publicClient;
+    if (!scanClient) return [];
+
+    try {
+      return await queryFromBlock(scanClient, BigInt(0));
+    } catch (err) {
+      // Provider likely enforces a max block-range per query. Fall back to a
+      // recent window so at least recently minted NFTs still show up.
+      console.info(
+        "Full-history NFT log scan failed; falling back to recent window:",
+        getMintErrorMessage(err),
+      );
+      try {
+        const latestBlock = await scanClient.getBlockNumber();
+        const fromBlock =
+          latestBlock > RECENT_TRANSFER_BLOCK_WINDOW
+            ? latestBlock - RECENT_TRANSFER_BLOCK_WINDOW
+            : BigInt(0);
+        return await queryFromBlock(scanClient, fromBlock);
+      } catch (windowErr) {
+        // Public node unreachable — last resort, try the wallet's own RPC.
+        if (publicClient && publicClient !== scanClient) {
+          console.info(
+            "Recent-window scan failed; retrying via wallet RPC:",
+            getMintErrorMessage(windowErr),
+          );
+          return await queryFromBlock(publicClient, BigInt(0));
+        }
+        throw windowErr;
+      }
+    }
+  };
 
   const rebuildGalleryFromLogs = async () => {
     if (!publicClient || !activeAddress || !hasUsableAddress || !nftContractAddress) {
@@ -515,12 +616,22 @@ export function SendTransactionTest({
     }
 
     try {
-      const logs = await publicClient.getLogs({
-        address: nftContractAddress,
-        event: NFT_TRANSFER_EVENT,
-        fromBlock: BigInt(0),
-        toBlock: "latest",
-      });
+      // The contract is plain ERC-721 (not Enumerable) with no totalSupply, so
+      // balanceOf tells us HOW MANY NFTs this wallet owns but not WHICH token
+      // IDs. We use it to skip the scan when the wallet is empty, and to detect
+      // when the log scan came back incomplete (e.g. provider range limit).
+      const ownedCount = await publicClient
+        .readContract({
+          address: nftContractAddress,
+          abi: NFT_CONTRACT_ABI,
+          functionName: "balanceOf",
+          args: [activeAddress],
+        })
+        .catch(() => undefined);
+
+      if (ownedCount === BigInt(0)) return [];
+
+      const logs = await fetchOwnerTransferLogs();
       const owned = new Map<string, MintedNft>();
       const normalizedOwner = activeAddress.toLowerCase();
       let highestTokenId: bigint | undefined;
@@ -552,6 +663,12 @@ export function SendTransactionTest({
         setNextMintTokenId((highestTokenId + BigInt(1)).toString());
       }
 
+      if (ownedCount !== undefined && BigInt(owned.size) !== ownedCount) {
+        console.info(
+          `NFT gallery may be incomplete: contract reports ${ownedCount} owned, recovered ${owned.size} from logs.`,
+        );
+      }
+
       const imageUrls = new Map<string, string>();
       Array.from(owned.keys()).forEach((tokenId) => {
         const selectedImageUrl = selectedImageByTokenIdRef.current[tokenId];
@@ -573,6 +690,7 @@ export function SendTransactionTest({
         imageUrls.set(tokenId, getNftImageUrl(tokenId));
       });
 
+      const blockClient = getLogScanClient(chain?.id) ?? publicClient;
       const blockTimestamps = new Map<bigint, string>();
       await Promise.all(
         Array.from(
@@ -582,11 +700,16 @@ export function SendTransactionTest({
               .filter((blockNumber): blockNumber is bigint => Boolean(blockNumber)),
           ),
         ).map(async (blockNumber) => {
-          const block = await publicClient.getBlock({ blockNumber });
-          blockTimestamps.set(
-            blockNumber,
-            new Date(Number(block.timestamp) * 1000).toISOString(),
-          );
+          // Timestamps are cosmetic — a failure here must not drop the NFT.
+          try {
+            const block = await blockClient.getBlock({ blockNumber });
+            blockTimestamps.set(
+              blockNumber,
+              new Date(Number(block.timestamp) * 1000).toISOString(),
+            );
+          } catch {
+            /* leave timestamp undefined */
+          }
         }),
       );
 
@@ -608,6 +731,9 @@ export function SendTransactionTest({
 
     const loadGallery = async () => {
       if (!activeAddress || !hasUsableAddress || !nftContractAddress) {
+        // Don't write here — just clear the view. Persisting only happens via
+        // the explicit mutators / rebuild, so a transient disconnect can't
+        // clobber the cache.
         setMintedNfts([]);
         return;
       }
@@ -618,7 +744,10 @@ export function SendTransactionTest({
         ownerAddress: activeAddress,
       });
 
-      if (cachedNfts) {
+      // Treat a non-empty cache as authoritative. An empty cached array is
+      // treated as a miss so we fall through to the RPC rebuild instead of
+      // showing an empty gallery forever.
+      if (cachedNfts && cachedNfts.length > 0) {
         if (cancelled) return;
         setMintedNfts(cachedNfts);
         const highestTokenId = cachedNfts.reduce<bigint | undefined>((highest, nft) => {
@@ -667,7 +796,6 @@ export function SendTransactionTest({
     setMintErrorScope("mint");
     setMintTxHash(undefined);
     setMintStatus("submitting");
-    setNftsOpen(false);
     const selectedImageUrl = checkoutImageUrl;
 
     let submittedTxHash: `0x${string}` | undefined;
@@ -892,6 +1020,17 @@ export function SendTransactionTest({
     setMintErrorMessage("");
   }, [mintTxHash, mintErrorScope]);
 
+  // When a new NFT is minted, open the gallery and scroll it back to the start
+  // so the newest token (prepended, hence leftmost) is immediately visible.
+  useEffect(() => {
+    if (!latestMintedTokenId) return;
+    setNftsOpen(true);
+    const raf = requestAnimationFrame(() => {
+      galleryScrollRef.current?.scrollTo({ left: 0, behavior: "smooth" });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [latestMintedTokenId]);
+
   useEffect(() => {
     if (!nftFocusRequest) return;
 
@@ -934,7 +1073,7 @@ export function SendTransactionTest({
             visible: mintToastVisible,
             tone: "success" as const,
             href: `${explorerBaseUrl}/tx/${mintTxHash}`,
-            icon: <Check className="h-4 w-4 shrink-0 text-emerald-700" />,
+            icon: <Check className="h-4 w-4 shrink-0 text-white" />,
             title: "NFT minted",
             message: latestMintedTokenId
               ? `NFT #${latestMintedTokenId} minted.`
@@ -947,7 +1086,7 @@ export function SendTransactionTest({
               visible: burnToastVisible,
               tone: "success" as const,
               href: `${explorerBaseUrl}/tx/${burnTxHash}`,
-              icon: <Check className="h-4 w-4 shrink-0 text-emerald-700" />,
+              icon: <Check className="h-4 w-4 shrink-0 text-white" />,
               title: "NFT burned",
               message: latestBurnedTokenId
                 ? `NFT #${latestBurnedTokenId} burned.`
@@ -956,63 +1095,68 @@ export function SendTransactionTest({
             }
           : null;
 
+  // Render the notification through a portal to <body> so its `position: fixed`
+  // pins to the viewport (just below the navbar) rather than to a transformed
+  // dashboard ancestor, which would otherwise trap it inside the playground frame.
+  const notificationBar = notification && (
+    <div
+      className={cn(
+        "fixed inset-x-0 top-20 z-50 pointer-events-none border-b transition duration-300 ease-out motion-reduce:transition-none",
+        notification.tone === "success"
+          ? "border-emerald-400 bg-emerald-500 text-white shadow-lg shadow-emerald-500/30"
+          : "border-red-200 bg-red-50/95 text-red-950 backdrop-blur-xl",
+        notification.visible
+          ? "translate-y-0 opacity-100"
+          : "-translate-y-2 opacity-0",
+      )}
+    >
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        {notification.href ? (
+          <a
+            key={notification.key}
+            href={notification.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn(
+              "pointer-events-auto flex min-h-10 items-center justify-between gap-4 py-2 transition-colors",
+              notification.tone === "success"
+                ? "hover:text-white/90"
+                : "border-red-200 bg-red-50/95 text-red-950",
+            )}
+          >
+            <span className="flex min-w-0 items-center gap-2">
+              {notification.icon}
+              <span className="min-w-0 text-sm">
+                <span className="font-semibold">{notification.title}</span>
+                <span className="text-current/75"> · {notification.message}</span>
+              </span>
+            </span>
+            <span className="inline-flex shrink-0 items-center gap-1 text-sm font-semibold underline underline-offset-4">
+              {notification.action}
+              <ExternalLink className="h-3.5 w-3.5" />
+            </span>
+          </a>
+        ) : (
+          <div
+            key={notification.key}
+            className="pointer-events-auto flex min-h-10 items-start gap-2 py-2 text-red-950"
+          >
+            {notification.icon}
+            <div className="min-w-0 text-sm">
+              <p className="font-semibold">{notification.title}</p>
+              <p className="line-clamp-2 break-words text-red-700">
+                {notification.message}
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
   return (
     <div className="space-y-5">
-      {notification && (
-        <div
-          className={cn(
-            "fixed inset-x-0 top-20 z-50 pointer-events-none border-b backdrop-blur-xl transition duration-300 ease-out motion-reduce:transition-none",
-            notification.tone === "success"
-              ? "border-emerald-200 bg-emerald-50/95 text-emerald-950"
-              : "border-red-200 bg-red-50/95 text-red-950",
-            notification.visible
-              ? "translate-y-0 opacity-100"
-              : "-translate-y-2 opacity-0",
-          )}
-        >
-          <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-            {notification.href ? (
-              <a
-                key={notification.key}
-                href={notification.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={cn(
-                  "pointer-events-auto flex min-h-10 items-center justify-between gap-4 py-2 transition-colors",
-                  notification.tone === "success"
-                    ? "hover:text-emerald-800"
-                    : "border-red-200 bg-red-50/95 text-red-950",
-                )}
-              >
-                <span className="flex min-w-0 items-center gap-2">
-                  {notification.icon}
-                  <span className="min-w-0 text-sm">
-                    <span className="font-semibold">{notification.title}</span>
-                    <span className="text-current/75"> · {notification.message}</span>
-                  </span>
-                </span>
-                <span className="inline-flex shrink-0 items-center gap-1 text-sm font-semibold underline underline-offset-4">
-                  {notification.action}
-                  <ExternalLink className="h-3.5 w-3.5" />
-                </span>
-              </a>
-            ) : (
-              <div
-                key={notification.key}
-                className="pointer-events-auto flex min-h-10 items-start gap-2 py-2 text-red-950"
-              >
-                {notification.icon}
-                <div className="min-w-0 text-sm">
-                  <p className="font-semibold">{notification.title}</p>
-                  <p className="line-clamp-2 break-words text-red-700">
-                    {notification.message}
-                  </p>
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-      )}
+      {mounted && notificationBar && createPortal(notificationBar, document.body)}
 
       {!nftContractAddress && (
         <div className="flex items-start gap-2 px-4 py-3 bg-yellow-50 border border-yellow-100 rounded-lg">
@@ -1095,34 +1239,6 @@ export function SendTransactionTest({
               )}
 	          </button>
           </div>
-          {mintInProgress && (
-            <div className="grid gap-2 rounded-lg bg-gray-50 p-2 sm:grid-cols-4">
-              {mintStatusSteps.map((step) => (
-                <div
-                  key={step.key}
-                  className={cn(
-                    "flex items-center gap-2 rounded-md px-2 py-1.5 text-xs font-semibold text-gray-500",
-                    step.done && "text-gray-950",
-                    step.active && "bg-white shadow-sm",
-                  )}
-                >
-                  <span
-                    className={cn(
-                      "flex h-4 w-4 items-center justify-center rounded-full bg-gray-200",
-                      step.done && "bg-emerald-100 text-emerald-800",
-                    )}
-                  >
-                    {step.active ? (
-                      <Loader2 className="h-3 w-3 animate-spin" />
-                    ) : step.done ? (
-                      <Check className="h-3 w-3" />
-                    ) : null}
-                  </span>
-                  {step.label}
-                </div>
-              ))}
-            </div>
-          )}
 	      </div>
       </div>
 
@@ -1148,7 +1264,7 @@ export function SendTransactionTest({
             />
           </button>
           {nftsOpen && (
-            <div className="flex snap-x gap-3 overflow-x-auto border-t border-gray-200 p-4">
+            <div ref={galleryScrollRef} className="flex snap-x gap-3 overflow-x-auto border-t border-gray-200 p-4">
               {galleryNfts.map((nft) => (
                 <div
                   key={`${nft.txHash ?? "owned"}-${nft.tokenId}`}

--- a/apps/zerodev-signer-demo/src/app/components/SendTransactionTest.tsx
+++ b/apps/zerodev-signer-demo/src/app/components/SendTransactionTest.tsx
@@ -1,17 +1,19 @@
 "use client";
 
 import { type ReactNode, useEffect, useRef, useState } from "react";
-import { Sparkles, AlertCircle, Loader2, Check, ChevronDown, Code2, ExternalLink, Trash2 } from "lucide-react";
+import { Sparkles, AlertCircle, Loader2, Check, ChevronDown, Code2, ExternalLink, Trash2, Shuffle } from "lucide-react";
 import { cn } from "../lib/utils";
 import {
   type Address,
+  encodeFunctionData,
   parseAbi,
   parseEventLogs,
   parseAbiItem,
   zeroAddress,
 } from "viem";
+import { getZeroDevConnector, getZeroDevStore } from "@zerodev/wallet-react";
 import { sepolia } from "wagmi/chains";
-import { useAccount, useWriteContract, usePublicClient } from "wagmi";
+import { useAccount, useConfig, usePublicClient } from "wagmi";
 
 // Per-chain NFT contract addresses
 const NFT_CONTRACTS: Record<number, `0x${string}`> = {
@@ -23,14 +25,15 @@ const NFT_CONTRACT_ABI = parseAbi([
   "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)",
   "function mint(address _to) public",
   "function balanceOf(address owner) external view returns (uint256 balance)",
+  "function ownerOf(uint256 tokenId) external view returns (address owner)",
+  "function transferFrom(address from, address to, uint256 tokenId) public",
 ]);
 
 const NFT_TRANSFER_EVENT = parseAbiItem(
   "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)"
 );
 
-const BURN_UNAVAILABLE_MESSAGE =
-  "Burn is not enabled in this demo. The current gas policy sponsors the free mint flow, but not ERC-721 transferFrom calls.";
+const DEAD_ADDRESS = "0x000000000000000000000000000000000000dEaD" as const;
 
 type MintedNft = {
   blockNumber?: bigint
@@ -40,8 +43,131 @@ type MintedNft = {
   txHash?: `0x${string}`
 }
 
+type MintStatus = "idle" | "submitting" | "submitted" | "confirmed" | "syncing";
+
+function getPicsumImageUrl(seed: string) {
+  return `https://picsum.photos/seed/${encodeURIComponent(seed)}/800/600`;
+}
+
+function getDeterministicNftImageUrl(tokenId: string) {
+  return getPicsumImageUrl(`nft-${tokenId}`);
+}
+
+function getNftImageUrl(tokenId: string, imageUrl?: string) {
+  return imageUrl && imageUrl.trim().length > 0
+    ? imageUrl
+    : getDeterministicNftImageUrl(tokenId);
+}
+
+function getNftImageCacheKey({
+  chainId,
+  contractAddress,
+  tokenId,
+}: {
+  chainId?: number
+  contractAddress?: Address
+  tokenId: string
+}) {
+  return chainId && contractAddress
+    ? `zd:nft-image:${chainId}:${contractAddress.toLowerCase()}:${tokenId}`
+    : undefined;
+}
+
+function getNftGalleryCacheKey({
+  chainId,
+  contractAddress,
+  ownerAddress,
+}: {
+  chainId?: number
+  contractAddress?: Address
+  ownerAddress?: Address
+}) {
+  return chainId && contractAddress && ownerAddress
+    ? `zd:nft-gallery:${chainId}:${contractAddress.toLowerCase()}:${ownerAddress.toLowerCase()}`
+    : undefined;
+}
+
+function readCachedNftImageUrl(params: {
+  chainId?: number
+  contractAddress?: Address
+  tokenId: string
+}) {
+  if (typeof window === "undefined") return undefined;
+  const key = getNftImageCacheKey(params);
+  if (!key) return undefined;
+  return window.localStorage.getItem(key) ?? undefined;
+}
+
+function writeCachedNftImageUrl(
+  params: {
+    chainId?: number
+    contractAddress?: Address
+    tokenId: string
+  },
+  imageUrl: string,
+) {
+  if (typeof window === "undefined") return;
+  const key = getNftImageCacheKey(params);
+  if (!key) return;
+  window.localStorage.setItem(key, imageUrl);
+}
+
+function readCachedNftGallery(params: {
+  chainId?: number
+  contractAddress?: Address
+  ownerAddress?: Address
+}) {
+  if (typeof window === "undefined") return undefined;
+  const key = getNftGalleryCacheKey(params);
+  if (!key) return undefined;
+
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw) as Array<Omit<MintedNft, "blockNumber"> & { blockNumber?: string }>;
+    return parsed.map((nft) => ({
+      ...nft,
+      blockNumber: nft.blockNumber ? BigInt(nft.blockNumber) : undefined,
+      imageUrl: nft.imageUrl ?? getDeterministicNftImageUrl(nft.tokenId),
+    }));
+  } catch {
+    return undefined;
+  }
+}
+
+function writeCachedNftGallery(
+  params: {
+    chainId?: number
+    contractAddress?: Address
+    ownerAddress?: Address
+  },
+  nfts: MintedNft[],
+) {
+  if (typeof window === "undefined") return;
+  const key = getNftGalleryCacheKey(params);
+  if (!key) return;
+
+  window.localStorage.setItem(
+    key,
+    JSON.stringify(
+      nfts.map((nft) => ({
+        ...nft,
+        blockNumber: nft.blockNumber?.toString(),
+      })),
+    ),
+  );
+}
+
 function formatShortHash(value: `0x${string}`) {
   return `${value.slice(0, 6)}...${value.slice(-4)}`;
+}
+
+function isTransactionHash(value: string): value is `0x${string}` {
+  return /^0x[a-fA-F0-9]{64}$/.test(value);
+}
+
+function toTransactionHash(value: unknown): `0x${string}` | null {
+  return typeof value === "string" && isTransactionHash(value) ? value : null;
 }
 
 function formatTimestamp(value?: string) {
@@ -59,10 +185,42 @@ function compareBlockNumbers(a?: bigint, b?: bigint) {
   return a > b ? -1 : 1;
 }
 
-function getMintErrorMessage(error: unknown) {
+function getErrorText(error: unknown) {
   if (!error) return "";
   if (typeof error === "string") return error;
+
+  const pieces: string[] = [];
+  if (error instanceof Error) pieces.push(error.message);
+  if (typeof error === "object") {
+    for (const key of ["message", "shortMessage", "details"]) {
+      if (
+        key in error &&
+        typeof error[key as keyof typeof error] === "string"
+      ) {
+        pieces.push(error[key as keyof typeof error] as string);
+      }
+    }
+  }
+
+  return pieces.join("\n");
+}
+
+function getMintErrorMessage(error: unknown) {
+  const rawMessage = getErrorText(error);
+  if (!rawMessage) return "";
+  const normalizedMessage = rawMessage.toLowerCase();
+
   if (
+    normalizedMessage.includes("pm_getpaymasterdata") ||
+    normalizedMessage.includes("pm_getpaymasterstubdata") ||
+    normalizedMessage.includes("did not match any gas sponsoring policies") ||
+    normalizedMessage.includes("no erc20 gas token data present")
+  ) {
+    return "Gas sponsorship rejected this action. Check that this contract and function are allowed in the dashboard gas policy, then try again.";
+  }
+
+  if (
+    error &&
     typeof error === "object" &&
     "shortMessage" in error &&
     typeof error.shortMessage === "string"
@@ -70,6 +228,9 @@ function getMintErrorMessage(error: unknown) {
     return error.shortMessage;
   }
   if (error instanceof Error) {
+    if (error.message.toLowerCase().includes("http request failed")) {
+      return "Wallet is catching up. Try again in 1-2 seconds.";
+    }
     if (
       error.message.toLowerCase().includes("unknown rpc error") ||
       error.message.toLowerCase().includes("user rejected")
@@ -81,23 +242,46 @@ function getMintErrorMessage(error: unknown) {
   return "Mint did not complete. Try again.";
 }
 
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string) {
+  let timeoutId: number;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = window.setTimeout(() => reject(new Error(message)), ms);
+  });
+
+  return Promise.race([promise, timeout]).finally(() => {
+    window.clearTimeout(timeoutId);
+  });
+}
+
+function wait(ms: number) {
+  return new Promise<void>((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
 function SeamlessImage({
   alt,
+  aspectClassName = "aspect-[4/3]",
   className,
+  fallbackSrc,
   src,
 }: {
   alt: string
+  aspectClassName?: string
   className?: string
+  fallbackSrc?: string
   src: string
 }) {
   const [loaded, setLoaded] = useState(false);
+  const [currentSrc, setCurrentSrc] = useState(src);
 
   useEffect(() => {
     setLoaded(false);
+    setCurrentSrc(src);
   }, [src]);
 
   return (
-    <div className="relative aspect-[4/3] overflow-hidden bg-gray-100">
+    <div className={cn("relative overflow-hidden bg-gray-100", aspectClassName)}>
       <div
         className={cn(
           "absolute inset-0 bg-[linear-gradient(110deg,#f3f4f6_0%,#ffffff_45%,#f3f4f6_90%)] opacity-100 transition-opacity duration-300",
@@ -105,15 +289,20 @@ function SeamlessImage({
         )}
       />
       <img
-        key={src}
-        src={src}
+        key={currentSrc}
+        src={currentSrc}
         alt={alt}
         loading="eager"
         decoding="async"
         onLoad={() => setLoaded(true)}
+        onError={() => {
+          const fallback = fallbackSrc ?? src;
+          if (currentSrc !== fallback) {
+            setCurrentSrc(fallback);
+          }
+        }}
         className={cn(
-          "absolute inset-0 h-full w-full object-cover opacity-0 transition duration-500 ease-out motion-reduce:transition-none",
-          loaded && "opacity-100",
+          "absolute inset-0 h-full w-full object-cover transition duration-500 ease-out motion-reduce:transition-none",
           className,
         )}
       />
@@ -133,160 +322,341 @@ export function SendTransactionTest({
   onNftCountChange?: (count: number) => void
 }) {
   const [error, setError] = useState<string>("");
-  const [nftBalance, setNftBalance] = useState<string>("0");
-  const [loadingBalance, setLoadingBalance] = useState(false);
   const [mintedNfts, setMintedNfts] = useState<MintedNft[]>([]);
-  const [confirmingMint, setConfirmingMint] = useState(false);
+  const [mintStatus, setMintStatus] = useState<MintStatus>("idle");
   const [codeOpen, setCodeOpen] = useState(false);
-  const [nftsOpen, setNftsOpen] = useState(true);
-  const [checkoutSeed, setCheckoutSeed] = useState("demo-collectible");
+  const [nftsOpen, setNftsOpen] = useState(false);
   const [checkoutImageVisible, setCheckoutImageVisible] = useState(true);
+  const [nextMintTokenId, setNextMintTokenId] = useState<string>("preview");
+  const [previewImageSeed, setPreviewImageSeed] = useState<string>("demo-collectible");
   const [renderMintToast, setRenderMintToast] = useState(false);
   const [mintToastVisible, setMintToastVisible] = useState(false);
+  const [renderBurnToast, setRenderBurnToast] = useState(false);
+  const [burnToastVisible, setBurnToastVisible] = useState(false);
   const [renderMintError, setRenderMintError] = useState(false);
   const [mintErrorVisible, setMintErrorVisible] = useState(false);
   const [mintErrorMessage, setMintErrorMessage] = useState("");
   const [mintErrorScope, setMintErrorScope] = useState<"mint" | "burn">("mint");
   const [mintCtaHighlighted, setMintCtaHighlighted] = useState(false);
   const [mintTxHash, setMintTxHash] = useState<`0x${string}` | undefined>();
+  const [burnTxHash, setBurnTxHash] = useState<`0x${string}` | undefined>();
+  const [burningTokenId, setBurningTokenId] = useState<string | null>(null);
+  const [removingTokenId, setRemovingTokenId] = useState<string | null>(null);
+  const [latestBurnedTokenId, setLatestBurnedTokenId] = useState<string | null>(null);
   const [latestMintedTokenId, setLatestMintedTokenId] = useState<string | null>(null);
-  const mintedImageByTokenIdRef = useRef<Record<string, string>>({});
-  const pendingMintImageUrlRef = useRef<string>("https://picsum.photos/seed/demo-collectible/800/600");
+  const selectedImageByTokenIdRef = useRef<Record<string, string>>({});
 
   // Wagmi hooks
   const { address, isConnected, chain } = useAccount();
+  const wagmiConfig = useConfig();
   const activeAddress = accountAddress ?? address;
   const hasUsableAddress =
     Boolean(activeAddress) && activeAddress?.toLowerCase() !== zeroAddress;
   const publicClient = usePublicClient({chainId: chain?.id});
-  const { writeContractAsync, isPending: isMinting, error: mintError } = useWriteContract();
 
   const nftContractAddress = chain?.id ? NFT_CONTRACTS[chain.id] : undefined;
   const explorerBaseUrl = chain?.blockExplorers?.default?.url ?? "https://sepolia.arbiscan.io";
   const galleryNfts = mintedNfts;
-  const mintedCount = mintedNfts.length || Number(nftBalance) || 0;
-  const mintInProgress = isMinting || confirmingMint;
-  const checkoutImageUrl = `https://picsum.photos/seed/${checkoutSeed}/800/600`;
+  const mintedCount = mintedNfts.length;
+  const mintInProgress = mintStatus !== "idle";
+  const nftActionInProgress = mintInProgress || Boolean(burningTokenId);
+  const checkoutImageUrl = getPicsumImageUrl(previewImageSeed);
+  const nextMintLabel = nextMintTokenId === "preview" ? "Next" : `#${nextMintTokenId}`;
+  const mintStatusSteps = [
+    {
+      key: "submitting",
+      label: "Submitting",
+      done: mintStatus !== "idle",
+      active: mintStatus === "submitting",
+    },
+    {
+      key: "submitted",
+      label: "Tx submitted",
+      done: ["submitted", "confirmed", "syncing"].includes(mintStatus),
+      active: mintStatus === "submitted",
+    },
+    {
+      key: "confirmed",
+      label: "Confirmed",
+      done: ["confirmed", "syncing"].includes(mintStatus),
+      active: mintStatus === "confirmed",
+    },
+    {
+      key: "syncing",
+      label: "Wallet updated",
+      done: mintStatus === "syncing",
+      active: mintStatus === "syncing",
+    },
+  ];
 
-  // Fetch NFT balance
-  const fetchNftBalance = async () => {
-    if (!isConnected || !activeAddress || !hasUsableAddress || !nftContractAddress) return;
+  const randomizePreviewImage = () => {
+    if (nftActionInProgress) return;
+    const nextSeed = `demo-collectible-${Date.now()}-${Math.floor(Math.random() * 100000)}`;
+    setCheckoutImageVisible(false);
+    window.setTimeout(() => {
+      setPreviewImageSeed(nextSeed);
+      setCheckoutImageVisible(true);
+    }, 120);
+  };
 
-    setLoadingBalance(true);
+  const sendNftTransaction = async (data: `0x${string}`) => {
+    if (!chain?.id || !nftContractAddress) {
+      throw new Error("NFT transaction is not available on this chain.");
+    }
+
+    const store = await getZeroDevStore(getZeroDevConnector(wagmiConfig));
+    let kernelClient = store.getState().kernelClients.get(chain.id);
+    const startedAt = Date.now();
+    while (!kernelClient && Date.now() - startedAt < 3000) {
+      await wait(250);
+      kernelClient = store.getState().kernelClients.get(chain.id);
+    }
+
+    if (!kernelClient) {
+      throw new Error("Smart account client is not ready. Reconnect the wallet and try again.");
+    }
+
+    const txHash = toTransactionHash(
+      await withTimeout(
+        kernelClient.sendTransaction({
+          calls: [
+            {
+              to: nftContractAddress,
+              data,
+              value: BigInt(0),
+            },
+          ],
+        }),
+        30000,
+        "Wallet RPC did not respond. Try again in a moment.",
+      ),
+    );
+
+    if (!txHash) {
+      throw new Error("The smart account did not return a transaction hash.");
+    }
+
+    return txHash;
+  };
+
+  const waitForNftTransactionReceipt = async (txHash: `0x${string}`) => {
+    if (!publicClient) {
+      throw new Error("RPC client is not ready");
+    }
+
+    const startedAt = Date.now();
+    let lastError: unknown;
+
+    while (Date.now() - startedAt < 60000) {
+      let receipt;
+      try {
+        receipt = await publicClient.getTransactionReceipt({ hash: txHash });
+      } catch (err) {
+        lastError = err;
+        await wait(1000);
+        continue;
+      }
+
+      if (receipt.status === "reverted") {
+        throw new Error("Transaction reverted.");
+      }
+      return receipt;
+    }
+
+    throw lastError instanceof Error
+      ? new Error(`Transaction was submitted but the receipt is still indexing. ${lastError.message}`)
+      : new Error("Transaction was submitted but the receipt is still indexing.");
+  };
+
+  const setGallery = (nextNfts: MintedNft[]) => {
+    setMintedNfts(nextNfts);
+  };
+
+  const addGalleryNft = (nft: MintedNft) => {
+    setMintedNfts((current) => {
+      const withoutDuplicate = current.filter((item) => item.tokenId !== nft.tokenId);
+      return [nft, ...withoutDuplicate].sort((a, b) =>
+        compareBlockNumbers(a.blockNumber, b.blockNumber),
+      );
+    });
+  };
+
+  const removeGalleryNft = (tokenId: string) => {
+    setMintedNfts((current) => {
+      return current.filter((nft) => nft.tokenId !== tokenId);
+    });
+  };
+
+  useEffect(() => {
+    onNftCountChange?.(mintedNfts.length);
+
+    if (!activeAddress || !hasUsableAddress || !nftContractAddress) return;
+
+    writeCachedNftGallery(
+      {
+        chainId: chain?.id,
+        contractAddress: nftContractAddress,
+        ownerAddress: activeAddress,
+      },
+      mintedNfts,
+    );
+  }, [
+    activeAddress,
+    chain?.id,
+    hasUsableAddress,
+    mintedNfts,
+    nftContractAddress,
+    onNftCountChange,
+  ]);
+
+  const rebuildGalleryFromLogs = async () => {
+    if (!publicClient || !activeAddress || !hasUsableAddress || !nftContractAddress) {
+      return [];
+    }
+
     try {
-      if (!publicClient) return;
-      const balance = await publicClient?.readContract({
+      const logs = await publicClient.getLogs({
         address: nftContractAddress,
-        abi: NFT_CONTRACT_ABI,
-        functionName: "balanceOf",
-        args: [activeAddress],
+        event: NFT_TRANSFER_EVENT,
+        fromBlock: BigInt(0),
+        toBlock: "latest",
+      });
+      const owned = new Map<string, MintedNft>();
+      const normalizedOwner = activeAddress.toLowerCase();
+      let highestTokenId: bigint | undefined;
+
+      for (const log of logs) {
+        const from = log.args.from?.toLowerCase();
+        const to = log.args.to?.toLowerCase();
+        const tokenId = log.args.tokenId?.toString();
+        if (!tokenId) continue;
+
+        const tokenIdBigInt = BigInt(tokenId);
+        if (highestTokenId === undefined || tokenIdBigInt > highestTokenId) {
+          highestTokenId = tokenIdBigInt;
+        }
+
+        if (from === normalizedOwner) {
+          owned.delete(tokenId);
+        }
+        if (to === normalizedOwner) {
+          owned.set(tokenId, {
+            blockNumber: log.blockNumber,
+            tokenId,
+            txHash: log.transactionHash,
+          });
+        }
+      }
+
+      if (highestTokenId !== undefined) {
+        setNextMintTokenId((highestTokenId + BigInt(1)).toString());
+      }
+
+      const imageUrls = new Map<string, string>();
+      Array.from(owned.keys()).forEach((tokenId) => {
+        const selectedImageUrl = selectedImageByTokenIdRef.current[tokenId];
+        if (selectedImageUrl) {
+          imageUrls.set(tokenId, selectedImageUrl);
+          return;
+        }
+
+        const cachedImageUrl = readCachedNftImageUrl({
+          chainId: chain?.id,
+          contractAddress: nftContractAddress,
+          tokenId,
+        });
+        if (cachedImageUrl) {
+          imageUrls.set(tokenId, cachedImageUrl);
+          return;
+        }
+
+        imageUrls.set(tokenId, getNftImageUrl(tokenId));
       });
 
-      const nextBalance = balance.toString();
-      setNftBalance(nextBalance);
-      onNftCountChange?.(Number(nextBalance));
+      const blockTimestamps = new Map<bigint, string>();
+      await Promise.all(
+        Array.from(
+          new Set(
+            Array.from(owned.values())
+              .map((nft) => nft.blockNumber)
+              .filter((blockNumber): blockNumber is bigint => Boolean(blockNumber)),
+          ),
+        ).map(async (blockNumber) => {
+          const block = await publicClient.getBlock({ blockNumber });
+          blockTimestamps.set(
+            blockNumber,
+            new Date(Number(block.timestamp) * 1000).toISOString(),
+          );
+        }),
+      );
+
+      return Array.from(owned.values())
+        .map((nft) => ({
+          ...nft,
+          imageUrl: imageUrls.get(nft.tokenId) ?? getNftImageUrl(nft.tokenId),
+          timestamp: nft.blockNumber ? blockTimestamps.get(nft.blockNumber) : undefined,
+        }))
+        .sort((a, b) => compareBlockNumbers(a.blockNumber, b.blockNumber));
     } catch (err) {
-      console.error("Failed to fetch NFT balance:", err);
-    } finally {
-      setLoadingBalance(false);
+      console.info("Could not rebuild NFT gallery from logs:", getMintErrorMessage(err));
+      return [];
     }
   };
 
   useEffect(() => {
-    if (isConnected) {
-      fetchNftBalance();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isConnected, publicClient, activeAddress, nftContractAddress, refreshKey]);
+    let cancelled = false;
 
-  useEffect(() => {
-    const fetchOwnedNfts = async () => {
-      if (!publicClient || !activeAddress || !hasUsableAddress || !nftContractAddress) {
+    const loadGallery = async () => {
+      if (!activeAddress || !hasUsableAddress || !nftContractAddress) {
         setMintedNfts([]);
         return;
       }
 
-      setLoadingBalance(true);
-      try {
-        const logs = await publicClient.getLogs({
-          address: nftContractAddress,
-          event: NFT_TRANSFER_EVENT,
-          fromBlock: BigInt(0),
-          toBlock: "latest",
-        });
-        const owned = new Map<string, MintedNft>();
-        const normalizedOwner = activeAddress.toLowerCase();
+      const cachedNfts = readCachedNftGallery({
+        chainId: chain?.id,
+        contractAddress: nftContractAddress,
+        ownerAddress: activeAddress,
+      });
 
-        for (const log of logs) {
-          const from = log.args.from?.toLowerCase();
-          const to = log.args.to?.toLowerCase();
-          const tokenId = log.args.tokenId?.toString();
-          if (!tokenId) continue;
-
-          if (from === normalizedOwner) {
-            owned.delete(tokenId);
-          }
-          if (to === normalizedOwner) {
-            owned.set(tokenId, {
-              blockNumber: log.blockNumber,
-              imageUrl:
-                mintedImageByTokenIdRef.current[tokenId] ??
-                `https://picsum.photos/seed/${tokenId}/800/600`,
-              tokenId,
-              txHash: log.transactionHash,
-            });
-          }
+      if (cachedNfts) {
+        if (cancelled) return;
+        setMintedNfts(cachedNfts);
+        const highestTokenId = cachedNfts.reduce<bigint | undefined>((highest, nft) => {
+          const tokenId = BigInt(nft.tokenId);
+          return highest === undefined || tokenId > highest ? tokenId : highest;
+        }, undefined);
+        if (highestTokenId !== undefined) {
+          setNextMintTokenId((highestTokenId + BigInt(1)).toString());
         }
-
-        const blockTimestamps = new Map<bigint, string>();
-        await Promise.all(
-          Array.from(
-            new Set(
-              Array.from(owned.values())
-                .map((nft) => nft.blockNumber)
-                .filter((blockNumber): blockNumber is bigint => Boolean(blockNumber)),
-            ),
-          ).map(async (blockNumber) => {
-            const block = await publicClient.getBlock({ blockNumber });
-            blockTimestamps.set(
-              blockNumber,
-              new Date(Number(block.timestamp) * 1000).toISOString(),
-            );
-          }),
-        );
-
-        const nextNfts = Array.from(owned.values())
-          .map((nft) => ({
-            ...nft,
-            timestamp: nft.blockNumber ? blockTimestamps.get(nft.blockNumber) : undefined,
-          }))
-          .sort((a, b) => compareBlockNumbers(a.blockNumber, b.blockNumber));
-        setMintedNfts(nextNfts);
-        onNftCountChange?.(nextNfts.length);
-      } catch (err) {
-        console.error("Failed to fetch owned NFTs:", err);
-      } finally {
-        setLoadingBalance(false);
+        return;
       }
+
+      const rebuiltNfts = await rebuildGalleryFromLogs();
+      if (cancelled) return;
+      setGallery(rebuiltNfts);
     };
 
-    fetchOwnedNfts();
-  }, [publicClient, activeAddress, hasUsableAddress, nftContractAddress, onNftCountChange, refreshKey]);
+    loadGallery();
 
-  useEffect(() => {
-    if (!activeAddress || !nftContractAddress) {
-      setMintedNfts([]);
-      return;
-    }
-  }, [activeAddress, nftContractAddress]);
+    return () => {
+      cancelled = true;
+    };
+    // Only rebuild from logs when there is no local gallery cache for this account/contract.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeAddress, chain?.id, hasUsableAddress, nftContractAddress, publicClient, refreshKey]);
 
   const handleMintNft = async () => {
+    if (nftActionInProgress) return;
     if (!isConnected || !activeAddress || !hasUsableAddress) {
       setError("Please authenticate first");
       return;
     }
     if (!nftContractAddress) {
       setError("NFT minting is not available on this chain");
+      return;
+    }
+    if (!publicClient) {
+      setError("RPC client is not ready");
       return;
     }
 
@@ -296,94 +666,154 @@ export function SendTransactionTest({
     setMintErrorMessage("");
     setMintErrorScope("mint");
     setMintTxHash(undefined);
-    pendingMintImageUrlRef.current = checkoutImageUrl;
+    setMintStatus("submitting");
+    setNftsOpen(false);
+    const selectedImageUrl = checkoutImageUrl;
 
+    let submittedTxHash: `0x${string}` | undefined;
     try {
-      const txHash = await writeContractAsync({
-        address: nftContractAddress,
+      const txHash = await sendNftTransaction(encodeFunctionData({
         abi: NFT_CONTRACT_ABI,
         functionName: "mint",
         args: [activeAddress],
-      });
+      }));
+      submittedTxHash = txHash;
 
-      setConfirmingMint(true);
+      setMintStatus("submitted");
       setMintTxHash(txHash);
 
-      if (publicClient) {
-        const receipt = await publicClient.waitForTransactionReceipt({
-          hash: txHash,
-        });
-        const transferLogs = parseEventLogs({
-          abi: NFT_CONTRACT_ABI,
-          eventName: "Transfer",
-          logs: receipt.logs,
-        });
-        const mintedTransfer = transferLogs.find((log) => {
-          const { from, to } = log.args;
-          return (
-            from.toLowerCase() === zeroAddress &&
-            to.toLowerCase() === activeAddress.toLowerCase()
-          );
-        });
-        const tokenId = mintedTransfer?.args.tokenId?.toString();
+      const receipt = await waitForNftTransactionReceipt(txHash);
+      setMintStatus("confirmed");
+      const transferLogs = parseEventLogs({
+        abi: NFT_CONTRACT_ABI,
+        eventName: "Transfer",
+        logs: receipt.logs,
+      });
+      const mintedTransfer = transferLogs.find((log) => {
+        const { from, to } = log.args;
+        return (
+          from.toLowerCase() === zeroAddress &&
+          to.toLowerCase() === activeAddress.toLowerCase()
+        );
+      });
+      const tokenId = mintedTransfer?.args.tokenId?.toString();
 
-        if (tokenId) {
+      if (tokenId) {
+        let timestamp = new Date().toISOString();
+        try {
           const block = await publicClient.getBlock({
             blockNumber: receipt.blockNumber,
           });
-          const mintedImageUrl = pendingMintImageUrlRef.current;
-          mintedImageByTokenIdRef.current[tokenId] = mintedImageUrl;
-          setLatestMintedTokenId(tokenId);
-          setCheckoutImageVisible(false);
-          window.setTimeout(() => {
-            setCheckoutSeed(`demo-collectible-next-${tokenId}`);
-            setCheckoutImageVisible(true);
-          }, 180);
-          setMintedNfts((current) => {
-            if (current.some((item) => item.tokenId === tokenId)) {
-              return current.map((item) =>
-                item.tokenId === tokenId
-                  ? { ...item, imageUrl: mintedImageUrl, txHash }
-                  : item,
-              );
-            }
-            return [
-              {
-                blockNumber: receipt.blockNumber,
-                imageUrl: mintedImageUrl,
-                timestamp: new Date(Number(block.timestamp) * 1000).toISOString(),
-                tokenId,
-                txHash,
-              },
-              ...current,
-            ];
-          });
+          timestamp = new Date(Number(block.timestamp) * 1000).toISOString();
+        } catch (blockError) {
+          console.info("Could not fetch mint block timestamp:", getMintErrorMessage(blockError));
         }
+        const mintedImageUrl = selectedImageUrl;
+        selectedImageByTokenIdRef.current[tokenId] = mintedImageUrl;
+        writeCachedNftImageUrl(
+          {
+            chainId: chain?.id,
+            contractAddress: nftContractAddress,
+            tokenId,
+          },
+          mintedImageUrl,
+        );
+        setLatestMintedTokenId(tokenId);
+        setCheckoutImageVisible(false);
+        window.setTimeout(() => {
+          setNextMintTokenId((BigInt(tokenId) + BigInt(1)).toString());
+          setPreviewImageSeed(`demo-collectible-${BigInt(tokenId) + BigInt(1)}`);
+          setCheckoutImageVisible(true);
+        }, 180);
+        setMintStatus("syncing");
+        addGalleryNft({
+          blockNumber: receipt.blockNumber,
+          imageUrl: mintedImageUrl,
+          timestamp,
+          tokenId,
+          txHash,
+        });
       }
 
-      await fetchNftBalance();
+      setMintStatus("idle");
     } catch (err) {
-      console.error("Mint error:", err);
+      console.info("Mint did not complete:", getMintErrorMessage(err));
       setMintErrorScope("mint");
-      setError(getMintErrorMessage(err) || "Mint failed");
-    } finally {
-      setConfirmingMint(false);
+
+      if (submittedTxHash) {
+        setMintTxHash(submittedTxHash);
+        setError("Transaction was submitted, but the receipt is still indexing. Check Arbiscan and try refreshing the NFTs if it does not appear.");
+      } else {
+        const message = getMintErrorMessage(err) || "Mint failed";
+        setError(message);
+      }
+      setMintStatus("idle");
     }
   };
 
   const handleBurnNft = async (tokenId: string) => {
-    void tokenId;
+    if (!isConnected || !activeAddress || !hasUsableAddress) {
+      setMintErrorScope("burn");
+      setError("Please authenticate first");
+      return;
+    }
+    if (!nftContractAddress) {
+      setMintErrorScope("burn");
+      setError("NFT burn is not available on this chain");
+      return;
+    }
+    if (!publicClient) {
+      setMintErrorScope("burn");
+      setError("RPC client is not ready");
+      return;
+    }
 
+    setError("");
     setMintErrorScope("burn");
-    setMintErrorMessage(BURN_UNAVAILABLE_MESSAGE);
-    setRenderMintError(true);
-    setMintErrorVisible(true);
-    window.setTimeout(() => {
-      setMintErrorVisible(false);
-    }, 7600);
-    window.setTimeout(() => {
-      setRenderMintError(false);
-    }, 8000);
+    setRenderMintError(false);
+    setMintErrorVisible(false);
+    setMintErrorMessage("");
+    setBurnTxHash(undefined);
+    setBurningTokenId(tokenId);
+
+    try {
+      const tokenIdBigInt = BigInt(tokenId);
+      const owner = await publicClient.readContract({
+        address: nftContractAddress,
+        abi: NFT_CONTRACT_ABI,
+        functionName: "ownerOf",
+        args: [tokenIdBigInt],
+      });
+
+      if (owner.toLowerCase() !== activeAddress.toLowerCase()) {
+        removeGalleryNft(tokenId);
+        throw new Error(
+          `NFT #${tokenId} is owned by ${formatShortHash(owner)}, not this wallet.`,
+        );
+      }
+
+      const txHash = await sendNftTransaction(encodeFunctionData({
+        abi: NFT_CONTRACT_ABI,
+        functionName: "transferFrom",
+        args: [owner, DEAD_ADDRESS, tokenIdBigInt],
+      }));
+
+      await waitForNftTransactionReceipt(txHash);
+
+      setLatestBurnedTokenId(tokenId);
+      setBurnTxHash(txHash);
+      setRemovingTokenId(tokenId);
+      window.setTimeout(() => {
+        removeGalleryNft(tokenId);
+        setRemovingTokenId((current) => current === tokenId ? null : current);
+      }, 220);
+    } catch (err) {
+      console.info("Burn did not complete:", getMintErrorMessage(err));
+      setMintErrorScope("burn");
+      setError(getMintErrorMessage(err) || "Burn failed");
+    } finally {
+      setBurningTokenId(null);
+    }
   };
 
   useEffect(() => {
@@ -408,19 +838,17 @@ export function SendTransactionTest({
   }, [mintTxHash]);
 
   useEffect(() => {
-    if (mintTxHash || mintedCount > 0 || !mintError) return;
+    if (!burnTxHash) return;
 
-    setMintErrorScope("mint");
-    setMintErrorMessage(getMintErrorMessage(mintError));
-    setRenderMintError(true);
+    setRenderBurnToast(true);
     const showFrame = window.requestAnimationFrame(() => {
-      setMintErrorVisible(true);
+      setBurnToastVisible(true);
     });
     const hideTimeout = window.setTimeout(() => {
-      setMintErrorVisible(false);
+      setBurnToastVisible(false);
     }, 7600);
     const unmountTimeout = window.setTimeout(() => {
-      setRenderMintError(false);
+      setRenderBurnToast(false);
     }, 8000);
 
     return () => {
@@ -428,10 +856,13 @@ export function SendTransactionTest({
       window.clearTimeout(hideTimeout);
       window.clearTimeout(unmountTimeout);
     };
-  }, [mintError, mintTxHash, mintedCount]);
+  }, [burnTxHash]);
 
   useEffect(() => {
-    if (!error || (mintedCount > 0 && mintErrorScope !== "burn")) return;
+    if (!error) return;
+
+    const hideAfter = 4200;
+    const unmountAfter = hideAfter + 300;
 
     setMintErrorMessage(error);
     setRenderMintError(true);
@@ -440,10 +871,10 @@ export function SendTransactionTest({
     });
     const hideTimeout = window.setTimeout(() => {
       setMintErrorVisible(false);
-    }, 7600);
+    }, hideAfter);
     const unmountTimeout = window.setTimeout(() => {
       setRenderMintError(false);
-    }, 8000);
+    }, unmountAfter);
 
     return () => {
       window.cancelAnimationFrame(showFrame);
@@ -453,13 +884,13 @@ export function SendTransactionTest({
   }, [error, mintedCount, mintErrorScope]);
 
   useEffect(() => {
-    if (mintedCount === 0 || mintErrorScope === "burn") return;
+    if (!mintTxHash || mintErrorScope === "burn") return;
 
     setError("");
     setRenderMintError(false);
     setMintErrorVisible(false);
     setMintErrorMessage("");
-  }, [mintedCount, mintErrorScope]);
+  }, [mintTxHash, mintErrorScope]);
 
   useEffect(() => {
     if (!nftFocusRequest) return;
@@ -487,8 +918,102 @@ export function SendTransactionTest({
     return () => window.clearTimeout(timeout);
   }, [nftFocusRequest, galleryNfts.length]);
 
+  const notification =
+    renderMintError && mintErrorMessage
+      ? {
+          key: "error",
+          visible: mintErrorVisible,
+          tone: "error" as const,
+          icon: <AlertCircle className="h-4 w-4 shrink-0 text-red-600" />,
+          title: mintErrorScope === "burn" ? "Burn failed" : "Transaction failed",
+          message: mintErrorMessage,
+        }
+      : mintTxHash && renderMintToast
+        ? {
+            key: "mint",
+            visible: mintToastVisible,
+            tone: "success" as const,
+            href: `${explorerBaseUrl}/tx/${mintTxHash}`,
+            icon: <Check className="h-4 w-4 shrink-0 text-emerald-700" />,
+            title: "NFT minted",
+            message: latestMintedTokenId
+              ? `NFT #${latestMintedTokenId} minted.`
+              : "NFT minted.",
+            action: `View tx ${formatShortHash(mintTxHash)}`,
+          }
+        : burnTxHash && renderBurnToast
+          ? {
+              key: "burn",
+              visible: burnToastVisible,
+              tone: "success" as const,
+              href: `${explorerBaseUrl}/tx/${burnTxHash}`,
+              icon: <Check className="h-4 w-4 shrink-0 text-emerald-700" />,
+              title: "NFT burned",
+              message: latestBurnedTokenId
+                ? `NFT #${latestBurnedTokenId} burned.`
+                : "NFT burned.",
+              action: `View tx ${formatShortHash(burnTxHash)}`,
+            }
+          : null;
+
   return (
     <div className="space-y-5">
+      {notification && (
+        <div
+          className={cn(
+            "fixed inset-x-0 top-20 z-50 pointer-events-none border-b backdrop-blur-xl transition duration-300 ease-out motion-reduce:transition-none",
+            notification.tone === "success"
+              ? "border-emerald-200 bg-emerald-50/95 text-emerald-950"
+              : "border-red-200 bg-red-50/95 text-red-950",
+            notification.visible
+              ? "translate-y-0 opacity-100"
+              : "-translate-y-2 opacity-0",
+          )}
+        >
+          <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+            {notification.href ? (
+              <a
+                key={notification.key}
+                href={notification.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cn(
+                  "pointer-events-auto flex min-h-10 items-center justify-between gap-4 py-2 transition-colors",
+                  notification.tone === "success"
+                    ? "hover:text-emerald-800"
+                    : "border-red-200 bg-red-50/95 text-red-950",
+                )}
+              >
+                <span className="flex min-w-0 items-center gap-2">
+                  {notification.icon}
+                  <span className="min-w-0 text-sm">
+                    <span className="font-semibold">{notification.title}</span>
+                    <span className="text-current/75"> · {notification.message}</span>
+                  </span>
+                </span>
+                <span className="inline-flex shrink-0 items-center gap-1 text-sm font-semibold underline underline-offset-4">
+                  {notification.action}
+                  <ExternalLink className="h-3.5 w-3.5" />
+                </span>
+              </a>
+            ) : (
+              <div
+                key={notification.key}
+                className="pointer-events-auto flex min-h-10 items-start gap-2 py-2 text-red-950"
+              >
+                {notification.icon}
+                <div className="min-w-0 text-sm">
+                  <p className="font-semibold">{notification.title}</p>
+                  <p className="line-clamp-2 break-words text-red-700">
+                    {notification.message}
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
       {!nftContractAddress && (
         <div className="flex items-start gap-2 px-4 py-3 bg-yellow-50 border border-yellow-100 rounded-lg">
           <AlertCircle className="h-4 w-4 text-yellow-600 mt-0.5" />
@@ -498,102 +1023,108 @@ export function SendTransactionTest({
         </div>
       )}
 
-	      <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
-        <div className="overflow-hidden rounded-lg border border-gray-200 bg-gray-50">
-          <SeamlessImage
-            src={checkoutImageUrl}
-            alt="Random image"
-            className={cn(
-              "transition duration-300 ease-out motion-reduce:transition-none",
-              checkoutImageVisible ? "scale-100 opacity-100" : "scale-[0.985] opacity-0",
-            )}
-          />
-        </div>
-        <div className="flex flex-col rounded-lg border border-gray-200 bg-white p-4">
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <p className="text-xs font-medium uppercase text-gray-500">
-                Free mint
-              </p>
-              <h2 className="mt-1 text-xl font-semibold tracking-tight text-gray-950">
-                Demo Collectible
+	      <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+        <SeamlessImage
+          src={checkoutImageUrl}
+          fallbackSrc={checkoutImageUrl}
+          alt="Demo collectible preview"
+          aspectClassName="aspect-[16/9]"
+          className={cn(
+            "transition duration-300 ease-out motion-reduce:transition-none",
+            checkoutImageVisible ? "scale-100 opacity-100" : "scale-[0.985] opacity-0",
+          )}
+        />
+        <div className="space-y-4 p-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0">
+              <h2 className="mt-1 text-2xl font-semibold tracking-tight text-gray-950">
+                Demo Collectible {nextMintLabel}
               </h2>
             </div>
-            <div className="rounded-full bg-gray-100 px-3 py-1 text-sm font-semibold text-gray-950">
-              $0.00
-            </div>
           </div>
-          <div className="mt-4 grid gap-2 text-sm">
-            <CheckoutRow label="Network" value={chain?.name ?? "Current network"} />
-            <CheckoutRow label="Gas" value="Sponsored" />
-            <CheckoutRow label="Your NFTs" value={loadingBalance ? "Refreshing..." : String(mintedCount)} />
-            {latestMintedTokenId && (
-              <CheckoutRow label="Last minted" value={`#${latestMintedTokenId}`} />
-            )}
-          </div>
-          <button
-            id="mint-nft-cta"
-            onClick={handleMintNft}
-            disabled={mintInProgress || !activeAddress || !hasUsableAddress || !nftContractAddress}
-            className={cn(
-              "mt-auto flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white transition-all duration-200 hover:bg-gray-800 cursor-pointer",
-              "disabled:cursor-not-allowed disabled:opacity-50",
-              mintCtaHighlighted && "ring-4 ring-blue-200",
-            )}
-          >
-            {mintInProgress ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin" />
-                {confirmingMint ? "Confirming mint..." : "Minting NFT..."}
-              </>
-            ) : (
-              <>
-                <Sparkles className="h-4 w-4" />
-                {mintedCount > 0 ? "Mint another" : "Mint for free"}
-              </>
-            )}
-	          </button>
-	        </div>
-	      </div>
 
-	      {(mintErrorScope === "burn" || mintedCount === 0) && renderMintError && mintErrorMessage && (
-        <div
-          className={cn(
-            "flex items-start gap-2 overflow-hidden rounded-lg border border-red-100 bg-red-50 px-4 py-3 transition duration-300 ease-out motion-reduce:transition-none",
-            mintErrorVisible ? "translate-y-0 opacity-100" : "-translate-y-1 opacity-0",
-          )}
-        >
-          <AlertCircle className="h-4 w-4 text-red-600 mt-0.5 shrink-0" />
-          <div className="min-w-0">
-            <p className="text-sm font-medium text-red-900">
-              {mintErrorScope === "burn" ? "Burn Failed" : "Transaction Failed"}
-            </p>
-            <p className="text-sm text-red-700 mt-0.5 break-words line-clamp-3">
-              {mintErrorMessage}
-            </p>
-          </div>
-        </div>
-      )}
-
-      {mintTxHash && renderMintToast && (
-        <a
-          href={`${explorerBaseUrl}/tx/${mintTxHash}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={cn(
-            "flex items-center justify-between gap-4 rounded-lg border border-green-100 bg-green-50 px-4 py-3 transition duration-300 ease-out hover:bg-green-100 motion-reduce:transition-none",
-            mintToastVisible ? "translate-y-0 opacity-100" : "-translate-y-1 opacity-0",
-          )}
-        >
-          <span className="flex min-w-0 items-center gap-2">
-            <Check className="h-4 w-4 text-green-600" />
-            <span className="truncate text-sm font-medium text-green-700">
-              NFT {latestMintedTokenId ? `#${latestMintedTokenId} ` : ""}minted. View tx {formatShortHash(mintTxHash)} on Arbiscan.
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <span className="rounded-full bg-gray-100 px-3 py-1 font-medium text-gray-700">
+              {chain?.name ?? "Current network"}
             </span>
-          </span>
-          <ExternalLink className="h-4 w-4 shrink-0 text-green-600" />
-        </a>
-      )}
+            <span className="rounded-full bg-gray-100 px-3 py-1 font-medium text-gray-700">
+              Free
+            </span>
+            <span className="rounded-full bg-green-50 px-3 py-1 font-semibold text-green-700">
+              Sponsored gas
+            </span>
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[auto_minmax(0,1fr)]">
+            <button
+              type="button"
+              onClick={randomizePreviewImage}
+              disabled={nftActionInProgress}
+              className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-4 text-sm font-semibold text-gray-900 shadow-sm transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <Shuffle className="h-4 w-4" />
+              Try another
+            </button>
+            <button
+              id="mint-nft-cta"
+              onClick={handleMintNft}
+              disabled={nftActionInProgress || !activeAddress || !hasUsableAddress || !nftContractAddress}
+              className={cn(
+                "flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white transition-all duration-200 hover:bg-gray-800 cursor-pointer",
+                "disabled:cursor-not-allowed disabled:opacity-50",
+                mintCtaHighlighted && "ring-4 ring-blue-200",
+              )}
+            >
+              {mintStatus === "syncing" ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Preparing next mint...
+                </>
+              ) : mintInProgress ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  {mintStatus === "submitted" || mintStatus === "confirmed"
+                    ? "Confirming mint..."
+                    : "Minting NFT..."}
+                </>
+              ) : (
+                <>
+                  <Sparkles className="h-4 w-4" />
+                  Mint this NFT
+                </>
+              )}
+	          </button>
+          </div>
+          {mintInProgress && (
+            <div className="grid gap-2 rounded-lg bg-gray-50 p-2 sm:grid-cols-4">
+              {mintStatusSteps.map((step) => (
+                <div
+                  key={step.key}
+                  className={cn(
+                    "flex items-center gap-2 rounded-md px-2 py-1.5 text-xs font-semibold text-gray-500",
+                    step.done && "text-gray-950",
+                    step.active && "bg-white shadow-sm",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "flex h-4 w-4 items-center justify-center rounded-full bg-gray-200",
+                      step.done && "bg-emerald-100 text-emerald-800",
+                    )}
+                  >
+                    {step.active ? (
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                    ) : step.done ? (
+                      <Check className="h-3 w-3" />
+                    ) : null}
+                  </span>
+                  {step.label}
+                </div>
+              ))}
+            </div>
+          )}
+	      </div>
+      </div>
 
       {galleryNfts.length > 0 && (
         <div id="minted-nfts" className="scroll-mt-6 overflow-hidden rounded-lg border border-gray-200 bg-white">
@@ -621,10 +1152,14 @@ export function SendTransactionTest({
               {galleryNfts.map((nft) => (
                 <div
                   key={`${nft.txHash ?? "owned"}-${nft.tokenId}`}
-                  className="w-[260px] shrink-0 snap-start overflow-hidden rounded-lg border border-gray-200 bg-gray-50"
+                  className={cn(
+                    "w-[260px] shrink-0 snap-start overflow-hidden rounded-lg border border-gray-200 bg-gray-50 transition duration-200 ease-out motion-reduce:transition-none",
+                    removingTokenId === nft.tokenId && "scale-[0.98] opacity-0",
+                  )}
                 >
                   <SeamlessImage
-                    src={nft.imageUrl ?? `https://picsum.photos/seed/${nft.tokenId}/800/600`}
+                    src={getNftImageUrl(nft.tokenId, nft.imageUrl)}
+                    fallbackSrc={getDeterministicNftImageUrl(nft.tokenId)}
                     alt={`Minted NFT #${nft.tokenId}`}
                   />
                   <div className="space-y-2 bg-white px-3 py-3">
@@ -660,7 +1195,7 @@ export function SendTransactionTest({
                       </span>
                     </div>
                     <a
-                      href={nft.imageUrl ?? `https://picsum.photos/seed/${nft.tokenId}/800/600`}
+                      href={getNftImageUrl(nft.tokenId, nft.imageUrl)}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="flex items-center justify-between gap-2 text-xs font-medium text-gray-500 transition-colors hover:text-gray-900"
@@ -682,13 +1217,18 @@ export function SendTransactionTest({
                     <button
                       type="button"
                       onClick={() => handleBurnNft(nft.tokenId)}
+                      disabled={nftActionInProgress}
                       className={cn(
                         "flex h-9 w-full items-center justify-center gap-2 rounded-lg border border-red-200 bg-red-50 text-sm font-semibold text-red-700 transition-colors hover:bg-red-100",
                         "disabled:cursor-not-allowed disabled:opacity-60",
                       )}
                     >
-                      <Trash2 className="h-3.5 w-3.5" />
-                      Burn unavailable
+                      {burningTokenId === nft.tokenId ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <Trash2 className="h-3.5 w-3.5" />
+                      )}
+                      {burningTokenId === nft.tokenId ? "Burning..." : "Burn"}
                     </button>
                   </div>
                 </div>

--- a/apps/zerodev-signer-demo/src/app/components/SendTransactionTest.tsx
+++ b/apps/zerodev-signer-demo/src/app/components/SendTransactionTest.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type ReactNode, useEffect, useRef, useState } from "react";
-import { Sparkles, AlertCircle, Loader2, Check, ChevronDown, Code2, ExternalLink } from "lucide-react";
+import { Sparkles, AlertCircle, Loader2, Check, ChevronDown, Code2, ExternalLink, Trash2 } from "lucide-react";
 import { cn } from "../lib/utils";
 import {
   type Address,
@@ -28,6 +28,9 @@ const NFT_CONTRACT_ABI = parseAbi([
 const NFT_TRANSFER_EVENT = parseAbiItem(
   "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)"
 );
+
+const BURN_UNAVAILABLE_MESSAGE =
+  "Burn is not enabled in this demo. The current gas policy sponsors the free mint flow, but not ERC-721 transferFrom calls.";
 
 type MintedNft = {
   blockNumber?: bigint
@@ -56,11 +59,77 @@ function compareBlockNumbers(a?: bigint, b?: bigint) {
   return a > b ? -1 : 1;
 }
 
+function getMintErrorMessage(error: unknown) {
+  if (!error) return "";
+  if (typeof error === "string") return error;
+  if (
+    typeof error === "object" &&
+    "shortMessage" in error &&
+    typeof error.shortMessage === "string"
+  ) {
+    return error.shortMessage;
+  }
+  if (error instanceof Error) {
+    if (
+      error.message.toLowerCase().includes("unknown rpc error") ||
+      error.message.toLowerCase().includes("user rejected")
+    ) {
+      return "Transaction confirmation was not completed.";
+    }
+    return error.message;
+  }
+  return "Mint did not complete. Try again.";
+}
+
+function SeamlessImage({
+  alt,
+  className,
+  src,
+}: {
+  alt: string
+  className?: string
+  src: string
+}) {
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    setLoaded(false);
+  }, [src]);
+
+  return (
+    <div className="relative aspect-[4/3] overflow-hidden bg-gray-100">
+      <div
+        className={cn(
+          "absolute inset-0 bg-[linear-gradient(110deg,#f3f4f6_0%,#ffffff_45%,#f3f4f6_90%)] opacity-100 transition-opacity duration-300",
+          loaded && "opacity-0",
+        )}
+      />
+      <img
+        key={src}
+        src={src}
+        alt={alt}
+        loading="eager"
+        decoding="async"
+        onLoad={() => setLoaded(true)}
+        className={cn(
+          "absolute inset-0 h-full w-full object-cover opacity-0 transition duration-500 ease-out motion-reduce:transition-none",
+          loaded && "opacity-100",
+          className,
+        )}
+      />
+    </div>
+  );
+}
+
 export function SendTransactionTest({
   accountAddress,
+  refreshKey = 0,
+  nftFocusRequest = 0,
   onNftCountChange,
 }: {
   accountAddress: Address | null
+  refreshKey?: number
+  nftFocusRequest?: number
   onNftCountChange?: (count: number) => void
 }) {
   const [error, setError] = useState<string>("");
@@ -70,7 +139,19 @@ export function SendTransactionTest({
   const [confirmingMint, setConfirmingMint] = useState(false);
   const [codeOpen, setCodeOpen] = useState(false);
   const [nftsOpen, setNftsOpen] = useState(true);
-  const lastMintHashRef = useRef<`0x${string}` | undefined>(undefined);
+  const [checkoutSeed, setCheckoutSeed] = useState("demo-collectible");
+  const [checkoutImageVisible, setCheckoutImageVisible] = useState(true);
+  const [renderMintToast, setRenderMintToast] = useState(false);
+  const [mintToastVisible, setMintToastVisible] = useState(false);
+  const [renderMintError, setRenderMintError] = useState(false);
+  const [mintErrorVisible, setMintErrorVisible] = useState(false);
+  const [mintErrorMessage, setMintErrorMessage] = useState("");
+  const [mintErrorScope, setMintErrorScope] = useState<"mint" | "burn">("mint");
+  const [mintCtaHighlighted, setMintCtaHighlighted] = useState(false);
+  const [mintTxHash, setMintTxHash] = useState<`0x${string}` | undefined>();
+  const [latestMintedTokenId, setLatestMintedTokenId] = useState<string | null>(null);
+  const mintedImageByTokenIdRef = useRef<Record<string, string>>({});
+  const pendingMintImageUrlRef = useRef<string>("https://picsum.photos/seed/demo-collectible/800/600");
 
   // Wagmi hooks
   const { address, isConnected, chain } = useAccount();
@@ -78,13 +159,14 @@ export function SendTransactionTest({
   const hasUsableAddress =
     Boolean(activeAddress) && activeAddress?.toLowerCase() !== zeroAddress;
   const publicClient = usePublicClient({chainId: chain?.id});
-  const { writeContract, isPending: isMinting, data: mintTxHash, error: mintError } = useWriteContract();
+  const { writeContractAsync, isPending: isMinting, error: mintError } = useWriteContract();
 
   const nftContractAddress = chain?.id ? NFT_CONTRACTS[chain.id] : undefined;
   const explorerBaseUrl = chain?.blockExplorers?.default?.url ?? "https://sepolia.arbiscan.io";
   const galleryNfts = mintedNfts;
   const mintedCount = mintedNfts.length || Number(nftBalance) || 0;
   const mintInProgress = isMinting || confirmingMint;
+  const checkoutImageUrl = `https://picsum.photos/seed/${checkoutSeed}/800/600`;
 
   // Fetch NFT balance
   const fetchNftBalance = async () => {
@@ -115,7 +197,7 @@ export function SendTransactionTest({
       fetchNftBalance();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isConnected, publicClient, activeAddress, nftContractAddress]);
+  }, [isConnected, publicClient, activeAddress, nftContractAddress, refreshKey]);
 
   useEffect(() => {
     const fetchOwnedNfts = async () => {
@@ -147,7 +229,9 @@ export function SendTransactionTest({
           if (to === normalizedOwner) {
             owned.set(tokenId, {
               blockNumber: log.blockNumber,
-              imageUrl: `https://picsum.photos/seed/${tokenId}/800/600`,
+              imageUrl:
+                mintedImageByTokenIdRef.current[tokenId] ??
+                `https://picsum.photos/seed/${tokenId}/800/600`,
               tokenId,
               txHash: log.transactionHash,
             });
@@ -187,7 +271,7 @@ export function SendTransactionTest({
     };
 
     fetchOwnedNfts();
-  }, [publicClient, activeAddress, hasUsableAddress, nftContractAddress, onNftCountChange]);
+  }, [publicClient, activeAddress, hasUsableAddress, nftContractAddress, onNftCountChange, refreshKey]);
 
   useEffect(() => {
     if (!activeAddress || !nftContractAddress) {
@@ -207,40 +291,27 @@ export function SendTransactionTest({
     }
 
     setError("");
+    setRenderMintError(false);
+    setMintErrorVisible(false);
+    setMintErrorMessage("");
+    setMintErrorScope("mint");
+    setMintTxHash(undefined);
+    pendingMintImageUrlRef.current = checkoutImageUrl;
 
     try {
-      // Use Wagmi's useWriteContract - provider handles gasless via EIP-7702
-      await writeContract({
+      const txHash = await writeContractAsync({
         address: nftContractAddress,
         abi: NFT_CONTRACT_ABI,
         functionName: "mint",
         args: [activeAddress],
       });
 
-      // Refresh NFT balance after successful mint
-      setTimeout(() => fetchNftBalance(), 3000);
-    } catch (err) {
-      console.error("Mint error:", err);
-      setError("Mint failed");
-    }
-  };
-
-  // Watch for transaction success and derive the minted NFT from Transfer logs.
-  useEffect(() => {
-    if (!mintTxHash || lastMintHashRef.current === mintTxHash) {
-      return;
-    }
-
-    lastMintHashRef.current = mintTxHash;
-    setError("");
-
-    const loadMintReceipt = async () => {
-      if (!publicClient || !activeAddress) return;
-
       setConfirmingMint(true);
-      try {
+      setMintTxHash(txHash);
+
+      if (publicClient) {
         const receipt = await publicClient.waitForTransactionReceipt({
-          hash: mintTxHash,
+          hash: txHash,
         });
         const transferLogs = parseEventLogs({
           abi: NFT_CONTRACT_ABI,
@@ -260,32 +331,161 @@ export function SendTransactionTest({
           const block = await publicClient.getBlock({
             blockNumber: receipt.blockNumber,
           });
+          const mintedImageUrl = pendingMintImageUrlRef.current;
+          mintedImageByTokenIdRef.current[tokenId] = mintedImageUrl;
+          setLatestMintedTokenId(tokenId);
+          setCheckoutImageVisible(false);
+          window.setTimeout(() => {
+            setCheckoutSeed(`demo-collectible-next-${tokenId}`);
+            setCheckoutImageVisible(true);
+          }, 180);
           setMintedNfts((current) => {
-            if (current.some((item) => item.tokenId === tokenId)) return current;
+            if (current.some((item) => item.tokenId === tokenId)) {
+              return current.map((item) =>
+                item.tokenId === tokenId
+                  ? { ...item, imageUrl: mintedImageUrl, txHash }
+                  : item,
+              );
+            }
             return [
               {
                 blockNumber: receipt.blockNumber,
-                imageUrl: `https://picsum.photos/seed/${tokenId}/800/600`,
+                imageUrl: mintedImageUrl,
                 timestamp: new Date(Number(block.timestamp) * 1000).toISOString(),
                 tokenId,
-                txHash: mintTxHash,
+                txHash,
               },
               ...current,
             ];
           });
         }
-
-        await fetchNftBalance();
-      } catch (err) {
-        console.error("Failed to confirm minted NFT:", err);
-      } finally {
-        setConfirmingMint(false);
       }
-    };
 
-    loadMintReceipt();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mintTxHash, publicClient, activeAddress]);
+      await fetchNftBalance();
+    } catch (err) {
+      console.error("Mint error:", err);
+      setMintErrorScope("mint");
+      setError(getMintErrorMessage(err) || "Mint failed");
+    } finally {
+      setConfirmingMint(false);
+    }
+  };
+
+  const handleBurnNft = async (tokenId: string) => {
+    void tokenId;
+
+    setMintErrorScope("burn");
+    setMintErrorMessage(BURN_UNAVAILABLE_MESSAGE);
+    setRenderMintError(true);
+    setMintErrorVisible(true);
+    window.setTimeout(() => {
+      setMintErrorVisible(false);
+    }, 7600);
+    window.setTimeout(() => {
+      setRenderMintError(false);
+    }, 8000);
+  };
+
+  useEffect(() => {
+    if (!mintTxHash) return;
+
+    setRenderMintToast(true);
+    const showFrame = window.requestAnimationFrame(() => {
+      setMintToastVisible(true);
+    });
+    const hideTimeout = window.setTimeout(() => {
+      setMintToastVisible(false);
+    }, 7600);
+    const unmountTimeout = window.setTimeout(() => {
+      setRenderMintToast(false);
+    }, 8000);
+
+    return () => {
+      window.cancelAnimationFrame(showFrame);
+      window.clearTimeout(hideTimeout);
+      window.clearTimeout(unmountTimeout);
+    };
+  }, [mintTxHash]);
+
+  useEffect(() => {
+    if (mintTxHash || mintedCount > 0 || !mintError) return;
+
+    setMintErrorScope("mint");
+    setMintErrorMessage(getMintErrorMessage(mintError));
+    setRenderMintError(true);
+    const showFrame = window.requestAnimationFrame(() => {
+      setMintErrorVisible(true);
+    });
+    const hideTimeout = window.setTimeout(() => {
+      setMintErrorVisible(false);
+    }, 7600);
+    const unmountTimeout = window.setTimeout(() => {
+      setRenderMintError(false);
+    }, 8000);
+
+    return () => {
+      window.cancelAnimationFrame(showFrame);
+      window.clearTimeout(hideTimeout);
+      window.clearTimeout(unmountTimeout);
+    };
+  }, [mintError, mintTxHash, mintedCount]);
+
+  useEffect(() => {
+    if (!error || (mintedCount > 0 && mintErrorScope !== "burn")) return;
+
+    setMintErrorMessage(error);
+    setRenderMintError(true);
+    const showFrame = window.requestAnimationFrame(() => {
+      setMintErrorVisible(true);
+    });
+    const hideTimeout = window.setTimeout(() => {
+      setMintErrorVisible(false);
+    }, 7600);
+    const unmountTimeout = window.setTimeout(() => {
+      setRenderMintError(false);
+    }, 8000);
+
+    return () => {
+      window.cancelAnimationFrame(showFrame);
+      window.clearTimeout(hideTimeout);
+      window.clearTimeout(unmountTimeout);
+    };
+  }, [error, mintedCount, mintErrorScope]);
+
+  useEffect(() => {
+    if (mintedCount === 0 || mintErrorScope === "burn") return;
+
+    setError("");
+    setRenderMintError(false);
+    setMintErrorVisible(false);
+    setMintErrorMessage("");
+  }, [mintedCount, mintErrorScope]);
+
+  useEffect(() => {
+    if (!nftFocusRequest) return;
+
+    if (galleryNfts.length > 0) {
+      setNftsOpen(true);
+      requestAnimationFrame(() => {
+        document
+          .getElementById("minted-nfts")
+          ?.scrollIntoView({ behavior: "smooth", block: "start" });
+      });
+      return;
+    }
+
+    setMintCtaHighlighted(true);
+    requestAnimationFrame(() => {
+      document
+        .getElementById("mint-nft-cta")
+        ?.scrollIntoView({ behavior: "smooth", block: "center" });
+    });
+    const timeout = window.setTimeout(() => {
+      setMintCtaHighlighted(false);
+    }, 1600);
+
+    return () => window.clearTimeout(timeout);
+  }, [nftFocusRequest, galleryNfts.length]);
 
   return (
     <div className="space-y-5">
@@ -300,10 +500,13 @@ export function SendTransactionTest({
 
 	      <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
         <div className="overflow-hidden rounded-lg border border-gray-200 bg-gray-50">
-          <img
-            src="https://picsum.photos/800/600"
+          <SeamlessImage
+            src={checkoutImageUrl}
             alt="Random image"
-            className="aspect-[4/3] w-full object-cover"
+            className={cn(
+              "transition duration-300 ease-out motion-reduce:transition-none",
+              checkoutImageVisible ? "scale-100 opacity-100" : "scale-[0.985] opacity-0",
+            )}
           />
         </div>
         <div className="flex flex-col rounded-lg border border-gray-200 bg-white p-4">
@@ -324,13 +527,18 @@ export function SendTransactionTest({
             <CheckoutRow label="Network" value={chain?.name ?? "Current network"} />
             <CheckoutRow label="Gas" value="Sponsored" />
             <CheckoutRow label="Your NFTs" value={loadingBalance ? "Refreshing..." : String(mintedCount)} />
+            {latestMintedTokenId && (
+              <CheckoutRow label="Last minted" value={`#${latestMintedTokenId}`} />
+            )}
           </div>
           <button
+            id="mint-nft-cta"
             onClick={handleMintNft}
             disabled={mintInProgress || !activeAddress || !hasUsableAddress || !nftContractAddress}
             className={cn(
-              "mt-auto flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white transition-colors hover:bg-gray-800 cursor-pointer",
-              "disabled:cursor-not-allowed disabled:opacity-50"
+              "mt-auto flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white transition-all duration-200 hover:bg-gray-800 cursor-pointer",
+              "disabled:cursor-not-allowed disabled:opacity-50",
+              mintCtaHighlighted && "ring-4 ring-blue-200",
             )}
           >
             {mintInProgress ? (
@@ -341,48 +549,50 @@ export function SendTransactionTest({
             ) : (
               <>
                 <Sparkles className="h-4 w-4" />
-                Mint for free
+                {mintedCount > 0 ? "Mint another" : "Mint for free"}
               </>
             )}
 	          </button>
 	        </div>
 	      </div>
 
-	      {(error || mintError) && (
-        <div className="flex items-start gap-2 px-4 py-3 bg-red-50 border border-red-100 rounded-lg overflow-hidden">
+	      {(mintErrorScope === "burn" || mintedCount === 0) && renderMintError && mintErrorMessage && (
+        <div
+          className={cn(
+            "flex items-start gap-2 overflow-hidden rounded-lg border border-red-100 bg-red-50 px-4 py-3 transition duration-300 ease-out motion-reduce:transition-none",
+            mintErrorVisible ? "translate-y-0 opacity-100" : "-translate-y-1 opacity-0",
+          )}
+        >
           <AlertCircle className="h-4 w-4 text-red-600 mt-0.5 shrink-0" />
           <div className="min-w-0">
-            <p className="text-sm font-medium text-red-900">Transaction Failed</p>
+            <p className="text-sm font-medium text-red-900">
+              {mintErrorScope === "burn" ? "Burn Failed" : "Transaction Failed"}
+            </p>
             <p className="text-sm text-red-700 mt-0.5 break-words line-clamp-3">
-              {error || (mintError as unknown as { shortMessage?: string })?.shortMessage || mintError?.message}
+              {mintErrorMessage}
             </p>
           </div>
         </div>
       )}
 
-      {mintTxHash && (
-        <div className="space-y-2">
-          <div className="flex items-center gap-2 px-4 py-3 bg-green-50 border border-green-100 rounded-lg">
+      {mintTxHash && renderMintToast && (
+        <a
+          href={`${explorerBaseUrl}/tx/${mintTxHash}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            "flex items-center justify-between gap-4 rounded-lg border border-green-100 bg-green-50 px-4 py-3 transition duration-300 ease-out hover:bg-green-100 motion-reduce:transition-none",
+            mintToastVisible ? "translate-y-0 opacity-100" : "-translate-y-1 opacity-0",
+          )}
+        >
+          <span className="flex min-w-0 items-center gap-2">
             <Check className="h-4 w-4 text-green-600" />
-            <span className="text-sm text-green-700 font-medium">
-              NFT minted into your wallet.
+            <span className="truncate text-sm font-medium text-green-700">
+              NFT {latestMintedTokenId ? `#${latestMintedTokenId} ` : ""}minted. View tx {formatShortHash(mintTxHash)} on Arbiscan.
             </span>
-          </div>
-          <a
-            href={`${explorerBaseUrl}/tx/${mintTxHash}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={cn(
-              "flex items-center justify-between px-4 py-3 bg-gray-50 border border-gray-200 rounded-lg",
-              "hover:bg-gray-100 transition-colors group"
-            )}
-          >
-            <span className="text-sm text-gray-700 font-medium">
-              Confirm on Arbiscan
-            </span>
-            <ExternalLink className="h-4 w-4 text-gray-400 group-hover:text-gray-600" />
-          </a>
-        </div>
+          </span>
+          <ExternalLink className="h-4 w-4 shrink-0 text-green-600" />
+        </a>
       )}
 
       {galleryNfts.length > 0 && (
@@ -393,8 +603,11 @@ export function SendTransactionTest({
             className="flex w-full items-center justify-between gap-4 px-4 py-3 text-left transition-colors hover:bg-gray-50 cursor-pointer"
             aria-expanded={nftsOpen}
           >
-            <span className="block text-sm font-semibold text-gray-950">
+            <span className="flex items-center gap-2 text-sm font-semibold text-gray-950">
               My NFTs
+              <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-semibold text-gray-600">
+                {galleryNfts.length}
+              </span>
             </span>
             <ChevronDown
               className={cn(
@@ -410,10 +623,9 @@ export function SendTransactionTest({
                   key={`${nft.txHash ?? "owned"}-${nft.tokenId}`}
                   className="w-[260px] shrink-0 snap-start overflow-hidden rounded-lg border border-gray-200 bg-gray-50"
                 >
-                  <img
+                  <SeamlessImage
                     src={nft.imageUrl ?? `https://picsum.photos/seed/${nft.tokenId}/800/600`}
                     alt={`Minted NFT #${nft.tokenId}`}
-                    className="aspect-[4/3] w-full object-cover"
                   />
                   <div className="space-y-2 bg-white px-3 py-3">
                     <div className="flex items-center justify-between gap-3">
@@ -429,9 +641,14 @@ export function SendTransactionTest({
                         <span className="text-xs font-medium text-gray-500">
                           Receipt
                         </span>
-                        <span className="truncate font-mono text-xs font-medium text-gray-600">
+                        <a
+                          href={`${explorerBaseUrl}/tx/${nft.txHash}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="truncate font-mono text-xs font-medium text-gray-600 underline-offset-2 transition-colors hover:text-gray-950 hover:underline"
+                        >
                           {formatShortHash(nft.txHash)}
-                        </span>
+                        </a>
                       </div>
                     )}
                     <div className="flex items-center justify-between gap-3">
@@ -462,6 +679,17 @@ export function SendTransactionTest({
                         <ExternalLink className="h-3.5 w-3.5" />
                       </a>
                     )}
+                    <button
+                      type="button"
+                      onClick={() => handleBurnNft(nft.tokenId)}
+                      className={cn(
+                        "flex h-9 w-full items-center justify-center gap-2 rounded-lg border border-red-200 bg-red-50 text-sm font-semibold text-red-700 transition-colors hover:bg-red-100",
+                        "disabled:cursor-not-allowed disabled:opacity-60",
+                      )}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                      Burn unavailable
+                    </button>
                   </div>
                 </div>
               ))}

--- a/apps/zerodev-signer-demo/src/app/components/SendTransactionTest.tsx
+++ b/apps/zerodev-signer-demo/src/app/components/SendTransactionTest.tsx
@@ -1,19 +1,17 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Send, Sparkles, AlertCircle, Loader2, Check, ExternalLink, RefreshCw } from "lucide-react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import { Sparkles, AlertCircle, Loader2, Check, ChevronDown, Code2, ExternalLink } from "lucide-react";
 import { cn } from "../lib/utils";
 import {
   type Address,
-  parseEther,
   parseAbi,
+  parseEventLogs,
+  parseAbiItem,
   zeroAddress,
-  isAddress,
 } from "viem";
 import { sepolia } from "wagmi/chains";
-import { useAccount, useSendTransaction, useWriteContract, usePublicClient } from "wagmi";
-
-type TransactionMode = "send-eth" | "mint-nft";
+import { useAccount, useWriteContract, usePublicClient } from "wagmi";
 
 // Per-chain NFT contract addresses
 const NFT_CONTRACTS: Record<number, `0x${string}`> = {
@@ -22,30 +20,75 @@ const NFT_CONTRACTS: Record<number, `0x${string}`> = {
 };
 
 const NFT_CONTRACT_ABI = parseAbi([
+  "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)",
   "function mint(address _to) public",
   "function balanceOf(address owner) external view returns (uint256 balance)",
 ]);
 
-export function SendTransactionTest() {
-  const [mode, setMode] = useState<TransactionMode>("mint-nft");
-  const [recipient, setRecipient] = useState<string>(zeroAddress);
-  const [amount, setAmount] = useState<string>("0");
+const NFT_TRANSFER_EVENT = parseAbiItem(
+  "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)"
+);
+
+type MintedNft = {
+  blockNumber?: bigint
+  imageUrl?: string
+  timestamp?: string
+  tokenId: string
+  txHash?: `0x${string}`
+}
+
+function formatShortHash(value: `0x${string}`) {
+  return `${value.slice(0, 6)}...${value.slice(-4)}`;
+}
+
+function formatTimestamp(value?: string) {
+  if (!value) return "Pending";
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function compareBlockNumbers(a?: bigint, b?: bigint) {
+  if (a === b) return 0;
+  if (a === undefined) return 1;
+  if (b === undefined) return -1;
+  return a > b ? -1 : 1;
+}
+
+export function SendTransactionTest({
+  accountAddress,
+  onNftCountChange,
+}: {
+  accountAddress: Address | null
+  onNftCountChange?: (count: number) => void
+}) {
   const [error, setError] = useState<string>("");
   const [nftBalance, setNftBalance] = useState<string>("0");
   const [loadingBalance, setLoadingBalance] = useState(false);
+  const [mintedNfts, setMintedNfts] = useState<MintedNft[]>([]);
+  const [confirmingMint, setConfirmingMint] = useState(false);
+  const [codeOpen, setCodeOpen] = useState(false);
+  const [nftsOpen, setNftsOpen] = useState(true);
+  const lastMintHashRef = useRef<`0x${string}` | undefined>(undefined);
 
   // Wagmi hooks
   const { address, isConnected, chain } = useAccount();
+  const activeAddress = accountAddress ?? address;
+  const hasUsableAddress =
+    Boolean(activeAddress) && activeAddress?.toLowerCase() !== zeroAddress;
   const publicClient = usePublicClient({chainId: chain?.id});
-  const { sendTransaction, isPending: isSendingTx, data: sendTxHash, error: sendError, reset: resetSendTx } = useSendTransaction();
-  const { writeContract, isPending: isMinting, data: mintTxHash, error: mintError, reset: resetMint } = useWriteContract();
+  const { writeContract, isPending: isMinting, data: mintTxHash, error: mintError } = useWriteContract();
 
-  const loading = isSendingTx || isMinting;
   const nftContractAddress = chain?.id ? NFT_CONTRACTS[chain.id] : undefined;
+  const explorerBaseUrl = chain?.blockExplorers?.default?.url ?? "https://sepolia.arbiscan.io";
+  const galleryNfts = mintedNfts;
+  const mintedCount = mintedNfts.length || Number(nftBalance) || 0;
+  const mintInProgress = isMinting || confirmingMint;
 
   // Fetch NFT balance
   const fetchNftBalance = async () => {
-    if (!isConnected || !address || !nftContractAddress) return;
+    if (!isConnected || !activeAddress || !hasUsableAddress || !nftContractAddress) return;
 
     setLoadingBalance(true);
     try {
@@ -54,10 +97,12 @@ export function SendTransactionTest() {
         address: nftContractAddress,
         abi: NFT_CONTRACT_ABI,
         functionName: "balanceOf",
-        args: [address],
+        args: [activeAddress],
       });
 
-      setNftBalance(balance.toString());
+      const nextBalance = balance.toString();
+      setNftBalance(nextBalance);
+      onNftCountChange?.(Number(nextBalance));
     } catch (err) {
       console.error("Failed to fetch NFT balance:", err);
     } finally {
@@ -65,46 +110,94 @@ export function SendTransactionTest() {
     }
   };
 
-  // Fetch balance when switching to NFT mode or chain changes
   useEffect(() => {
-    if (mode === "mint-nft" && isConnected) {
+    if (isConnected) {
       fetchNftBalance();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode, isConnected, publicClient]);
+  }, [isConnected, publicClient, activeAddress, nftContractAddress]);
 
-  const handleSendEth = async () => {
-    if (!isConnected || !address || !recipient) {
-      setError("Please authenticate and enter recipient address");
+  useEffect(() => {
+    const fetchOwnedNfts = async () => {
+      if (!publicClient || !activeAddress || !hasUsableAddress || !nftContractAddress) {
+        setMintedNfts([]);
+        return;
+      }
+
+      setLoadingBalance(true);
+      try {
+        const logs = await publicClient.getLogs({
+          address: nftContractAddress,
+          event: NFT_TRANSFER_EVENT,
+          fromBlock: BigInt(0),
+          toBlock: "latest",
+        });
+        const owned = new Map<string, MintedNft>();
+        const normalizedOwner = activeAddress.toLowerCase();
+
+        for (const log of logs) {
+          const from = log.args.from?.toLowerCase();
+          const to = log.args.to?.toLowerCase();
+          const tokenId = log.args.tokenId?.toString();
+          if (!tokenId) continue;
+
+          if (from === normalizedOwner) {
+            owned.delete(tokenId);
+          }
+          if (to === normalizedOwner) {
+            owned.set(tokenId, {
+              blockNumber: log.blockNumber,
+              imageUrl: `https://picsum.photos/seed/${tokenId}/800/600`,
+              tokenId,
+              txHash: log.transactionHash,
+            });
+          }
+        }
+
+        const blockTimestamps = new Map<bigint, string>();
+        await Promise.all(
+          Array.from(
+            new Set(
+              Array.from(owned.values())
+                .map((nft) => nft.blockNumber)
+                .filter((blockNumber): blockNumber is bigint => Boolean(blockNumber)),
+            ),
+          ).map(async (blockNumber) => {
+            const block = await publicClient.getBlock({ blockNumber });
+            blockTimestamps.set(
+              blockNumber,
+              new Date(Number(block.timestamp) * 1000).toISOString(),
+            );
+          }),
+        );
+
+        const nextNfts = Array.from(owned.values())
+          .map((nft) => ({
+            ...nft,
+            timestamp: nft.blockNumber ? blockTimestamps.get(nft.blockNumber) : undefined,
+          }))
+          .sort((a, b) => compareBlockNumbers(a.blockNumber, b.blockNumber));
+        setMintedNfts(nextNfts);
+        onNftCountChange?.(nextNfts.length);
+      } catch (err) {
+        console.error("Failed to fetch owned NFTs:", err);
+      } finally {
+        setLoadingBalance(false);
+      }
+    };
+
+    fetchOwnedNfts();
+  }, [publicClient, activeAddress, hasUsableAddress, nftContractAddress, onNftCountChange]);
+
+  useEffect(() => {
+    if (!activeAddress || !nftContractAddress) {
+      setMintedNfts([]);
       return;
     }
-
-    setError("");
-
-    if (!isAddress(recipient)) {
-      setError("Invalid recipient address");
-      return;
-    }
-    if (isNaN(Number(amount)) || Number(amount) <= 0) {
-      setError("Invalid amount");
-      return;
-    }
-
-    try {
-      // Use Wagmi's useSendTransaction - provider handles gasless via EIP-7702
-      await sendTransaction({
-        to: recipient as Address,
-        value: parseEther(amount || "0"),
-      });
-    } catch (err) {
-      console.error("Transaction error:", err);
-      setError("Transaction failed");
-    }
-  };
+  }, [activeAddress, nftContractAddress]);
 
   const handleMintNft = async () => {
-    console.log("handleMintNft", isConnected, address);
-    if (!isConnected || !address) {
+    if (!isConnected || !activeAddress || !hasUsableAddress) {
       setError("Please authenticate first");
       return;
     }
@@ -121,7 +214,7 @@ export function SendTransactionTest() {
         address: nftContractAddress,
         abi: NFT_CONTRACT_ABI,
         functionName: "mint",
-        args: [address],
+        args: [activeAddress],
       });
 
       // Refresh NFT balance after successful mint
@@ -132,215 +225,380 @@ export function SendTransactionTest() {
     }
   };
 
-  // Watch for transaction success
+  // Watch for transaction success and derive the minted NFT from Transfer logs.
   useEffect(() => {
-    if (sendTxHash || mintTxHash) {
-      setError("");
+    if (!mintTxHash || lastMintHashRef.current === mintTxHash) {
+      return;
     }
-  }, [sendTxHash, mintTxHash]);
+
+    lastMintHashRef.current = mintTxHash;
+    setError("");
+
+    const loadMintReceipt = async () => {
+      if (!publicClient || !activeAddress) return;
+
+      setConfirmingMint(true);
+      try {
+        const receipt = await publicClient.waitForTransactionReceipt({
+          hash: mintTxHash,
+        });
+        const transferLogs = parseEventLogs({
+          abi: NFT_CONTRACT_ABI,
+          eventName: "Transfer",
+          logs: receipt.logs,
+        });
+        const mintedTransfer = transferLogs.find((log) => {
+          const { from, to } = log.args;
+          return (
+            from.toLowerCase() === zeroAddress &&
+            to.toLowerCase() === activeAddress.toLowerCase()
+          );
+        });
+        const tokenId = mintedTransfer?.args.tokenId?.toString();
+
+        if (tokenId) {
+          const block = await publicClient.getBlock({
+            blockNumber: receipt.blockNumber,
+          });
+          setMintedNfts((current) => {
+            if (current.some((item) => item.tokenId === tokenId)) return current;
+            return [
+              {
+                blockNumber: receipt.blockNumber,
+                imageUrl: `https://picsum.photos/seed/${tokenId}/800/600`,
+                timestamp: new Date(Number(block.timestamp) * 1000).toISOString(),
+                tokenId,
+                txHash: mintTxHash,
+              },
+              ...current,
+            ];
+          });
+        }
+
+        await fetchNftBalance();
+      } catch (err) {
+        console.error("Failed to confirm minted NFT:", err);
+      } finally {
+        setConfirmingMint(false);
+      }
+    };
+
+    loadMintReceipt();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mintTxHash, publicClient, activeAddress]);
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h2 className="text-lg font-semibold text-gray-900">Send Transaction</h2>
-        <p className="text-sm text-gray-500 mt-1">
-          Send ETH or mint NFTs on {chain?.name}
-        </p>
-      </div>
-
-      {/* Mode Selector */}
-      <div className="flex gap-2 p-1 bg-gray-100 rounded-lg">
-        <button
-          onClick={() => { setMode("mint-nft"); setError(""); resetSendTx(); }}
-          className={cn(
-            "flex-1 py-2 px-4 rounded-md text-sm font-medium transition-all cursor-pointer",
-            mode === "mint-nft" ? "bg-white text-gray-900 shadow-sm" : "text-gray-600 hover:text-gray-900"
-          )}
-        >
-          Mint NFT
-        </button>
-        <button
-          onClick={() => { setMode("send-eth"); setError(""); resetMint(); }}
-          className={cn(
-            "flex-1 py-2 px-4 rounded-md text-sm font-medium transition-all cursor-pointer",
-            mode === "send-eth" ? "bg-white text-gray-900 shadow-sm" : "text-gray-600 hover:text-gray-900"
-          )}
-        >
-          Send ETH
-        </button>
-      </div>
-
-      {/* No NFT contract for current chain */}
-      {mode === "mint-nft" && !nftContractAddress && (
+    <div className="space-y-5">
+      {!nftContractAddress && (
         <div className="flex items-start gap-2 px-4 py-3 bg-yellow-50 border border-yellow-100 rounded-lg">
           <AlertCircle className="h-4 w-4 text-yellow-600 mt-0.5" />
           <p className="text-sm text-yellow-700">
-            NFT minting is not yet available on {chain?.name}. Switch to Sepolia to mint NFTs.
+            NFT minting is not available on {chain?.name}. Switch to Arbitrum Sepolia to mint.
           </p>
         </div>
       )}
 
-      {/* NFT Balance (only show in mint mode when contract exists) */}
-      {mode === "mint-nft" && nftContractAddress && (
-        <div className="flex items-center justify-between p-4 bg-blue-50 rounded-lg border border-blue-100">
-          <div>
-            <p className="text-xs font-medium text-blue-500 mb-1">Your NFT Balance</p>
-            <p className="text-2xl font-bold text-blue-900">{nftBalance}</p>
+	      <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-gray-50">
+          <img
+            src="https://picsum.photos/800/600"
+            alt="Random image"
+            className="aspect-[4/3] w-full object-cover"
+          />
+        </div>
+        <div className="flex flex-col rounded-lg border border-gray-200 bg-white p-4">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-xs font-medium uppercase text-gray-500">
+                Free mint
+              </p>
+              <h2 className="mt-1 text-xl font-semibold tracking-tight text-gray-950">
+                Demo Collectible
+              </h2>
+            </div>
+            <div className="rounded-full bg-gray-100 px-3 py-1 text-sm font-semibold text-gray-950">
+              $0.00
+            </div>
+          </div>
+          <div className="mt-4 grid gap-2 text-sm">
+            <CheckoutRow label="Network" value={chain?.name ?? "Current network"} />
+            <CheckoutRow label="Gas" value="Sponsored" />
+            <CheckoutRow label="Your NFTs" value={loadingBalance ? "Refreshing..." : String(mintedCount)} />
           </div>
           <button
-            onClick={fetchNftBalance}
-            disabled={loadingBalance}
-            className="p-2 text-blue-500 hover:text-blue-700 disabled:opacity-50 transition-colors cursor-pointer"
-            title="Refresh balance"
+            onClick={handleMintNft}
+            disabled={mintInProgress || !activeAddress || !hasUsableAddress || !nftContractAddress}
+            className={cn(
+              "mt-auto flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white transition-colors hover:bg-gray-800 cursor-pointer",
+              "disabled:cursor-not-allowed disabled:opacity-50"
+            )}
           >
-            <RefreshCw className={cn("h-4 w-4", loadingBalance && "animate-spin")} />
-          </button>
-        </div>
-      )}
-
-      {/* Gasless Info */}
-      <div className="flex items-start gap-3 p-3 bg-blue-50 rounded-lg border border-blue-200">
-        <Sparkles className="h-4 w-4 text-blue-500 shrink-0 mt-0.5" />
-        <p className="text-sm font-medium text-blue-900">Gasless transactions are active</p>
-      </div>
-
-      {/* Form */}
-      <div className="space-y-4">
-        {mode === "send-eth" && (
-          <>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1.5">
-                Recipient Address
-              </label>
-              <input
-                type="text"
-                value={recipient}
-                onChange={(e) => setRecipient(e.target.value)}
-                placeholder="0x..."
-                className={cn(
-                  "w-full px-4 py-2.5 rounded-lg border border-gray-200 font-mono text-sm",
-                  "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
-                  "text-gray-900 placeholder:text-gray-400"
-                )}
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1.5">
-                Amount (ETH)
-              </label>
-              <input
-                type="text"
-                value={amount}
-                onChange={(e) => setAmount(e.target.value)}
-                placeholder="0.001"
-                className={cn(
-                  "w-full px-4 py-2.5 rounded-lg border border-gray-200 text-sm",
-                  "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
-                  "text-gray-900 placeholder:text-gray-400"
-                )}
-              />
-            </div>
-          </>
-        )}
-      </div>
-
-      {/* Action Button */}
-      <button
-        onClick={() => mode === "send-eth" ? handleSendEth() : handleMintNft()}
-        disabled={loading || (mode === "send-eth" && !recipient) || (mode === "mint-nft" && !nftContractAddress)}
-        style={{
-          background: 'linear-gradient(white, white) padding-box, linear-gradient(to right, #22d3ee, #2563eb) border-box',
-        }}
-        className={cn(
-          "w-full py-3 px-4 rounded-lg font-semibold text-sm transition-all duration-200 cursor-pointer",
-          "border-2 border-transparent text-blue-500",
-          "disabled:opacity-50 disabled:cursor-not-allowed",
-          "flex items-center justify-center gap-2"
-        )}
-      >
-        {loading ? (
-          <>
-            <Loader2 className="h-4 w-4 animate-spin" />
-            {mode === "send-eth" ? "Sending..." : "Minting..."}
-          </>
-        ) : (
-          <>
-            {mode === "send-eth" ? (
+            {mintInProgress ? (
               <>
-                <Send className="h-4 w-4" />
-                Send ETH
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {confirmingMint ? "Confirming mint..." : "Minting NFT..."}
               </>
             ) : (
               <>
                 <Sparkles className="h-4 w-4" />
-                Mint NFT
+                Mint for free
               </>
             )}
-          </>
-        )}
-      </button>
+	          </button>
+	        </div>
+	      </div>
 
-      {/* Error */}
-      {(error || mintError || sendError) && (
+	      {(error || mintError) && (
         <div className="flex items-start gap-2 px-4 py-3 bg-red-50 border border-red-100 rounded-lg overflow-hidden">
           <AlertCircle className="h-4 w-4 text-red-600 mt-0.5 shrink-0" />
           <div className="min-w-0">
             <p className="text-sm font-medium text-red-900">Transaction Failed</p>
-            <p className="text-sm text-red-700 mt-0.5 break-words line-clamp-3">{error || (mintError as unknown as { shortMessage?: string })?.shortMessage || (sendError as unknown as { shortMessage?: string })?.shortMessage || mintError?.message || sendError?.message}</p>
-          </div>
-        </div>
-      )}
-
-      {/* Success Result - Send ETH */}
-      {mode === "send-eth" && sendTxHash && (
-        <div className="space-y-2">
-          <div className="flex items-center gap-2 px-4 py-3 bg-green-50 border border-green-100 rounded-lg">
-            <Check className="h-4 w-4 text-green-600" />
-            <span className="text-sm text-green-700 font-medium">ETH sent successfully</span>
-          </div>
-          <a
-            href={`${chain?.blockExplorers?.default?.url}/tx/${sendTxHash}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={cn(
-              "flex items-center justify-between px-4 py-3 bg-gray-50 border border-gray-200 rounded-lg",
-              "hover:bg-gray-100 transition-colors group"
-            )}
-          >
-            <span className="text-sm text-gray-700 font-medium">View on Explorer</span>
-            <ExternalLink className="h-4 w-4 text-gray-400 group-hover:text-gray-600" />
-          </a>
-        </div>
-      )}
-
-      {/* Success Result - Mint NFT */}
-      {mode === "mint-nft" && mintTxHash && (
-        <div className="space-y-2">
-          <div className="flex items-center gap-2 px-4 py-3 bg-green-50 border border-green-100 rounded-lg">
-            <Check className="h-4 w-4 text-green-600" />
-            <span className="text-sm text-green-700 font-medium">NFT minted successfully!</span>
-          </div>
-          <a
-            href={`${chain?.blockExplorers?.default?.url}/tx/${mintTxHash}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={cn(
-              "flex items-center justify-between px-4 py-3 bg-gray-50 border border-gray-200 rounded-lg",
-              "hover:bg-gray-100 transition-colors group"
-            )}
-          >
-            <span className="text-sm text-gray-700 font-medium">View on Explorer</span>
-            <ExternalLink className="h-4 w-4 text-gray-400 group-hover:text-gray-600" />
-          </a>
-          <div className="px-4 py-3 bg-blue-50 border border-blue-100 rounded-lg">
-            <p className="text-sm text-blue-700">
-              NFT minted to your wallet!
+            <p className="text-sm text-red-700 mt-0.5 break-words line-clamp-3">
+              {error || (mintError as unknown as { shortMessage?: string })?.shortMessage || mintError?.message}
             </p>
-            <p className="text-xs text-blue-500 mt-1">Balance will update in a few seconds...</p>
           </div>
         </div>
       )}
+
+      {mintTxHash && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 px-4 py-3 bg-green-50 border border-green-100 rounded-lg">
+            <Check className="h-4 w-4 text-green-600" />
+            <span className="text-sm text-green-700 font-medium">
+              NFT minted into your wallet.
+            </span>
+          </div>
+          <a
+            href={`${explorerBaseUrl}/tx/${mintTxHash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn(
+              "flex items-center justify-between px-4 py-3 bg-gray-50 border border-gray-200 rounded-lg",
+              "hover:bg-gray-100 transition-colors group"
+            )}
+          >
+            <span className="text-sm text-gray-700 font-medium">
+              Confirm on Arbiscan
+            </span>
+            <ExternalLink className="h-4 w-4 text-gray-400 group-hover:text-gray-600" />
+          </a>
+        </div>
+      )}
+
+      {galleryNfts.length > 0 && (
+        <div id="minted-nfts" className="scroll-mt-6 overflow-hidden rounded-lg border border-gray-200 bg-white">
+          <button
+            type="button"
+            onClick={() => setNftsOpen((open) => !open)}
+            className="flex w-full items-center justify-between gap-4 px-4 py-3 text-left transition-colors hover:bg-gray-50 cursor-pointer"
+            aria-expanded={nftsOpen}
+          >
+            <span className="block text-sm font-semibold text-gray-950">
+              My NFTs
+            </span>
+            <ChevronDown
+              className={cn(
+                "h-4 w-4 shrink-0 text-gray-500 transition-transform",
+                nftsOpen && "rotate-180",
+              )}
+            />
+          </button>
+          {nftsOpen && (
+            <div className="flex snap-x gap-3 overflow-x-auto border-t border-gray-200 p-4">
+              {galleryNfts.map((nft) => (
+                <div
+                  key={`${nft.txHash ?? "owned"}-${nft.tokenId}`}
+                  className="w-[260px] shrink-0 snap-start overflow-hidden rounded-lg border border-gray-200 bg-gray-50"
+                >
+                  <img
+                    src={nft.imageUrl ?? `https://picsum.photos/seed/${nft.tokenId}/800/600`}
+                    alt={`Minted NFT #${nft.tokenId}`}
+                    className="aspect-[4/3] w-full object-cover"
+                  />
+                  <div className="space-y-2 bg-white px-3 py-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-xs font-medium text-gray-500">
+                        Token ID
+                      </span>
+                      <span className="truncate font-mono text-sm font-semibold text-gray-950">
+                        #{nft.tokenId}
+                      </span>
+                    </div>
+                    {nft.txHash && (
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="text-xs font-medium text-gray-500">
+                          Receipt
+                        </span>
+                        <span className="truncate font-mono text-xs font-medium text-gray-600">
+                          {formatShortHash(nft.txHash)}
+                        </span>
+                      </div>
+                    )}
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-xs font-medium text-gray-500">
+                        Minted
+                      </span>
+                      <span className="truncate text-xs font-medium text-gray-600">
+                        {formatTimestamp(nft.timestamp)}
+                      </span>
+                    </div>
+                    <a
+                      href={nft.imageUrl ?? `https://picsum.photos/seed/${nft.tokenId}/800/600`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center justify-between gap-2 text-xs font-medium text-gray-500 transition-colors hover:text-gray-900"
+                    >
+                      Image link
+                      <ExternalLink className="h-3 w-3" />
+                    </a>
+                    {nft.txHash && (
+                      <a
+                        href={`${explorerBaseUrl}/tx/${nft.txHash}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+	                        className="flex h-9 items-center justify-center gap-2 rounded-lg border border-gray-200 bg-gray-50 text-sm font-semibold text-gray-800 transition-colors hover:bg-gray-100"
+	                      >
+	                        View receipt
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </a>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm">
+        <button
+          type="button"
+          onClick={() => setCodeOpen((open) => !open)}
+          className="flex w-full items-center justify-between gap-4 bg-gray-950 px-4 py-3 text-left text-white transition-colors hover:bg-gray-900 cursor-pointer"
+          aria-expanded={codeOpen}
+        >
+          <span className="flex items-center gap-2 text-sm font-semibold">
+            <Code2 className="h-4 w-4 text-gray-300" />
+            Code
+          </span>
+          <ChevronDown
+            className={cn(
+              "h-4 w-4 text-gray-300 transition-transform",
+              codeOpen && "rotate-180",
+            )}
+          />
+        </button>
+        {codeOpen && (
+          <div className="border-t border-gray-200 bg-gray-50 p-4">
+            <div className="mb-3 flex flex-wrap gap-2">
+              <a
+                href="https://docs.zerodev.app/wallets"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 text-xs font-semibold text-gray-800 transition-colors hover:bg-gray-100"
+              >
+                Wallet docs
+                <ExternalLink className="h-3 w-3" />
+              </a>
+              <a
+                href="https://github.com/zerodevapp/zerodev-wallet-sdk/blob/main/apps/zerodev-signer-demo/src/app/components/SendTransactionTest.tsx"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 text-xs font-semibold text-gray-800 transition-colors hover:bg-gray-100"
+              >
+                View source
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </div>
+            <div className="grid gap-3 lg:grid-cols-2">
+              <CodeSnippet label="Signing the mint">
+                <span className="text-purple-300">import</span>{" "}
+                <span className="text-gray-100">{"{ useWriteContract }"}</span>{" "}
+                <span className="text-purple-300">from</span>{" "}
+                <span className="text-green-300">'wagmi'</span>
+                {"\n\n"}
+                <span className="text-purple-300">const</span>{" "}
+                <span className="text-gray-100">{"{ writeContract }"}</span>{" "}
+                <span className="text-purple-300">=</span>{" "}
+                <span className="text-blue-300">useWriteContract</span>
+                <span className="text-gray-100">()</span>
+                {"\n\n"}
+                <span className="text-blue-300">writeContract</span>
+                <span className="text-gray-100">({"{"}</span>
+                {"\n  "}
+                <span className="text-cyan-200">address</span>
+                <span className="text-gray-100">: nftContractAddress,</span>
+                {"\n  "}
+                <span className="text-cyan-200">abi</span>
+                <span className="text-gray-100">: NFT_CONTRACT_ABI,</span>
+                {"\n  "}
+                <span className="text-cyan-200">functionName</span>
+                <span className="text-gray-100">: </span>
+                <span className="text-green-300">'mint'</span>
+                <span className="text-gray-100">,</span>
+                {"\n  "}
+                <span className="text-cyan-200">args</span>
+                <span className="text-gray-100">: [activeAddress],</span>
+                {"\n"}
+                <span className="text-gray-100">{"})"}</span>
+              </CodeSnippet>
+              <CodeSnippet label="Wallet setup">
+                <span className="text-purple-300">export const</span>{" "}
+                <span className="text-gray-100">config </span>
+                <span className="text-purple-300">=</span>{" "}
+                <span className="text-blue-300">createConfig</span>
+                <span className="text-gray-100">({"{"}</span>
+                {"\n  "}
+                <span className="text-cyan-200">chains</span>
+                <span className="text-gray-100">: [arbitrumSepolia, sepolia],</span>
+                {"\n  "}
+                <span className="text-cyan-200">connectors</span>
+                <span className="text-gray-100">: [</span>
+                {"\n    "}
+                <span className="text-blue-300">zeroDevWallet</span>
+                <span className="text-gray-100">({"{"}</span>
+                {"\n      "}
+                <span className="text-cyan-200">projectId</span>
+                <span className="text-gray-100">,</span>
+                {"\n      "}
+                <span className="text-cyan-200">proxyBaseUrl</span>
+                <span className="text-gray-100">,</span>
+                {"\n      "}
+                <span className="text-cyan-200">chains</span>
+                <span className="text-gray-100">: [arbitrumSepolia, sepolia],</span>
+                {"\n    "}
+                <span className="text-gray-100">{"}),"}</span>
+                {"\n  "}
+                <span className="text-gray-100">],</span>
+                {"\n"}
+                <span className="text-gray-100">{"})"}</span>
+              </CodeSnippet>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CheckoutRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-md bg-gray-50 px-3 py-2">
+      <span className="text-gray-500">{label}</span>
+      <span className="font-medium text-gray-950">{value}</span>
+    </div>
+  );
+}
+
+function CodeSnippet({ children, label }: { children: ReactNode; label: string }) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-gray-200 bg-gray-950">
+      <div className="border-b border-white/10 px-3 py-2 text-xs font-semibold text-gray-300">
+        {label}
+      </div>
+      <pre className="overflow-x-auto p-3 text-xs leading-5 text-gray-100">
+        <code>{children}</code>
+      </pre>
     </div>
   );
 }

--- a/apps/zerodev-signer-demo/src/app/components/SigningTest.tsx
+++ b/apps/zerodev-signer-demo/src/app/components/SigningTest.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { useAccount, useSignMessage, useSignTypedData } from "wagmi";
 import { cn } from "../lib/utils";
 import { arbitrumSepolia } from "viem/chains";
+import { type Address, zeroAddress } from "viem";
 
 type SigningMode = "message" | "typedData";
 
@@ -40,26 +41,28 @@ const typedData = {
 
 const message = "Hello World";
 
-export function SigningTest() {
+export function SigningTest({
+  accountAddress,
+}: {
+  accountAddress: Address | null
+}) {
   const [mode, setMode] = useState<SigningMode>("message");
   const [payload, setPayload] = useState(message);
   const [error, setError] = useState<string>("");
 
   // Wagmi hooks
   const { address } = useAccount();
+  const activeAddress = accountAddress ?? address;
+  const hasUsableAddress =
+    Boolean(activeAddress) && activeAddress?.toLowerCase() !== zeroAddress;
   // const publicClient = usePublicClient()
   const { signMessage, data: messageSignature, isPending: isSigningMessage, isSuccess: isMessageSuccess, error: signError } = useSignMessage();
   const { signTypedData, data: typedDataSignature, isPending: isSigningTypedData, isSuccess: isTypedDataSuccess, error: typedDataError } = useSignTypedData();
-  console.log("messageSignature", messageSignature);
-  console.log("isMessageSuccess", isMessageSuccess);
-  console.log("typedDataSignature", typedDataSignature);
-  console.log("isTypedDataSuccess", isTypedDataSuccess);
-
   const loading = isSigningMessage || isSigningTypedData;
   // const result = messageSignature || typedDataSignature;
 
   const handleSign = async () => {
-    if (!address) {
+    if (!activeAddress || !hasUsableAddress) {
       setError("Please authenticate first");
       return;
     }
@@ -148,7 +151,7 @@ export function SigningTest() {
       {/* Sign Button */}
       <button
         onClick={handleSign}
-        disabled={loading || !payload.trim() || !address}
+        disabled={loading || !payload.trim() || !activeAddress || !hasUsableAddress}
         style={{
           background: 'linear-gradient(white, white) padding-box, linear-gradient(to right, #22d3ee, #2563eb) border-box',
         }}

--- a/apps/zerodev-signer-demo/src/app/components/SigningTest.tsx
+++ b/apps/zerodev-signer-demo/src/app/components/SigningTest.tsx
@@ -1,19 +1,65 @@
 "use client";
 
-import { AlertCircle, FileSignature, Loader2, Sparkles } from "lucide-react";
-import { useState } from "react";
-import { useAccount, useSignMessage, useSignTypedData } from "wagmi";
-import { cn } from "../lib/utils";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
+import {
+  AlertCircle,
+  Check,
+  ExternalLink,
+  FileSignature,
+  Loader2,
+  Send,
+  Sparkles,
+  Wallet,
+} from "lucide-react";
+import {
+  useAccount,
+  useConfig,
+  usePublicClient,
+  useSignMessage,
+  useSignTypedData,
+} from "wagmi";
+import {
+  type Address,
+  encodeFunctionData,
+  formatEther,
+  formatUnits,
+  getAddress,
+  isAddress,
+  parseAbi,
+  parseEther,
+  parseUnits,
+  zeroAddress,
+} from "viem";
+import { getZeroDevConnector, getZeroDevStore } from "@zerodev/wallet-react";
 import { arbitrumSepolia } from "viem/chains";
-import { type Address, zeroAddress } from "viem";
+import { cn } from "../lib/utils";
+import { FaucetLink } from "./FaucetLink";
 
-type SigningMode = "message" | "typedData";
+const USDC_BY_CHAIN: Record<number, Address> = {
+  421614: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
+  11155111: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+};
+const EXPLORER_BY_CHAIN: Record<number, string> = {
+  421614: "https://sepolia.arbiscan.io",
+  11155111: "https://sepolia.etherscan.io",
+};
+const USDC_FAUCET_URL = "https://faucet.circle.com/";
+const ETH_FAUCET_BY_CHAIN: Record<number, string> = {
+  421614: "https://www.alchemy.com/faucets/arbitrum-sepolia",
+  11155111: "https://www.alchemy.com/faucets/ethereum-sepolia",
+};
+const DEFAULT_SEND_TO: Address = "0x1111111111111111111111111111111111111111";
 
-// type VerificationResult = {
-//   isValid: boolean;
-// };
+type SendAsset = "usdc" | "eth";
+const DEFAULT_AMOUNT: Record<SendAsset, string> = { usdc: "0.01", eth: "0.001" };
 
-const typedData = {
+const erc20Abi = parseAbi([
+  "function transfer(address to, uint256 amount) returns (bool)",
+  "function balanceOf(address account) view returns (uint256)",
+]);
+
+// Sample EIP-712 typed data (the classic "Ether Mail" example).
+const sampleTypedData = {
   domain: {
     name: "Ether Mail",
     version: "1",
@@ -38,163 +84,485 @@ const typedData = {
     contents: "Hello, Bob!",
   },
 };
+const sampleTypedDataJson = JSON.stringify(sampleTypedData, null, 2);
 
-const message = "Hello World";
+function formatShort(value: string) {
+  return `${value.slice(0, 8)}...${value.slice(-6)}`;
+}
+
+function getErrorMessage(error: unknown) {
+  if (!error) return "Something went wrong.";
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object") {
+    for (const key of ["shortMessage", "details", "message"]) {
+      const value = (error as Record<string, unknown>)[key];
+      if (typeof value === "string" && value.trim()) return value;
+    }
+  }
+  return error instanceof Error ? error.message : "Something went wrong.";
+}
 
 export function SigningTest({
   accountAddress,
+  sendFocusRequest = 0,
+  sendFocusAsset,
 }: {
   accountAddress: Address | null
+  sendFocusRequest?: number
+  sendFocusAsset?: SendAsset
 }) {
-  const [mode, setMode] = useState<SigningMode>("message");
-  const [payload, setPayload] = useState(message);
-  const [error, setError] = useState<string>("");
+  const { address, chain } = useAccount();
+  const wagmiConfig = useConfig();
+  const publicClient = usePublicClient({ chainId: chain?.id });
 
-  // Wagmi hooks
-  const { address } = useAccount();
   const activeAddress = accountAddress ?? address;
   const hasUsableAddress =
     Boolean(activeAddress) && activeAddress?.toLowerCase() !== zeroAddress;
-  // const publicClient = usePublicClient()
-  const { signMessage, data: messageSignature, isPending: isSigningMessage, isSuccess: isMessageSuccess, error: signError } = useSignMessage();
-  const { signTypedData, data: typedDataSignature, isPending: isSigningTypedData, isSuccess: isTypedDataSuccess, error: typedDataError } = useSignTypedData();
-  const loading = isSigningMessage || isSigningTypedData;
-  // const result = messageSignature || typedDataSignature;
 
-  const handleSign = async () => {
-    if (!activeAddress || !hasUsableAddress) {
-      setError("Please authenticate first");
+  const usdcAddress = chain?.id ? USDC_BY_CHAIN[chain.id] : undefined;
+  const explorerBaseUrl =
+    (chain?.id ? EXPLORER_BY_CHAIN[chain.id] : undefined) ?? "https://sepolia.arbiscan.io";
+
+  // Step 1 — personal sign
+  const [message, setMessage] = useState("Hello World");
+  const {
+    signMessage,
+    data: messageSignature,
+    isPending: signingMessage,
+    error: messageError,
+    reset: resetMessage,
+  } = useSignMessage();
+
+  // Step 2 — typed data
+  const [typedDataJson, setTypedDataJson] = useState(sampleTypedDataJson);
+  const {
+    signTypedData,
+    data: typedDataSignature,
+    isPending: signingTypedData,
+    error: typedDataError,
+    reset: resetTypedData,
+  } = useSignTypedData();
+  const [typedDataParseError, setTypedDataParseError] = useState("");
+
+  // Step 3 — send assets
+  const [asset, setAsset] = useState<SendAsset>("usdc");
+  const [sendTo, setSendTo] = useState<string>(DEFAULT_SEND_TO);
+  const [sendAmount, setSendAmount] = useState(DEFAULT_AMOUNT.usdc);
+  const [sending, setSending] = useState(false);
+  const [sendHash, setSendHash] = useState<`0x${string}` | undefined>(undefined);
+  const [sentInfo, setSentInfo] = useState<{ amount: string; symbol: string; to: string } | null>(
+    null,
+  );
+  const [sendError, setSendError] = useState("");
+  const [usdcBalance, setUsdcBalance] = useState("0");
+  const [ethBalance, setEthBalance] = useState("0");
+
+  const loadBalance = useCallback(async () => {
+    if (!activeAddress || !publicClient) return;
+    try {
+      const native = await publicClient.getBalance({ address: activeAddress });
+      setEthBalance(formatEther(native));
+    } catch {
+      /* keep last known */
+    }
+    if (!usdcAddress) {
+      setUsdcBalance("0");
+      return;
+    }
+    try {
+      const balance = await publicClient.readContract({
+        address: usdcAddress,
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [activeAddress],
+      });
+      setUsdcBalance(formatUnits(balance, 6));
+    } catch {
+      /* keep last known */
+    }
+  }, [activeAddress, publicClient, usdcAddress]);
+
+  useEffect(() => {
+    loadBalance();
+  }, [loadBalance]);
+
+  const switchAsset = (next: SendAsset) => {
+    setAsset(next);
+    setSendAmount(DEFAULT_AMOUNT[next]);
+    setSendHash(undefined);
+    setSendError("");
+  };
+
+  // When the user taps an asset in the top navbar, jump to the send step with
+  // that asset preselected.
+  useEffect(() => {
+    if (!sendFocusRequest) return;
+    if (sendFocusAsset) {
+      setAsset(sendFocusAsset);
+      setSendAmount(DEFAULT_AMOUNT[sendFocusAsset]);
+    }
+    requestAnimationFrame(() => {
+      document
+        .getElementById("sign-send")
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+  }, [sendFocusRequest, sendFocusAsset]);
+
+  const handleSignMessage = () => {
+    resetMessage();
+    if (!hasUsableAddress) return;
+    signMessage({ message });
+  };
+
+  const handleSignTypedData = () => {
+    resetTypedData();
+    setTypedDataParseError("");
+    if (!hasUsableAddress) return;
+    try {
+      const parsed = JSON.parse(typedDataJson);
+      signTypedData(parsed);
+    } catch {
+      setTypedDataParseError("That isn't valid JSON. Fix it or load the sample.");
+    }
+  };
+
+  const handleSend = async () => {
+    setSendError("");
+    setSendHash(undefined);
+    setSentInfo(null);
+    if (!hasUsableAddress || !activeAddress) {
+      setSendError("Please authenticate first.");
+      return;
+    }
+    if (!chain?.id) {
+      setSendError("Wallet network isn't ready.");
+      return;
+    }
+    if (asset === "usdc" && !usdcAddress) {
+      setSendError("Sending USDC isn't available on this network.");
+      return;
+    }
+    const to = sendTo.trim();
+    if (!isAddress(to)) {
+      setSendError("Enter a valid recipient address.");
+      return;
+    }
+    let amountRaw: bigint;
+    try {
+      amountRaw = asset === "usdc" ? parseUnits(sendAmount || "0", 6) : parseEther(sendAmount || "0");
+    } catch {
+      amountRaw = BigInt(0);
+    }
+    if (amountRaw <= BigInt(0)) {
+      setSendError("Enter an amount greater than 0.");
       return;
     }
 
-    setError("");
-
+    setSending(true);
     try {
-      if (mode === "message") {
-        signMessage({ message: payload });
-      } else {
-        const parsedTypedData = JSON.parse(payload);
-        signTypedData(parsedTypedData);
+      const store = await getZeroDevStore(getZeroDevConnector(wagmiConfig));
+      const kernelClient = store.getState().kernelClients.get(chain.id);
+      if (!kernelClient) {
+        throw new Error("Smart account client isn't ready. Reconnect and try again.");
       }
+      const call =
+        asset === "usdc"
+          ? {
+              to: usdcAddress!,
+              value: BigInt(0),
+              data: encodeFunctionData({
+                abi: erc20Abi,
+                functionName: "transfer",
+                args: [getAddress(to), amountRaw],
+              }),
+            }
+          : { to: getAddress(to), value: amountRaw, data: "0x" as const };
+      const hash = await kernelClient.sendTransaction({ calls: [call] });
+      setSentInfo({
+        amount: sendAmount,
+        symbol: asset === "usdc" ? "USDC" : "ETH",
+        to: getAddress(to),
+      });
+      setSendHash(hash);
+      await loadBalance();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Signing failed");
+      setSendError(getErrorMessage(err));
+    } finally {
+      setSending(false);
     }
   };
 
-
-  const loadSample = () => {
-    if (mode === "message") {
-      setPayload(message);
-    } else {
-      setPayload(JSON.stringify(typedData, null, 2));
-    }
-  };
+  const assetSymbol = asset === "usdc" ? "USDC" : "ETH";
+  const balanceNumber = Number(asset === "usdc" ? usdcBalance : ethBalance) || 0;
+  const ethFaucetUrl = (chain?.id ? ETH_FAUCET_BY_CHAIN[chain.id] : undefined) ??
+    ETH_FAUCET_BY_CHAIN[421614];
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-5">
       <div>
-        <h2 className="text-lg font-semibold text-gray-900">Sign Message</h2>
-        <p className="text-sm text-gray-500 mt-1">
-          Sign messages and typed data with your wallet
+        <h2 className="text-lg font-semibold text-gray-950">Sign anything</h2>
+        <p className="mt-1 text-sm leading-6 text-gray-600">
+          Your smart wallet signs like any wallet — a plain message, structured typed data, and
+          a real asset transfer. Walk through each below.
         </p>
       </div>
 
-      {/* Mode Selector */}
-      <div className="flex gap-2 p-1 bg-gray-100 rounded-lg">
+      {/* Step 1 — personal sign */}
+      <StepCard step={1} title="Sign a plain message">
+        <p className="text-sm text-gray-600">
+          A <span className="font-mono">personal_sign</span> over any text — edit it to whatever
+          you like.
+        </p>
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          rows={2}
+          spellCheck={false}
+          placeholder="Type a message to sign..."
+          className="w-full rounded-lg border border-gray-200 px-3 py-2 font-mono text-sm text-gray-950 outline-none focus:border-gray-400"
+        />
         <button
-          onClick={() => { setMode("message"); setPayload("Hello World"); }}
-          className={cn(
-            "flex-1 py-2 px-4 rounded-md text-sm font-medium transition-all cursor-pointer",
-            mode === "message" ? "bg-white text-gray-900 shadow-sm" : "text-gray-600 hover:text-gray-900"
-          )}
+          type="button"
+          onClick={handleSignMessage}
+          disabled={signingMessage || !message.trim() || !hasUsableAddress}
+          className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
         >
-          Message
-        </button>
-        <button
-          onClick={() => { setMode("typedData"); setPayload(JSON.stringify(typedData, null, 2)); }}
-          className={cn(
-            "flex-1 py-2 px-4 rounded-md text-sm font-medium transition-all cursor-pointer",
-            mode === "typedData" ? "bg-white text-gray-900 shadow-sm" : "text-gray-600 hover:text-gray-900"
+          {signingMessage ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Signing...
+            </>
+          ) : (
+            <>
+              <FileSignature className="h-4 w-4" />
+              Sign message
+            </>
           )}
-        >
-          Typed Data (EIP-712)
         </button>
-      </div>
+        {messageError && <ErrorNote message={getErrorMessage(messageError)} />}
+        {messageSignature && (
+          <SignatureResult label="Signature" value={messageSignature} />
+        )}
+      </StepCard>
 
-      {/* Payload Input */}
-      <div>
-        <div className="flex items-center justify-between mb-2">
-          <label className="text-sm font-medium text-gray-700">
-            {mode === "message" ? "Message" : "Typed Data JSON"}
-          </label>
+      {/* Step 2 — typed data */}
+      <StepCard step={2} title="Sign structured data (EIP-712)">
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-gray-600">
+            Human-readable typed data — what dapps use for orders, permits, and logins.
+          </p>
           <button
-            onClick={loadSample}
-            className="text-sm text-blue-500 hover:text-blue-700 font-medium flex items-center gap-1 cursor-pointer"
+            type="button"
+            onClick={() => {
+              setTypedDataJson(sampleTypedDataJson);
+              setTypedDataParseError("");
+            }}
+            className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-gray-500 transition-colors hover:text-gray-900"
           >
             <Sparkles className="h-3.5 w-3.5" />
-            Load Sample
+            Reset sample
           </button>
         </div>
         <textarea
-          value={payload}
-          onChange={(e) => setPayload(e.target.value)}
-          rows={mode === "message" ? 3 : 10}
-          placeholder={mode === "message" ? "Enter message to sign..." : "Enter EIP-712 typed data JSON..."}
-          className={cn(
-            "w-full px-4 py-3 rounded-lg border border-gray-200 font-mono text-sm",
-            "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
-            "text-gray-900 placeholder:text-gray-400"
-          )}
+          value={typedDataJson}
+          onChange={(e) => setTypedDataJson(e.target.value)}
+          rows={10}
+          spellCheck={false}
+          className="w-full rounded-lg border border-gray-200 px-3 py-2 font-mono text-xs text-gray-950 outline-none focus:border-gray-400"
         />
-      </div>
-
-      {/* Sign Button */}
-      <button
-        onClick={handleSign}
-        disabled={loading || !payload.trim() || !activeAddress || !hasUsableAddress}
-        style={{
-          background: 'linear-gradient(white, white) padding-box, linear-gradient(to right, #22d3ee, #2563eb) border-box',
-        }}
-        className={cn(
-          "w-full py-3 px-4 rounded-lg font-semibold text-sm transition-all duration-200 cursor-pointer",
-          "border-2 border-transparent text-blue-500",
-          "disabled:opacity-50 disabled:cursor-not-allowed",
-          "flex items-center justify-center gap-2"
+        <button
+          type="button"
+          onClick={handleSignTypedData}
+          disabled={signingTypedData || !typedDataJson.trim() || !hasUsableAddress}
+          className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {signingTypedData ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Signing...
+            </>
+          ) : (
+            <>
+              <FileSignature className="h-4 w-4" />
+              Sign typed data
+            </>
+          )}
+        </button>
+        {(typedDataParseError || typedDataError) && (
+          <ErrorNote message={typedDataParseError || getErrorMessage(typedDataError)} />
         )}
-      >
-        {loading ? (
-          <>
-            <Loader2 className="h-4 w-4 animate-spin" />
-            Signing...
-          </>
+        {typedDataSignature && (
+          <SignatureResult label="Signature" value={typedDataSignature} />
+        )}
+      </StepCard>
+
+      {/* Step 3 — send assets */}
+      <StepCard step={3} title="Sign to send assets" id="sign-send">
+        <p className="text-sm text-gray-600">
+          Same signature, real money: move USDC or native ETH to any address — gas sponsored.
+        </p>
+
+        {/* Asset toggle */}
+        <div className="flex gap-1 rounded-lg bg-gray-100 p-1">
+          {(["usdc", "eth"] as const).map((a) => (
+            <button
+              key={a}
+              type="button"
+              onClick={() => switchAsset(a)}
+              className={cn(
+                "flex-1 rounded-md px-4 py-2 text-sm font-semibold transition-colors",
+                asset === a
+                  ? "bg-white text-gray-950 shadow-sm"
+                  : "text-gray-600 hover:text-gray-900",
+              )}
+            >
+              {a === "usdc" ? "USDC" : "Native ETH"}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
+          <span className="flex items-center gap-2 text-sm font-medium text-gray-600">
+            <Wallet className="h-4 w-4 text-gray-500" />
+            Your {assetSymbol}
+          </span>
+          <span className="flex items-center gap-3">
+            <span className="font-mono text-sm font-semibold text-gray-950">
+              {asset === "usdc" ? balanceNumber.toFixed(2) : balanceNumber.toFixed(5)} {assetSymbol}
+            </span>
+            <FaucetLink
+              href={asset === "usdc" ? USDC_FAUCET_URL : ethFaucetUrl}
+              address={activeAddress}
+              className="inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer"
+            >
+              Faucet
+              <ExternalLink className="h-3 w-3" />
+            </FaucetLink>
+          </span>
+        </div>
+
+        {asset === "usdc" && !usdcAddress ? (
+          <div className="flex items-start gap-2 rounded-lg border border-yellow-100 bg-yellow-50 px-3 py-2">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-600" />
+            <p className="text-sm text-yellow-700">
+              USDC isn&apos;t available on {chain?.name ?? "this network"}. Switch to Arbitrum
+              Sepolia or Ethereum Sepolia, or send native ETH instead.
+            </p>
+          </div>
         ) : (
-          <>
-            <FileSignature className="h-4 w-4" />
-            Sign {mode === "message" ? "Message" : "Typed Data"}
-          </>
+          <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_140px]">
+            <label className="block">
+              <span className="text-xs font-medium text-gray-500">Recipient</span>
+              <input
+                value={sendTo}
+                onChange={(e) => setSendTo(e.target.value)}
+                spellCheck={false}
+                placeholder="0x..."
+                className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 font-mono text-xs text-gray-950 outline-none focus:border-gray-400"
+              />
+            </label>
+            <label className="block">
+              <span className="text-xs font-medium text-gray-500">{assetSymbol} amount</span>
+              <input
+                type="number"
+                min="0"
+                step={asset === "usdc" ? "0.01" : "0.0001"}
+                value={sendAmount}
+                onChange={(e) => setSendAmount(e.target.value)}
+                className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 font-mono text-sm text-gray-950 outline-none focus:border-gray-400"
+              />
+            </label>
+          </div>
         )}
-      </button>
 
-      {/* Error */}
-      {(error || signError || typedDataError) && (
-        <div className="flex items-start gap-2 px-4 py-3 bg-red-50 border border-red-100 rounded-lg">
-          <AlertCircle className="h-4 w-4 text-red-600 mt-0.5" />
-          <div>
-            <p className="text-sm font-medium text-red-900">Signing Failed</p>
-            <p className="text-sm text-red-700 mt-0.5">{error || signError?.message || typedDataError?.message}</p>
-          </div>
-        </div>
-      )}
+        <button
+          type="button"
+          onClick={handleSend}
+          disabled={sending || (asset === "usdc" && !usdcAddress) || !hasUsableAddress}
+          className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {sending ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Sending...
+            </>
+          ) : (
+            <>
+              <Send className="h-4 w-4" />
+              Send {sendAmount || "0"} {assetSymbol}
+            </>
+          )}
+        </button>
+        {sendError && <ErrorNote message={sendError} />}
+        {sendHash && (
+          <a
+            href={`${explorerBaseUrl}/tx/${sendHash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-between gap-3 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-900 transition-colors hover:bg-emerald-100"
+          >
+            <span className="flex min-w-0 items-center gap-2 font-medium">
+              <Check className="h-4 w-4 shrink-0 text-emerald-600" />
+              {sentInfo ? (
+                <span className="truncate">
+                  Sent {sentInfo.amount} {sentInfo.symbol} to {formatShort(sentInfo.to)}
+                </span>
+              ) : (
+                <span>Sent</span>
+              )}
+            </span>
+            <span className="inline-flex shrink-0 items-center gap-1 font-mono text-xs">
+              {formatShort(sendHash)}
+              <ExternalLink className="h-3 w-3" />
+            </span>
+          </a>
+        )}
+      </StepCard>
+    </div>
+  );
+}
 
-      {/* Success Result */}
-      {(isMessageSuccess || isTypedDataSuccess) && (messageSignature || typedDataSignature) && (
-        <div className="space-y-3">
-          <div className="p-4 bg-gray-50 border border-gray-200 rounded-lg">
-            <p className="text-xs font-medium text-gray-500 mb-2">Signature</p>
-            <p className="text-xs text-gray-700 font-mono break-all">{mode === "message" ? messageSignature : typedDataSignature}</p>
-          </div>
-        </div>
-      )}
+function StepCard({
+  step,
+  title,
+  children,
+  id,
+}: {
+  step: number
+  title: string
+  children: ReactNode
+  id?: string
+}) {
+  return (
+    <div id={id} className="scroll-mt-24 rounded-lg border border-gray-200 bg-white p-4">
+      <div className="flex items-center gap-2">
+        <span className="flex h-6 w-6 items-center justify-center rounded-full bg-gray-950 text-xs font-semibold text-white">
+          {step}
+        </span>
+        <h3 className="text-sm font-semibold text-gray-950">{title}</h3>
+      </div>
+      <div className="mt-4 space-y-3">{children}</div>
+    </div>
+  );
+}
+
+function ErrorNote({ message }: { message: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-lg border border-red-100 bg-red-50 px-3 py-2">
+      <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-600" />
+      <p className="break-words text-sm text-red-700">{message}</p>
+    </div>
+  );
+}
+
+function SignatureResult({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-emerald-200 bg-emerald-50/60 p-3">
+      <p className="flex items-center gap-1.5 text-xs font-semibold text-emerald-900">
+        <Check className="h-3.5 w-3.5 text-emerald-600" />
+        {label}
+      </p>
+      <p className="mt-1 break-all font-mono text-xs text-gray-700">{value}</p>
     </div>
   );
 }

--- a/apps/zerodev-signer-demo/src/app/components/TreasuryPermissionsTest.tsx
+++ b/apps/zerodev-signer-demo/src/app/components/TreasuryPermissionsTest.tsx
@@ -1,0 +1,1405 @@
+"use client";
+
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  AlertCircle,
+  ArrowRight,
+  Ban,
+  Check,
+  ChevronDown,
+  Code2,
+  ExternalLink,
+  Info,
+  KeyRound,
+  Loader2,
+  Minus,
+  Play,
+  Plus,
+  RefreshCw,
+  RotateCcw,
+  ShieldCheck,
+  Square,
+  UserRound,
+  Users,
+  Wallet,
+  Zap,
+} from "lucide-react";
+import {
+  type Address,
+  type Hash,
+  encodeFunctionData,
+  formatUnits,
+  getAddress,
+  http,
+  isAddress,
+  parseAbi,
+  parseUnits,
+} from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { arbitrumSepolia } from "wagmi/chains";
+import { useAccount, useConfig, usePublicClient } from "wagmi";
+import { getZeroDevConnector, getZeroDevStore } from "@zerodev/wallet-react";
+import {
+  createKernelAccount,
+  createKernelAccountClient,
+  createZeroDevPaymasterClient,
+} from "@zerodev/sdk";
+import { getEntryPoint, KERNEL_V3_3 } from "@zerodev/sdk/constants";
+import {
+  deserializePermissionAccount,
+  serializePermissionAccount,
+  toPermissionValidator,
+} from "@zerodev/permissions";
+import { toECDSASigner } from "@zerodev/permissions/signers";
+import {
+  CallPolicyVersion,
+  ParamCondition,
+  toCallPolicy,
+  toRateLimitPolicy,
+} from "@zerodev/permissions/policies";
+import { cn } from "../lib/utils";
+import { FaucetLink } from "./FaucetLink";
+
+// Scoped to Arbitrum Sepolia, where the demo's USDC + paymaster live.
+const ARBITRUM_SEPOLIA_CHAIN_ID = 421614;
+const USDC_ADDRESS: Address = "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d";
+const USDC_FAUCET_URL = "https://faucet.circle.com/";
+const EXPLORER_BASE_URL = "https://sepolia.arbiscan.io";
+
+const entryPoint = getEntryPoint("0.7");
+const kernelVersion = KERNEL_V3_3;
+
+const erc20Abi = parseAbi([
+  "function transfer(address to, uint256 amount) returns (bool)",
+  "function balanceOf(address account) view returns (uint256)",
+]);
+
+// Example payout wallets — editable; the user picks how many to allow-list.
+const EXAMPLE_RECIPIENTS: Address[] = [
+  "0x1111111111111111111111111111111111111111",
+  "0x2222222222222222222222222222222222222222",
+  "0x3333333333333333333333333333333333333333",
+  "0x4444444444444444444444444444444444444444",
+  "0x5555555555555555555555555555555555555555",
+];
+const INITIAL_RECIPIENT_COUNT = 3;
+const MIN_RECIPIENTS = 1;
+const MAX_RECIPIENTS = EXAMPLE_RECIPIENTS.length; // 5
+
+// Reasonable bounds for the demo inputs.
+const AMOUNT_MIN = 0.01;
+const AMOUNT_MAX = 10;
+const COUNT_MIN = 1;
+const COUNT_MAX = 20;
+const INTERVAL_MIN = 1;
+const INTERVAL_MAX = 60;
+
+function clampNumber(raw: string, min: number, max: number, integer = false): string {
+  let n = Number(raw);
+  if (!Number.isFinite(n)) n = min;
+  n = Math.min(max, Math.max(min, n));
+  if (integer) n = Math.round(n);
+  // Trim float noise (e.g. 0.30000000000000004) without forcing decimals.
+  return integer ? String(n) : String(Number(n.toFixed(2)));
+}
+
+// Mirrors the connector's bundler/paymaster URL (getAAUrl isn't exported).
+function getAaUrl(chainId: number) {
+  const projectId = process.env.NEXT_PUBLIC_ZERODEV_PROJECT_ID;
+  return `https://staging-meta-aa-provider.onrender.com/api/v3/${projectId}/chain/${chainId}`;
+}
+
+function formatShort(value: string) {
+  return `${value.slice(0, 6)}...${value.slice(-4)}`;
+}
+
+function getErrorMessage(error: unknown) {
+  if (!error) return "Something went wrong.";
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object") {
+    for (const key of ["shortMessage", "details", "message"]) {
+      const value = (error as Record<string, unknown>)[key];
+      if (typeof value === "string" && value.trim()) return value;
+    }
+  }
+  return error instanceof Error ? error.message : "Something went wrong.";
+}
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+type GrantInfo = {
+  serialized: string
+  sessionPrivateKey: `0x${string}`
+  sessionAddress: Address
+  recipients: Address[]
+  capRaw: string // per-payout cap, bigint serialized
+  amountEach: string
+  count: number // total payouts allowed (rate limit)
+  intervalSec: number
+  used?: number // payouts already consumed on-chain (persisted across reloads)
+};
+
+type PayoutRow = {
+  id: number
+  recipient: Address
+  amount: string
+  status: "pending" | "sent" | "rejected"
+  hash?: `0x${string}`
+  error?: string
+};
+
+export function TreasuryPermissionsTest({
+  accountAddress,
+}: {
+  accountAddress: Address | null
+}) {
+  const { chain } = useAccount();
+  const wagmiConfig = useConfig();
+  const publicClient = usePublicClient({ chainId: chain?.id });
+
+  const isArbitrumSepolia = chain?.id === ARBITRUM_SEPOLIA_CHAIN_ID;
+  const owner = accountAddress;
+
+  // Config
+  const [amountEach, setAmountEach] = useState("0.05");
+  const [payoutCount, setPayoutCount] = useState("5");
+  const [intervalSec, setIntervalSec] = useState("3");
+  const [recipients, setRecipients] = useState<string[]>(() =>
+    EXAMPLE_RECIPIENTS.slice(0, INITIAL_RECIPIENT_COUNT),
+  );
+
+  const [usdcBalance, setUsdcBalance] = useState("0");
+
+  // Session key + grant + drip state
+  const [sessionKey, setSessionKey] = useState<{
+    privateKey: `0x${string}`
+    address: Address
+  } | null>(null);
+  const [grant, setGrant] = useState<GrantInfo | null>(null);
+  const [granting, setGranting] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [countdown, setCountdown] = useState(0);
+  const [feed, setFeed] = useState<PayoutRow[]>([]);
+  const [sentCount, setSentCount] = useState(0);
+  const [revoking, setRevoking] = useState(false);
+  const [revoked, setRevoked] = useState(false);
+  const [revokeHash, setRevokeHash] = useState<Hash | undefined>(undefined);
+  const [postRevokeAttempt, setPostRevokeAttempt] = useState<string | null>(null);
+  const [tryingAfterRevoke, setTryingAfterRevoke] = useState(false);
+  const [error, setError] = useState("");
+  const [codeOpen, setCodeOpen] = useState(false);
+
+  const runIdRef = useRef(0);
+  const sentCountRef = useRef(0);
+  useEffect(() => {
+    sentCountRef.current = sentCount;
+  }, [sentCount]);
+
+  // Stop any running drip on unmount.
+  useEffect(() => {
+    return () => {
+      runIdRef.current += 1;
+    };
+  }, []);
+
+  const storageKey =
+    owner && chain?.id ? `zd:treasury-session:${chain.id}:${owner.toLowerCase()}` : null;
+
+  useEffect(() => {
+    if (!storageKey) return;
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      const parsed = raw ? (JSON.parse(raw) as Partial<GrantInfo>) : null;
+      // Only restore grants that match the current shape. Older versions wrote
+      // grants without count/intervalSec, which would make the drip a no-op.
+      if (
+        parsed &&
+        typeof parsed.serialized === "string" &&
+        typeof parsed.sessionPrivateKey === "string" &&
+        typeof parsed.count === "number" &&
+        typeof parsed.intervalSec === "number" &&
+        Array.isArray(parsed.recipients)
+      ) {
+        setGrant(parsed as GrantInfo);
+        setSessionKey({
+          privateKey: parsed.sessionPrivateKey,
+          address: parsed.sessionAddress as Address,
+        });
+        setSentCount(Math.min(parsed.used ?? 0, parsed.count));
+      } else {
+        if (raw) window.localStorage.removeItem(storageKey);
+        setGrant(null);
+        setSessionKey(null);
+        setSentCount(0);
+      }
+    } catch {
+      setGrant(null);
+      setSessionKey(null);
+      setSentCount(0);
+    }
+  }, [storageKey]);
+
+  // Persist the grant + how many payouts have been consumed, so an exhausted
+  // key is recognized after a reload instead of failing the first payout.
+  // Skipped once revoked so the header badge clears and stays cleared.
+  useEffect(() => {
+    if (!storageKey || !grant || revoked) return;
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({ ...grant, used: sentCount }),
+    );
+  }, [grant, sentCount, storageKey, revoked]);
+
+  const loadBalance = useCallback(async () => {
+    if (!owner || !publicClient || !isArbitrumSepolia) return;
+    try {
+      const balance = await publicClient.readContract({
+        address: USDC_ADDRESS,
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [owner],
+      });
+      setUsdcBalance(formatUnits(balance, 6));
+    } catch {
+      /* keep last known */
+    }
+  }, [owner, publicClient, isArbitrumSepolia]);
+
+  useEffect(() => {
+    loadBalance();
+    const id = window.setInterval(loadBalance, 7000);
+    return () => window.clearInterval(id);
+  }, [loadBalance]);
+
+  const normalizedRecipients = (): Address[] =>
+    recipients.map((value) => {
+      const trimmed = value.trim();
+      if (!isAddress(trimmed)) {
+        throw new Error(`"${trimmed || "(empty)"}" is not a valid address.`);
+      }
+      return getAddress(trimmed);
+    });
+
+  const updateRecipient = (index: number, value: string) => {
+    setRecipients((current) => current.map((r, i) => (i === index ? value : r)));
+  };
+
+  const addRecipient = () => {
+    setRecipients((current) =>
+      current.length >= MAX_RECIPIENTS
+        ? current
+        : [...current, EXAMPLE_RECIPIENTS[current.length] ?? ""],
+    );
+  };
+
+  const removeRecipient = () => {
+    setRecipients((current) =>
+      current.length <= MIN_RECIPIENTS ? current : current.slice(0, -1),
+    );
+  };
+
+  // Scoped permission: only USDC.transfer, only to the allow-list, only up to the
+  // per-payout cap, and only a fixed number of payouts total (rate limit).
+  const buildPermissionPlugin = async (
+    sessionPrivateKey: `0x${string}`,
+    allowlist: Address[],
+    capRaw: bigint,
+    count: number,
+  ) => {
+    if (!publicClient) throw new Error("RPC client is not ready.");
+    const sessionKeySigner = await toECDSASigner({
+      signer: privateKeyToAccount(sessionPrivateKey),
+    });
+    const callPolicy = toCallPolicy({
+      policyVersion: CallPolicyVersion.V0_0_4,
+      permissions: [
+        {
+          target: USDC_ADDRESS,
+          valueLimit: BigInt(0),
+          abi: erc20Abi,
+          functionName: "transfer",
+          args: [
+            { condition: ParamCondition.ONE_OF, value: allowlist },
+            { condition: ParamCondition.LESS_THAN_OR_EQUAL, value: capRaw },
+          ],
+        },
+      ],
+    });
+    // interval 0 => a total cap of `count` payouts (no reset window).
+    const rateLimitPolicy = toRateLimitPolicy({ count, interval: 0 });
+    return toPermissionValidator(publicClient, {
+      entryPoint,
+      kernelVersion,
+      signer: sessionKeySigner,
+      policies: [callPolicy, rateLimitPolicy],
+    });
+  };
+
+  const buildSessionKeyAccount = async (
+    sessionPrivateKey: `0x${string}`,
+    allowlist: Address[],
+    capRaw: bigint,
+    count: number,
+  ) => {
+    if (!publicClient) throw new Error("RPC client is not ready.");
+    const store = await getZeroDevStore(getZeroDevConnector(wagmiConfig));
+    const ownerSigner = store.getState().eoaAccount;
+    if (!ownerSigner) {
+      throw new Error("Owner signer is not ready. Reconnect the wallet and try again.");
+    }
+    const permissionPlugin = await buildPermissionPlugin(
+      sessionPrivateKey,
+      allowlist,
+      capRaw,
+      count,
+    );
+    return createKernelAccount(publicClient, {
+      entryPoint,
+      kernelVersion,
+      eip7702Account: ownerSigner,
+      address: ownerSigner.address,
+      plugins: { regular: permissionPlugin },
+    });
+  };
+
+  const buildSessionClient = async (serialized: string) => {
+    if (!publicClient) throw new Error("RPC client is not ready.");
+    const account = await deserializePermissionAccount(
+      publicClient,
+      entryPoint,
+      kernelVersion,
+      serialized,
+    );
+    const aaUrl = getAaUrl(ARBITRUM_SEPOLIA_CHAIN_ID);
+    const client = createKernelAccountClient({
+      account,
+      chain: arbitrumSepolia,
+      bundlerTransport: http(aaUrl),
+      paymaster: createZeroDevPaymasterClient({
+        chain: arbitrumSepolia,
+        transport: http(aaUrl),
+      }),
+    });
+    return { account, client };
+  };
+
+  const resetAll = () => {
+    runIdRef.current += 1;
+    setSessionKey(null);
+    setGrant(null);
+    setRunning(false);
+    setCountdown(0);
+    setFeed([]);
+    setSentCount(0);
+    setRevoked(false);
+    setRevokeHash(undefined);
+    setPostRevokeAttempt(null);
+    setError("");
+    if (storageKey) window.localStorage.removeItem(storageKey);
+  };
+
+  // Step 1: generate the throwaway session key (no on-chain action yet).
+  const createSessionKeyPair = () => {
+    const privateKey = generatePrivateKey();
+    const address = privateKeyToAccount(privateKey).address;
+    const pair = { privateKey, address };
+    setSessionKey(pair);
+    return pair;
+  };
+
+  const handleCreateSessionKey = () => {
+    setError("");
+    // Starting a fresh key invalidates any prior grant/run (and stops the drip).
+    runIdRef.current += 1;
+    setRunning(false);
+    setCountdown(0);
+    setGrant(null);
+    setFeed([]);
+    setSentCount(0);
+    setRevoked(false);
+    setRevokeHash(undefined);
+    setPostRevokeAttempt(null);
+    if (storageKey) window.localStorage.removeItem(storageKey);
+    createSessionKeyPair();
+  };
+
+  // Step 2: grant the scoped, rate-limited allowance to a session key.
+  const grantWithKey = async (sessionPrivateKey: `0x${string}`, sessionAddress: Address) => {
+    if (!owner || !isArbitrumSepolia) return;
+    setError("");
+    setRevokeHash(undefined);
+    setRevoked(false);
+    setPostRevokeAttempt(null);
+    setFeed([]);
+    setSentCount(0);
+    setGranting(true);
+    try {
+      const allowlist = normalizedRecipients();
+      const amt = clampNumber(amountEach, AMOUNT_MIN, AMOUNT_MAX);
+      setAmountEach(amt);
+      const capRaw = parseUnits(amt, 6);
+      if (capRaw <= BigInt(0)) throw new Error("Set an amount greater than 0.");
+      const count = Number(clampNumber(payoutCount, COUNT_MIN, COUNT_MAX, true));
+      const interval = Number(clampNumber(intervalSec, INTERVAL_MIN, INTERVAL_MAX, true));
+      setPayoutCount(String(count));
+      setIntervalSec(String(interval));
+
+      const sessionKeyAccount = await buildSessionKeyAccount(
+        sessionPrivateKey,
+        allowlist,
+        capRaw,
+        count,
+      );
+      // Owner signs ONCE here.
+      const serialized = await serializePermissionAccount(
+        sessionKeyAccount,
+        sessionPrivateKey,
+      );
+
+      const next: GrantInfo = {
+        serialized,
+        sessionPrivateKey,
+        sessionAddress,
+        recipients: allowlist,
+        capRaw: capRaw.toString(),
+        amountEach: amt,
+        count,
+        intervalSec: interval,
+      };
+      setGrant(next);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setGranting(false);
+    }
+  };
+
+  const handleGrant = async () => {
+    if (!sessionKey) {
+      setError("Create a session key first.");
+      return;
+    }
+    await grantWithKey(sessionKey.privateKey, sessionKey.address);
+  };
+
+  // Wait `seconds`, updating the countdown; returns false if cancelled.
+  const waitCountdown = async (seconds: number, myRun: number) => {
+    for (let s = Math.max(0, Math.floor(seconds)); s > 0; s--) {
+      if (runIdRef.current !== myRun) return false;
+      setCountdown(s);
+      await wait(1000);
+    }
+    setCountdown(0);
+    return runIdRef.current === myRun;
+  };
+
+  const startDrip = async () => {
+    if (!grant || running || revoked) return;
+    const myRun = ++runIdRef.current;
+    setRunning(true);
+    setError("");
+    try {
+      const { client } = await buildSessionClient(grant.serialized);
+      const amountRaw = BigInt(grant.capRaw);
+      let attempt = sentCountRef.current;
+      const maxAttempts = grant.count + 1; // N payouts + 1 overflow that proves the cap
+
+      while (runIdRef.current === myRun && attempt < maxAttempts) {
+        const proceed = await waitCountdown(grant.intervalSec, myRun);
+        if (!proceed) break;
+
+        const recipient = grant.recipients[attempt % grant.recipients.length];
+        const rowId = attempt;
+        setFeed((f) => [
+          ...f,
+          { id: rowId, recipient, amount: grant.amountEach, status: "pending" },
+        ]);
+        try {
+          const hash = await client.sendTransaction({
+            calls: [
+              { to: USDC_ADDRESS, value: BigInt(0), data: encodeTransfer(recipient, amountRaw) },
+            ],
+          });
+          if (runIdRef.current !== myRun) break;
+          setFeed((f) =>
+            f.map((r) => (r.id === rowId ? { ...r, status: "sent", hash } : r)),
+          );
+          setSentCount((c) => c + 1);
+          await loadBalance();
+        } catch (err) {
+          if (runIdRef.current !== myRun) break;
+          setFeed((f) =>
+            f.map((r) =>
+              r.id === rowId ? { ...r, status: "rejected", error: getErrorMessage(err) } : r,
+            ),
+          );
+          break; // cap reached (or another rejection) — stop the drip
+        }
+        attempt++;
+      }
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      if (runIdRef.current === myRun) {
+        setRunning(false);
+        setCountdown(0);
+      }
+    }
+  };
+
+  const stopDrip = () => {
+    runIdRef.current += 1;
+    setRunning(false);
+    setCountdown(0);
+  };
+
+  const handleRevoke = async () => {
+    if (!grant) return;
+    runIdRef.current += 1; // stop any drip
+    setRunning(false);
+    setCountdown(0);
+    setError("");
+    setRevoking(true);
+    try {
+      // The permission validator is installed on-chain only on the FIRST
+      // successful payout. If the key was granted but never used, there's
+      // nothing installed to uninstall (uninstall would revert) — discarding the
+      // local key is the revoke.
+      if (sentCount > 0) {
+        const store = await getZeroDevStore(getZeroDevConnector(wagmiConfig));
+        const ownerKernelClient = store
+          .getState()
+          .kernelClients.get(ARBITRUM_SEPOLIA_CHAIN_ID);
+        if (!ownerKernelClient) {
+          throw new Error("Owner smart-account client isn't ready. Reconnect and try again.");
+        }
+        const permissionPlugin = await buildPermissionPlugin(
+          grant.sessionPrivateKey,
+          grant.recipients,
+          BigInt(grant.capRaw),
+          grant.count,
+        );
+        const hash = await ownerKernelClient.uninstallPlugin({ plugin: permissionPlugin });
+        setRevokeHash(hash);
+      }
+      setRevoked(true);
+      // Clear the persisted grant so the header "active session key" badge goes
+      // away. The in-memory grant stays for the "try a payout anyway" demo.
+      if (storageKey) window.localStorage.removeItem(storageKey);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setRevoking(false);
+    }
+  };
+
+  const handleTryAfterRevoke = async () => {
+    if (!grant) return;
+    setTryingAfterRevoke(true);
+    setPostRevokeAttempt(null);
+    try {
+      const { client } = await buildSessionClient(grant.serialized);
+      try {
+        await client.sendTransaction({
+          calls: [
+            {
+              to: USDC_ADDRESS,
+              value: BigInt(0),
+              data: encodeTransfer(grant.recipients[0], BigInt(grant.capRaw)),
+            },
+          ],
+        });
+        setPostRevokeAttempt("Unexpected: the payout went through after revoke.");
+      } catch (err) {
+        setPostRevokeAttempt(getErrorMessage(err));
+      }
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setTryingAfterRevoke(false);
+    }
+  };
+
+  const recipientTotals = useMemo(() => {
+    const totals = new Map<string, number>();
+    for (const row of feed) {
+      if (row.status !== "sent") continue;
+      const key = row.recipient.toLowerCase();
+      totals.set(key, (totals.get(key) ?? 0) + Number(row.amount));
+    }
+    return totals;
+  }, [feed]);
+
+  if (!isArbitrumSepolia) {
+    return (
+      <div className="flex items-start gap-2 rounded-lg border border-yellow-100 bg-yellow-50 px-4 py-3">
+        <AlertCircle className="mt-0.5 h-4 w-4 text-yellow-600" />
+        <p className="text-sm text-yellow-700">
+          This permissions demo runs on Arbitrum Sepolia. Switch networks to continue.
+        </p>
+      </div>
+    );
+  }
+
+  const balanceNumber = Number(usdcBalance) || 0;
+  const needsFunding = balanceNumber <= 0;
+  const granted = Boolean(grant);
+  const keyCreated = Boolean(sessionKey);
+  const sessionAddress = sessionKey?.address ?? grant?.sessionAddress ?? null;
+
+  const activeRecipients = grant?.recipients ?? recipients;
+  const amountNum = Number(grant?.amountEach ?? amountEach) || 0;
+  const countNum = grant?.count ?? Math.max(1, Math.floor(Number(payoutCount) || 0));
+  const totalBudget = amountNum * countNum;
+  const spent = sentCount * amountNum;
+  const progressPct = totalBudget > 0 ? Math.min(100, (spent / totalBudget) * 100) : 0;
+  const dripComplete = granted && !running && sentCount >= countNum;
+  const hasRejection = feed.some((row) => row.status === "rejected");
+  // The key can no longer pay out: it hit the cap this run, or a payout was
+  // rejected (e.g. an already-exhausted/invalid key). Either way the fix is a
+  // new key, so prompt for one and stop Start from re-trying the dead key.
+  const keySpent = granted && !running && !revoked && (dripComplete || hasRejection);
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-950">Delegate a budget</h2>
+        <p className="mt-1 text-sm leading-6 text-gray-600">
+          Authorize a throwaway key to drip out a capped amount of <strong>your own</strong>{" "}
+          USDC, on a timer, only to specific wallets. Watch it pay out by itself — then watch
+          your account refuse the payout that would go over the limit, or kill it instantly by
+          revoking.
+        </p>
+      </div>
+
+      {error && (
+        <div className="flex items-start gap-2 rounded-lg border border-red-100 bg-red-50 px-4 py-3">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-600" />
+          <p className="break-words text-sm text-red-700">{error}</p>
+        </div>
+      )}
+
+      {/* Flow diagram */}
+      <FlowDiagram
+        owner={owner}
+        balance={balanceNumber}
+        sessionAddress={sessionAddress}
+        granted={granted}
+        grant={grant}
+        sentCount={sentCount}
+        recipients={activeRecipients}
+        recipientTotals={recipientTotals}
+      />
+
+      {/* Wallet balance + faucet */}
+      <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
+        <span className="flex items-center gap-2 text-sm font-medium text-gray-600">
+          <Wallet className="h-4 w-4 text-gray-500" />
+          Your wallet&apos;s USDC
+        </span>
+        <span className="flex items-center gap-3">
+          <span className="font-mono text-sm font-semibold text-gray-950">
+            {balanceNumber.toFixed(2)} USDC
+          </span>
+          <FaucetLink
+            href={USDC_FAUCET_URL}
+            address={owner}
+            className="inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer"
+          >
+            Faucet
+            <ExternalLink className="h-3 w-3" />
+          </FaucetLink>
+        </span>
+      </div>
+      {needsFunding && (
+        <div className="space-y-3 rounded-lg border border-blue-100 bg-blue-50 px-4 py-3">
+          <div className="flex items-start gap-2">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
+            <p className="text-sm text-blue-700">
+              You have no USDC yet. Grab some test USDC (clicking copies your wallet address so
+              you can paste it into the faucet). This balance refreshes automatically.
+            </p>
+          </div>
+          <FaucetLink
+            href={USDC_FAUCET_URL}
+            address={owner}
+            className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-blue-200 bg-white px-3 py-2 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-100 cursor-pointer"
+          >
+            Get test USDC
+            <ExternalLink className="h-3.5 w-3.5" />
+          </FaucetLink>
+        </div>
+      )}
+
+      {/* Step 1: create the session key */}
+      <StepCard step={1} title="Create the session key">
+        <p className="flex items-center gap-1.5 text-sm text-gray-600">
+          A fresh throwaway key — it holds nothing and can&apos;t do anything until you grant it
+          an allowance in Step 2.
+          <InfoHint text="In production this is usually a key your backend holds, so it can keep acting for the user even while they're offline. Here it's generated in your browser for the demo." />
+        </p>
+        {!keyCreated ? (
+          <button
+            type="button"
+            onClick={handleCreateSessionKey}
+            disabled={!owner}
+            className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <KeyRound className="h-4 w-4" />
+            Create session key
+          </button>
+        ) : (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-3 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
+              <span className="flex items-center gap-2 text-sm">
+                <KeyRound className="h-4 w-4 text-gray-500" />
+                <span className="font-medium text-gray-700">Session key</span>
+                <a
+                  href={`${EXPLORER_BASE_URL}/address/${sessionAddress}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 font-mono text-xs text-gray-950 underline-offset-2 hover:underline"
+                >
+                  {sessionAddress ? formatShort(sessionAddress) : "—"}
+                  <ExternalLink className="h-3 w-3 text-gray-400" />
+                </a>
+              </span>
+              <span className="rounded bg-emerald-50 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 ring-1 ring-emerald-200">
+                created
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={handleCreateSessionKey}
+              className="inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 transition-colors hover:text-gray-900"
+              title="Discard this key and generate a fresh one (you'll grant it again in Step 2)"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+              Swap to a new session key
+            </button>
+          </div>
+        )}
+      </StepCard>
+
+      {/* Step 2: configure + grant */}
+      <StepCard step={2} title="Set the allowance & grant" disabled={!keyCreated}>
+        {!keyCreated && (
+          <p className="rounded-lg bg-gray-50 px-3 py-2 text-xs font-medium text-gray-500">
+            Create a session key in Step 1 first.
+          </p>
+        )}
+        <div className="grid gap-3 sm:grid-cols-3">
+          <label className="block">
+            <span className="text-xs font-medium text-gray-500">
+              USDC per payout ({AMOUNT_MIN}–{AMOUNT_MAX})
+            </span>
+            <input
+              type="number"
+              min={AMOUNT_MIN}
+              max={AMOUNT_MAX}
+              step="0.01"
+              value={amountEach}
+              disabled={granted}
+              onChange={(e) => setAmountEach(e.target.value)}
+              onBlur={() => setAmountEach(clampNumber(amountEach, AMOUNT_MIN, AMOUNT_MAX))}
+              className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 font-mono text-sm text-gray-950 outline-none focus:border-gray-400 disabled:bg-gray-50 disabled:text-gray-500"
+            />
+          </label>
+          <label className="block">
+            <span className="text-xs font-medium text-gray-500">
+              # of payouts ({COUNT_MIN}–{COUNT_MAX})
+            </span>
+            <input
+              type="number"
+              min={COUNT_MIN}
+              max={COUNT_MAX}
+              step="1"
+              value={payoutCount}
+              disabled={granted}
+              onChange={(e) => setPayoutCount(e.target.value)}
+              onBlur={() =>
+                setPayoutCount(clampNumber(payoutCount, COUNT_MIN, COUNT_MAX, true))
+              }
+              className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 font-mono text-sm text-gray-950 outline-none focus:border-gray-400 disabled:bg-gray-50 disabled:text-gray-500"
+            />
+          </label>
+          <label className="block">
+            <span className="text-xs font-medium text-gray-500">
+              Every (sec, {INTERVAL_MIN}–{INTERVAL_MAX})
+            </span>
+            <input
+              type="number"
+              min={INTERVAL_MIN}
+              max={INTERVAL_MAX}
+              step="1"
+              value={intervalSec}
+              disabled={granted}
+              onChange={(e) => setIntervalSec(e.target.value)}
+              onBlur={() =>
+                setIntervalSec(clampNumber(intervalSec, INTERVAL_MIN, INTERVAL_MAX, true))
+              }
+              className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 font-mono text-sm text-gray-950 outline-none focus:border-gray-400 disabled:bg-gray-50 disabled:text-gray-500"
+            />
+          </label>
+        </div>
+
+        <div className="rounded-lg bg-gray-50 px-3 py-2 text-xs text-gray-600">
+          Total budget: <strong className="font-mono">{totalBudget} USDC</strong> ({countNum}{" "}
+          payouts × {amountNum} USDC). The account enforces this hard cap on-chain.
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="flex items-center gap-1.5 text-xs font-medium text-gray-500">
+              Allow-listed wallets
+              <InfoHint text="Example payout wallets — edit them to addresses you control. Choose how many to allow-list (1–5). Only these can ever receive funds from the session key." />
+            </span>
+            {!granted && (
+              <span className="flex items-center gap-1.5">
+                <button
+                  type="button"
+                  onClick={removeRecipient}
+                  disabled={recipients.length <= MIN_RECIPIENTS}
+                  aria-label="Remove a wallet"
+                  className="flex h-6 w-6 items-center justify-center rounded-md border border-gray-200 text-gray-600 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <Minus className="h-3.5 w-3.5" />
+                </button>
+                <span className="w-4 text-center font-mono text-xs text-gray-700">
+                  {recipients.length}
+                </span>
+                <button
+                  type="button"
+                  onClick={addRecipient}
+                  disabled={recipients.length >= MAX_RECIPIENTS}
+                  aria-label="Add a wallet"
+                  className="flex h-6 w-6 items-center justify-center rounded-md border border-gray-200 text-gray-600 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                </button>
+              </span>
+            )}
+          </div>
+          {recipients.map((recipient, index) => (
+            <input
+              key={index}
+              value={recipient}
+              disabled={granted}
+              onChange={(e) => updateRecipient(index, e.target.value)}
+              spellCheck={false}
+              placeholder="0x..."
+              className="w-full rounded-lg border border-gray-200 px-3 py-2 font-mono text-xs text-gray-950 outline-none focus:border-gray-400 disabled:bg-gray-50 disabled:text-gray-500"
+            />
+          ))}
+        </div>
+
+        {!granted ? (
+          <button
+            type="button"
+            onClick={handleGrant}
+            disabled={granting || !owner || !keyCreated}
+            className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {granting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Granting (you sign once)...
+              </>
+            ) : (
+              <>
+                <ShieldCheck className="h-4 w-4" />
+                Grant allowance to this key
+              </>
+            )}
+          </button>
+        ) : (
+          <GrantSummary grant={grant!} sentCount={sentCount} revoked={revoked} />
+        )}
+      </StepCard>
+
+      {/* Step 2: run the drip */}
+      <StepCard step={3} title="Run the allowance drip" disabled={!granted}>
+        {!granted && (
+          <p className="rounded-lg bg-gray-50 px-3 py-2 text-xs font-medium text-gray-500">
+            Grant an allowance in Step 2 first to unlock the drip.
+          </p>
+        )}
+        <p className="text-sm text-gray-600">
+          The session key — not you — signs each payout on a timer, gas sponsored. It stops on
+          its own when it hits the {countNum}-payout cap.
+        </p>
+
+        {/* Progress */}
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between text-xs text-gray-500">
+            <span>
+              <span className="font-semibold text-gray-900">{spent.toFixed(2)}</span> /{" "}
+              {totalBudget} USDC paid out
+            </span>
+            <span>
+              {sentCount} / {countNum} payouts
+            </span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-gray-100">
+            <div
+              className="h-full rounded-full bg-gray-900 transition-all duration-500"
+              style={{ width: `${progressPct}%` }}
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {!running ? (
+            <button
+              type="button"
+              onClick={startDrip}
+              disabled={!granted || revoked || dripComplete || hasRejection}
+              className="inline-flex h-11 flex-1 items-center justify-center gap-2 rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <Play className="h-4 w-4" />
+              {sentCount > 0 ? "Resume drip" : "Start drip"}
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={stopDrip}
+              className="inline-flex h-11 flex-1 items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 text-sm font-semibold text-gray-900 transition-colors hover:bg-gray-50"
+            >
+              <Square className="h-4 w-4" />
+              Stop
+            </button>
+          )}
+          {running && countdown > 0 && (
+            <span className="inline-flex h-11 items-center gap-2 rounded-lg bg-gray-50 px-3 text-sm font-medium text-gray-600">
+              <Loader2 className="h-4 w-4 animate-spin text-gray-400" />
+              next in {countdown}s
+            </span>
+          )}
+        </div>
+
+        {keySpent && (
+          <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+            <span>
+              <strong>This session key can&apos;t pay out anymore.</strong>{" "}
+              {dripComplete
+                ? `It hit its ${countNum}-payout cap.`
+                : "Its allowance is used up (or the key is no longer valid)."}{" "}
+              A rate-limited key can&apos;t be topped up — use <strong>Revoke</strong> or{" "}
+              <strong>Reset</strong> in Step 4 to start over with a new key.
+            </span>
+          </div>
+        )}
+
+        {/* Live feed */}
+        {feed.length > 0 && (
+          <div className="divide-y divide-gray-100 rounded-lg border border-gray-200">
+            {feed.map((row) => {
+              const isLimitHit = row.status === "rejected" && row.id >= countNum;
+              return (
+                <div
+                  key={row.id}
+                  className="flex items-center justify-between gap-3 px-3 py-2 text-sm"
+                >
+                  <span className="flex min-w-0 items-center gap-2">
+                    <span className="font-mono text-xs text-gray-400">#{row.id + 1}</span>
+                    <span className="font-mono text-xs text-gray-700">
+                      {formatShort(row.recipient)}
+                    </span>
+                    <span className="text-gray-400">·</span>
+                    <span className="text-gray-500">{row.amount} USDC</span>
+                  </span>
+                  <span className="flex items-center gap-2">
+                    {row.status === "pending" && (
+                      <Loader2 className="h-4 w-4 animate-spin text-gray-400" />
+                    )}
+                    {row.status === "sent" && row.hash && (
+                      <a
+                        href={`${EXPLORER_BASE_URL}/tx/${row.hash}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 font-medium text-emerald-700 underline-offset-2 hover:underline"
+                        title="Signed by the session key"
+                      >
+                        <Check className="h-3.5 w-3.5" />
+                        {formatShort(row.hash)}
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    )}
+                    {row.status === "rejected" && (
+                      <span className="text-xs font-semibold text-red-600">
+                        {isLimitHit ? "Cap reached — rejected" : "Rejected"}
+                      </span>
+                    )}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </StepCard>
+
+      {/* Step 3: revoke + reset */}
+      <StepCard step={4} title="Revoke & reset" disabled={!granted}>
+        <p className="text-sm text-gray-600">
+          Kill the session key on-chain at any time. Even mid-drip, the next payout is refused.
+        </p>
+
+        {revokeHash && (
+          <div className="flex items-start gap-2 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-900">
+            <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
+            <span>
+              Revoked on-chain.{" "}
+              <a
+                href={`${EXPLORER_BASE_URL}/tx/${revokeHash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-semibold underline underline-offset-2"
+              >
+                View transaction
+              </a>
+            </span>
+          </div>
+        )}
+
+        {revoked && !revokeHash && (
+          <div className="flex items-start gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700">
+            <Ban className="mt-0.5 h-4 w-4 shrink-0 text-gray-500" />
+            <span>
+              Key discarded. It was never used, so nothing was installed on-chain to revoke —
+              your local copy is gone.
+            </span>
+          </div>
+        )}
+
+        {revoked && postRevokeAttempt && (
+          <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-900">
+            <p className="font-semibold">Payout after revoke — rejected by the account</p>
+            <pre className="mt-1 max-h-32 overflow-auto whitespace-pre-wrap break-words rounded-md bg-white/70 p-2 font-mono text-[11px] leading-4 text-gray-700">
+              {postRevokeAttempt}
+            </pre>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-2 sm:flex-row">
+          {!revoked ? (
+            <button
+              type="button"
+              onClick={handleRevoke}
+              disabled={!granted || revoking}
+              className="inline-flex h-11 flex-1 items-center justify-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 text-sm font-semibold text-red-700 transition-colors hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {revoking ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Revoking on-chain...
+                </>
+              ) : (
+                <>
+                  <Ban className="h-4 w-4" />
+                  Revoke session key
+                </>
+              )}
+            </button>
+          ) : revokeHash ? (
+            <button
+              type="button"
+              onClick={handleTryAfterRevoke}
+              disabled={tryingAfterRevoke}
+              className="inline-flex h-11 flex-1 items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 text-sm font-semibold text-gray-900 transition-colors hover:bg-gray-50 disabled:opacity-60"
+            >
+              {tryingAfterRevoke ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Zap className="h-4 w-4 text-red-500" />
+              )}
+              Try a payout anyway
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={resetAll}
+            disabled={revoking}
+            className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-4 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-60"
+            title="Clear this page (no on-chain transaction)"
+          >
+            <RotateCcw className="h-4 w-4" />
+            Reset
+          </button>
+        </div>
+      </StepCard>
+
+      <CodePanel open={codeOpen} onToggle={() => setCodeOpen((o) => !o)} />
+    </div>
+  );
+}
+
+function FlowDiagram({
+  owner,
+  balance,
+  sessionAddress,
+  granted,
+  sentCount,
+  recipients,
+  recipientTotals,
+}: {
+  owner: Address | null
+  balance: number
+  sessionAddress: string | null
+  granted: boolean
+  grant: GrantInfo | null
+  sentCount: number
+  recipients: string[]
+  recipientTotals: Map<string, number>
+}) {
+  return (
+    <div className="grid items-stretch gap-3 rounded-lg border border-gray-200 bg-white p-4 lg:grid-cols-[1fr_auto_1fr_auto_1fr]">
+      {/* You */}
+      <div className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+        <p className="flex items-center gap-1.5 text-xs font-semibold text-gray-500">
+          <UserRound className="h-3.5 w-3.5" />
+          You (this wallet)
+        </p>
+        <p className="mt-1 font-mono text-xs font-semibold text-gray-950">
+          {owner ? formatShort(owner) : "—"}
+        </p>
+        <p className="mt-1 text-xs text-gray-500">
+          Holds <span className="font-mono">{balance.toFixed(2)} USDC</span> · signs once
+        </p>
+      </div>
+
+      <FlowArrow />
+
+      {/* Session key */}
+      <div className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+        <p className="flex items-center gap-1.5 text-xs font-semibold text-gray-500">
+          <KeyRound className="h-3.5 w-3.5" />
+          Session key
+          <InfoHint text="In production this is usually a key your backend holds, so it can keep acting for the user even while they're offline. Here it's generated in your browser just for the demo." />
+        </p>
+        {sessionAddress ? (
+          <>
+            <a
+              href={`${EXPLORER_BASE_URL}/address/${sessionAddress}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-1 inline-flex items-center gap-1 font-mono text-xs font-semibold text-gray-950 underline-offset-2 hover:underline"
+            >
+              {formatShort(sessionAddress)}
+              <ExternalLink className="h-3 w-3 text-gray-400" />
+            </a>
+            <div className="mt-1.5 flex flex-wrap gap-1">
+              <span className="rounded bg-white px-1.5 py-0.5 text-[10px] font-medium text-gray-600 ring-1 ring-gray-200">
+                0 ETH · 0 USDC
+              </span>
+              <span className="rounded bg-emerald-50 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 ring-1 ring-emerald-200">
+                gas sponsored
+              </span>
+            </div>
+            <p className="mt-1 text-xs text-gray-500">
+              {granted ? `signed ${sentCount} payouts` : "no allowance yet — grant one"}
+            </p>
+          </>
+        ) : (
+          <p className="mt-1 text-xs text-gray-400">created in Step 1 →</p>
+        )}
+      </div>
+
+      <FlowArrow />
+
+      {/* Recipients */}
+      <div className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+        <p className="flex items-center gap-1.5 text-xs font-semibold text-gray-500">
+          <Users className="h-3.5 w-3.5" />
+          Recipients
+          <InfoHint text="Example payout wallets. Edit them to addresses you control and pick how many to allow-list — the session key can only ever send to these." />
+        </p>
+        <ul className="mt-1 space-y-0.5">
+          {recipients.slice(0, 4).map((r) => {
+            const received = recipientTotals.get(r.toLowerCase()) ?? 0;
+            return (
+              <li key={r} className="flex items-center justify-between gap-2 text-xs">
+                <span className="font-mono text-gray-700">{formatShort(r)}</span>
+                <span className={cn("font-mono", received > 0 ? "text-emerald-700" : "text-gray-400")}>
+                  +{received.toFixed(2)}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function InfoHint({ text }: { text: string }) {
+  return (
+    <span className="group/info relative inline-flex">
+      <Info className="h-3.5 w-3.5 cursor-help text-gray-400" />
+      <span className="pointer-events-none absolute left-1/2 top-full z-30 mt-1.5 hidden w-56 -translate-x-1/2 rounded-md border border-gray-200 bg-white px-2.5 py-1.5 text-[11px] font-normal leading-4 text-gray-600 shadow-md group-hover/info:block">
+        {text}
+      </span>
+    </span>
+  );
+}
+
+function FlowArrow() {
+  return (
+    <div className="flex items-center justify-center text-gray-300">
+      <ArrowRight className="hidden h-5 w-5 lg:block" />
+      <ArrowRight className="h-5 w-5 rotate-90 lg:hidden" />
+    </div>
+  );
+}
+
+function StepCard({
+  step,
+  title,
+  children,
+  disabled = false,
+}: {
+  step: number
+  title: string
+  children: ReactNode
+  disabled?: boolean
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-gray-200 bg-white p-4 transition-opacity",
+        disabled && "opacity-50",
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            "flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold text-white",
+            disabled ? "bg-gray-300" : "bg-gray-950",
+          )}
+        >
+          {step}
+        </span>
+        <h3 className="text-sm font-semibold text-gray-950">{title}</h3>
+      </div>
+      <div
+        className={cn("mt-4 space-y-4", disabled && "pointer-events-none select-none")}
+        aria-disabled={disabled}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function GrantSummary({
+  grant,
+  sentCount,
+  revoked,
+}: {
+  grant: GrantInfo
+  sentCount: number
+  revoked: boolean
+}) {
+  return (
+    <div
+      className={cn(
+        "space-y-2 rounded-lg border p-3",
+        revoked ? "border-gray-200 bg-gray-50" : "border-emerald-200 bg-emerald-50/60",
+      )}
+    >
+      <div className="flex items-center gap-2 text-sm font-semibold">
+        {revoked ? (
+          <>
+            <Ban className="h-4 w-4 text-gray-500" />
+            <span className="text-gray-700">Permission revoked</span>
+          </>
+        ) : (
+          <>
+            <ShieldCheck className="h-4 w-4 text-emerald-600" />
+            <span className="text-emerald-900">Allowance granted</span>
+          </>
+        )}
+      </div>
+      <p className="text-xs leading-5 text-gray-600">
+        The session key may call <span className="font-mono">USDC.transfer</span> up to{" "}
+        <strong>{grant.amountEach} USDC</strong> per payout, only to the{" "}
+        {grant.recipients.length} allow-listed wallets, for at most{" "}
+        <strong>{grant.count} payouts</strong>. You signed once; the key has signed {sentCount}.
+      </p>
+    </div>
+  );
+}
+
+function CodePanel({ open, onToggle }: { open: boolean; onToggle: () => void }) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center justify-between gap-4 bg-gray-950 px-4 py-3 text-left text-white transition-colors hover:bg-gray-900"
+        aria-expanded={open}
+      >
+        <span className="flex items-center gap-2 text-sm font-semibold">
+          <Code2 className="h-4 w-4 text-gray-300" />
+          Code
+        </span>
+        <ChevronDown
+          className={cn("h-4 w-4 text-gray-300 transition-transform", open && "rotate-180")}
+        />
+      </button>
+      {open && (
+        <div className="border-t border-gray-200 bg-gray-50 p-4">
+          <CodeBlock label="Grant a scoped, rate-limited session key">{GRANT_SNIPPET}</CodeBlock>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CodeBlock({ children, label }: { children: ReactNode; label: string }) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-gray-200 bg-gray-950">
+      <div className="border-b border-white/10 px-3 py-2 text-xs font-semibold text-gray-300">
+        {label}
+      </div>
+      <pre className="overflow-x-auto p-3 text-xs leading-5 text-gray-100">
+        <code>{children}</code>
+      </pre>
+    </div>
+  );
+}
+
+function encodeTransfer(to: Address, amount: bigint): `0x${string}` {
+  return encodeFunctionData({
+    abi: erc20Abi,
+    functionName: "transfer",
+    args: [to, amount],
+  });
+}
+
+const GRANT_SNIPPET = `const permission = await toPermissionValidator(publicClient, {
+  entryPoint, kernelVersion,
+  signer: await toECDSASigner({ signer: sessionKey }),
+  policies: [
+    toCallPolicy({
+      policyVersion: CallPolicyVersion.V0_0_4,
+      permissions: [{
+        target: USDC, abi: erc20Abi, functionName: "transfer",
+        args: [
+          { condition: ParamCondition.ONE_OF, value: recipients },
+          { condition: ParamCondition.LESS_THAN_OR_EQUAL, value: cap },
+        ],
+      }],
+    }),
+    // hard cap of N payouts total (interval 0 = no reset)
+    toRateLimitPolicy({ count: N, interval: 0 }),
+  ],
+})
+
+const account = await createKernelAccount(publicClient, {
+  entryPoint, kernelVersion,
+  eip7702Account: owner, address: owner.address,
+  plugins: { regular: permission },
+})
+
+const approval = await serializePermissionAccount(account, sessionPrivateKey)`;

--- a/apps/zerodev-signer-demo/src/app/dashboard/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/dashboard/page.tsx
@@ -29,15 +29,18 @@ import { useRouter } from "next/navigation";
 import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import {
   Address,
+  createWalletClient,
   encodeFunctionData,
   formatEther,
   formatUnits,
+  http,
   isAddress,
   parseAbi,
   parseUnits,
   zeroAddress,
 } from "viem";
 import { useAccount, useConfig, useDisconnect, usePublicClient } from "wagmi";
+import { arbitrumSepolia } from "wagmi/chains";
 import { ChainSelector } from "../components/ChainSelector";
 import { ExportPrivateKeyModal } from "../components/ExportPrivateKeyModal";
 import { ExportWalletModal } from "../components/ExportWalletModal";
@@ -129,6 +132,10 @@ const ARBITRUM_SEPOLIA_USDC_WETH_FEE = 3000;
 const usdcSwapAbi = parseAbi([
   "function approve(address spender, uint256 amount) external returns (bool)",
   "function allowance(address owner, address spender) external view returns (uint256)",
+]);
+
+const wethAbi = parseAbi([
+  "function withdraw(uint256 amount) external",
 ]);
 
 const swapRouterAbi = parseAbi([
@@ -1112,11 +1119,17 @@ const stableGasModes: Array<{
   { mode: "manual", label: "EOA wallet", badge: "Traditional" },
 ]
 
-const stableGasSteps: StableGasStep[] = [
+const eoaStableGasSteps: StableGasStep[] = [
   { label: "Fund gas", detail: "native ETH required", threshold: 25, token: "eth" },
   { label: "Approve USDC", detail: "allow Uniswap to spend USDC", threshold: 50, token: "usdc" },
   { label: "Swap to WETH", detail: "USDC -> WETH on Uniswap", threshold: 75, token: "swap" },
   { label: "Unwrap to ETH", detail: "WETH -> native wallet ETH", threshold: 100, token: "eth" },
+]
+
+const zeroDevStableGasSteps: StableGasStep[] = [
+  { label: "Approve USDC", detail: "gas sponsored", threshold: 34, token: "usdc" },
+  { label: "Swap to WETH", detail: "gas sponsored on Uniswap", threshold: 67, token: "swap" },
+  { label: "Unwrap to ETH", detail: "gas sponsored", threshold: 100, token: "eth" },
 ]
 
 function StableGasSwapTest({
@@ -1136,6 +1149,7 @@ function StableGasSwapTest({
   const [availableUsdc, setAvailableUsdc] = useState("0")
   const [receivedEth, setReceivedEth] = useState<string | null>(null)
   const [batchDurationMs, setBatchDurationMs] = useState<number | null>(null)
+  const [wethToUnwrap, setWethToUnwrap] = useState<bigint>(BigInt(0))
   const [progressMessage, setProgressMessage] = useState("Ready")
   const [activeCallIndex, setActiveCallIndex] = useState<number | null>(null)
   const runVersionRef = useRef(0)
@@ -1200,44 +1214,188 @@ function StableGasSwapTest({
     return kernelClient
   }
 
+  const getRawEoaWalletClient = async () => {
+    const store = await getZeroDevStore(getZeroDevConnector(wagmiConfig))
+    const eoaAccount = store.getState().eoaAccount
+    if (!eoaAccount) {
+      throw new Error("Raw EOA signer is not ready. Reconnect the wallet and try again.")
+    }
+    return createWalletClient({
+      account: eoaAccount,
+      chain: arbitrumSepolia,
+      transport: http(process.env.NEXT_PUBLIC_ARB_SEPOLIA_RPC_URL),
+    })
+  }
+
   const resetStableGasRun = () => {
     runVersionRef.current += 1
     setError("")
     setTxs([])
     setReceivedEth(null)
     setBatchDurationMs(null)
+    setWethToUnwrap(BigInt(0))
     setProgressMessage("Ready")
     setStatus("idle")
     setActiveCallIndex(null)
   }
 
-  const completeSimulatedEoaStep = async (index: number, label: string) => {
+  const completeGasCheckStep = async (runVersion: number) => {
+    if (!accountAddress || !publicClient) return
+    setProgressMessage("Checking native ETH")
+    const nativeBalance = await publicClient.getBalance({ address: accountAddress })
+    if (runVersionRef.current !== runVersion) return
+    if (nativeBalance <= BigInt(0)) {
+      throw new Error("Run the one-click sponsored route first to add native ETH, then retry the EOA steps.")
+    }
+    setTxs((current) => [
+      ...current,
+      {
+        id: "eoa-gas-ready",
+        label: "Native gas ready",
+        simulatedStep: true,
+      },
+    ])
+    setProgressMessage("Native gas ready")
+  }
+
+  const sendRawEoaTransaction = async ({
+    data,
+    label,
+    to,
+  }: {
+    data: `0x${string}`
+    label: string
+    to: Address
+  }) => {
+    if (!publicClient) throw new Error("RPC client is not ready.")
+    const walletClient = await getRawEoaWalletClient()
+    const hash = toTransactionHash(
+      await walletClient.sendTransaction({
+        data,
+        to,
+        value: BigInt(0),
+      }),
+    )
+    if (!hash) throw new Error(`${label} did not return a transaction hash.`)
+    setTxs((current) => [...current, { label, hash }])
+    await publicClient.waitForTransactionReceipt({ hash })
+    return hash
+  }
+
+  const handleEoaStep = async (index: number) => {
+    if (!accountAddress || !publicClient) return
+
     const runVersion = runVersionRef.current + 1
     runVersionRef.current = runVersion
     setError("")
     setStatus("swapping")
     setActiveCallIndex(index)
-    setProgressMessage(index === 0 ? "Funding native gas" : `Signing ${label}`)
 
-    await new Promise((resolve) => window.setTimeout(resolve, 650))
-    if (runVersionRef.current !== runVersion) return
-    setTxs((current) => [
-      ...current,
-      {
-        id: `eoa-step-${index}`,
-        label,
-        simulatedStep: true,
-      },
-    ])
-    if (index === 3) {
-      setReceivedEth("0.0003")
-      setStatus("complete")
-      setProgressMessage("Native ETH received")
-    } else {
+    try {
+      if (index === 0) {
+        await completeGasCheckStep(runVersion)
+      }
+
+      if (index === 1) {
+        if (amountIn <= BigInt(0)) throw new Error("Choose at least 1 USDC.")
+        setProgressMessage("Sending EOA approval")
+        await sendRawEoaTransaction({
+          label: "USDC approval",
+          to: usdcAddress,
+          data: encodeFunctionData({
+            abi: usdcSwapAbi,
+            functionName: "approve",
+            args: [ARBITRUM_SEPOLIA_SWAP_ROUTER, amountIn],
+          }),
+        })
+        if (runVersionRef.current !== runVersion) return
+        setProgressMessage("USDC approved")
+      }
+
+      if (index === 2) {
+        if (amountIn <= BigInt(0)) throw new Error("Choose at least 1 USDC.")
+        setProgressMessage("Swapping USDC to WETH")
+        const wethBefore = await publicClient.readContract({
+          address: ARBITRUM_SEPOLIA_WETH,
+          abi: erc20BalanceAbi,
+          functionName: "balanceOf",
+          args: [accountAddress],
+        })
+        await sendRawEoaTransaction({
+          label: "USDC to WETH swap",
+          to: ARBITRUM_SEPOLIA_SWAP_ROUTER,
+          data: encodeFunctionData({
+            abi: swapRouterAbi,
+            functionName: "exactInputSingle",
+            args: [
+              {
+                tokenIn: usdcAddress,
+                tokenOut: ARBITRUM_SEPOLIA_WETH,
+                fee: ARBITRUM_SEPOLIA_USDC_WETH_FEE,
+                recipient: accountAddress,
+                amountIn,
+                amountOutMinimum: BigInt(1),
+                sqrtPriceLimitX96: BigInt(0),
+              },
+            ],
+          }),
+        })
+        if (runVersionRef.current !== runVersion) return
+        const wethAfter = await publicClient.readContract({
+          address: ARBITRUM_SEPOLIA_WETH,
+          abi: erc20BalanceAbi,
+          functionName: "balanceOf",
+          args: [accountAddress],
+        })
+        const receivedWeth = wethAfter > wethBefore ? wethAfter - wethBefore : wethAfter
+        setWethToUnwrap(receivedWeth)
+        setProgressMessage("WETH received")
+      }
+
+      if (index === 3) {
+        const unwrapAmount =
+          wethToUnwrap > BigInt(0)
+            ? wethToUnwrap
+            : await publicClient.readContract({
+                address: ARBITRUM_SEPOLIA_WETH,
+                abi: erc20BalanceAbi,
+                functionName: "balanceOf",
+                args: [accountAddress],
+              })
+        if (unwrapAmount <= BigInt(0)) {
+          throw new Error("No WETH is available to unwrap. Complete the swap step first.")
+        }
+        setProgressMessage("Unwrapping WETH to native ETH")
+        const ethBefore = await publicClient.getBalance({ address: accountAddress })
+        await sendRawEoaTransaction({
+          label: "WETH unwrap",
+          to: ARBITRUM_SEPOLIA_WETH,
+          data: encodeFunctionData({
+            abi: wethAbi,
+            functionName: "withdraw",
+            args: [unwrapAmount],
+          }),
+        })
+        if (runVersionRef.current !== runVersion) return
+        const ethAfter = await publicClient.getBalance({ address: accountAddress })
+        if (ethAfter > ethBefore) setReceivedEth(formatEther(ethAfter - ethBefore))
+        setStatus("complete")
+        setProgressMessage("Native ETH received")
+        setActiveCallIndex(null)
+        onRefreshAssets()
+        return
+      }
+
       setStatus("idle")
-      setProgressMessage(index === 0 ? "Native gas funded" : `${label} signed`)
+      setActiveCallIndex(null)
+      onRefreshAssets()
+    } catch (err) {
+      if (runVersionRef.current !== runVersion) return
+      setError(getSwapErrorMessage(err))
+      setProgressMessage("Ready")
+      setStatus("idle")
+      setActiveCallIndex(null)
     }
-    setActiveCallIndex(null)
   }
 
   const handleSwapToNativeEth = async () => {
@@ -1249,6 +1407,7 @@ function StableGasSwapTest({
     setTxs([])
     setReceivedEth(null)
     setBatchDurationMs(null)
+    setWethToUnwrap(BigInt(0))
     setProgressMessage("Checking USDC balance and allowance")
     setStatus("checking")
     setActiveCallIndex(0)
@@ -1375,11 +1534,13 @@ function StableGasSwapTest({
         : activeCallIndex !== null
           ? Math.min(92, activeCallIndex * 25 + 14)
           : Math.min(100, txs.length * 25)
+  const activeStableGasSteps =
+    executionMode === "batch" ? zeroDevStableGasSteps : eoaStableGasSteps
   const manualStepHandlers = [
-    () => completeSimulatedEoaStep(0, "Native gas funding"),
-    () => completeSimulatedEoaStep(1, "USDC approval"),
-    () => completeSimulatedEoaStep(2, "USDC to WETH swap"),
-    () => completeSimulatedEoaStep(3, "WETH unwrap"),
+    () => handleEoaStep(0),
+    () => handleEoaStep(1),
+    () => handleEoaStep(2),
+    () => handleEoaStep(3),
   ]
   const flowLocked =
     isRunning ||
@@ -1403,11 +1564,12 @@ function StableGasSwapTest({
     return txs[index]
   }
   const getStepDetail = (index: number) => {
-    if (index === 0) {
-      return executionMode === "batch"
-        ? "Gas is sponsored by the ZeroDev policy."
-        : "EOA wallets need native ETH before the first transaction."
+    if (executionMode === "batch") {
+      if (index === 0) return `Approve ${amount} USDC with sponsored gas.`
+      if (index === 1) return `Swap ${amount} USDC through the USDC/WETH 0.3% pool with sponsored gas.`
+      return "Unwrap WETH into native ETH with sponsored gas."
     }
+    if (index === 0) return "EOA wallets need native ETH before the first transaction."
     if (index === 1) return `Approve ${amount} USDC for the Uniswap router.`
     if (index === 2) return `Swap ${amount} USDC through the USDC/WETH 0.3% pool.`
     return "Unwrap WETH into native ETH in the wallet."
@@ -1518,12 +1680,12 @@ function StableGasSwapTest({
           </span>
         </div>
         <div className="mt-3 grid gap-2">
-              {stableGasSteps.map((step, index) => {
+              {activeStableGasSteps.map((step, index) => {
                   const isDone =
                     executionMode === "batch"
                       ? zeroDevProgress >= step.threshold
                       : txs.length > index || (status === "complete" && index === 3)
-                  const currentStep = stableGasSteps.find(
+                  const currentStep = activeStableGasSteps.find(
                     (item) => visualProgress < item.threshold,
                   )
                   const canRunManualStep =
@@ -1592,6 +1754,11 @@ function StableGasSwapTest({
                           <div className="min-w-0">
                           <p className="truncate text-sm font-semibold text-gray-950">
                             {step.label}
+                            {executionMode === "batch" && (
+                              <span className="ml-2 rounded-full bg-green-50 px-2 py-0.5 text-[10px] font-semibold uppercase text-green-700">
+                                Gas sponsored
+                              </span>
+                            )}
                             {step.token === "swap" && (
                               <span className="ml-2 rounded-full bg-pink-50 px-2 py-0.5 text-[10px] font-semibold uppercase text-pink-700">
                                 Uniswap

--- a/apps/zerodev-signer-demo/src/app/dashboard/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/dashboard/page.tsx
@@ -1,58 +1,208 @@
 /* eslint-disable @next/next/no-img-element */
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
-import { useAuthenticators } from "@zerodev/wallet-react";
+import {
+  getZeroDevConnector,
+  getZeroDevStore,
+  getZeroDevWallet,
+} from "@zerodev/wallet-react";
 import { SignatureRequest } from "@zerodev/wallet-react-kit";
 import {
+  ArrowRight,
+  AlertTriangle,
   Check,
   Copy,
-  FileSignature,
+  Coins,
+  Component,
+  ChevronDown,
+  ExternalLink,
   Fuel,
+  ImageIcon,
   Key,
   Loader2,
   LogOut,
-  Send,
+  Settings,
+  ShieldCheck,
   Upload,
-  Wallet
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import { Address, formatEther, isAddress } from "viem";
-import { useAccount, useDisconnect, usePublicClient } from "wagmi";
+import { Address, formatEther, formatUnits, isAddress, zeroAddress } from "viem";
+import { useAccount, useConfig, useDisconnect, usePublicClient } from "wagmi";
 import { ChainSelector } from "../components/ChainSelector";
 import { ExportPrivateKeyModal } from "../components/ExportPrivateKeyModal";
 import { ExportWalletModal } from "../components/ExportWalletModal";
 import { LogoutOverlay } from "../components/LogoutOverlay";
 import { SendTransactionTest } from "../components/SendTransactionTest";
 import { SigningTest } from "../components/SigningTest";
-import { submitToHubSpot } from "../lib/hubspot";
 import { cn } from "../lib/utils";
 
 export const dynamic = 'force-dynamic';
 
-type ActiveTab = "signing" | "transaction";
+type ExperienceId =
+  | "transact"
+  | "stables"
+  | "sign"
+  | "export"
+  | "customize";
 
-const tabs = [
-  { id: "signing" as const, name: "Sign Message", icon: FileSignature },
-  { id: "transaction" as const, name: "Send Transaction", icon: Send },
+const experiences = [
+  {
+    id: "transact" as const,
+    title: "Mint without gas",
+    description: "Mint an NFT even when the wallet holds no native ETH.",
+    icon: Fuel,
+  },
+  {
+    id: "stables" as const,
+    title: "Use stables without gas",
+    description: "Let users operate with stablecoins instead of requiring native gas.",
+    icon: Coins,
+  },
+  {
+    id: "sign" as const,
+    title: "Sign anything",
+    description: "Review and sign messages, typed data, and app requests.",
+    icon: ShieldCheck,
+  },
+  {
+    id: "export" as const,
+    title: "Own and export keys",
+    description: "Show that the wallet is non-custodial and user-owned.",
+    icon: Key,
+  },
+  {
+    id: "customize" as const,
+    title: "Customize the flow",
+    description: "Start with prebuilt UI, then progressively replace every surface.",
+    icon: Component,
+  },
 ];
+
+const usdcContracts: Record<number, Address> = {
+  421614: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
+  11155111: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+};
+
+const erc20BalanceAbi = [
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "balance", type: "uint256" }],
+  },
+] as const;
+
+const tokenMetadata = {
+  eth: {
+    name: "ETH",
+    icon: "https://cryptologos.cc/logos/ethereum-eth-logo.svg",
+  },
+  usdc: {
+    name: "USDC",
+    icon: "https://cryptologos.cc/logos/usd-coin-usdc-logo.svg",
+    faucet: "https://faucet.circle.com/",
+  },
+};
+
+const ethFaucets: Record<number, string> = {
+  421614: "https://faucet.triangleplatform.com/arbitrum/sepolia",
+  11155111: "https://faucet.triangleplatform.com/ethereum/sepolia",
+};
+
+function isUsableAddress(value: string | null | undefined): value is Address {
+  return Boolean(value && isAddress(value) && value.toLowerCase() !== zeroAddress)
+}
+
+function formatShortAddress(value: string) {
+  if (!isAddress(value)) return value;
+  return `${value.slice(0, 6)}...${value.slice(-4)}`;
+}
+
+async function deleteZeroDevIndexedDbState() {
+  if (typeof indexedDB === "undefined") return;
+
+  const indexedDbWithDatabases = indexedDB as IDBFactory & {
+    databases?: () => Promise<Array<{ name?: string }>>;
+  };
+  const databases = await indexedDbWithDatabases.databases?.();
+  if (!databases) return;
+
+  await Promise.all(
+    databases
+      .map((database) => database.name)
+      .filter((name): name is string => {
+        if (!name) return false;
+        const normalized = name.toLowerCase();
+        return normalized.includes("turnkey") || normalized.includes("zerodev");
+      })
+      .map(
+        (name) =>
+          new Promise<void>((resolve) => {
+            const request = indexedDB.deleteDatabase(name);
+            request.onsuccess = () => resolve();
+            request.onerror = () => resolve();
+            request.onblocked = () => resolve();
+          }),
+      ),
+  );
+}
+
+async function clearWalletBrowserState() {
+  if (typeof window === "undefined") return;
+
+  const storedSessionKeys = JSON.parse(
+    localStorage.getItem("@zerodev/sessions") || "[]",
+  ) as unknown;
+
+  const keysToRemove = [
+    "zerodev-wallet",
+    "zerodev:auth:otpSession",
+    "@zerodev/active_session",
+    "@zerodev/sessions",
+    "wagmi.store",
+    "wagmi.recentConnectorId",
+    "wagmi.connected",
+  ];
+
+  for (const key of keysToRemove) {
+    localStorage.removeItem(key);
+    sessionStorage.removeItem(key);
+  }
+
+  if (Array.isArray(storedSessionKeys)) {
+    for (const key of storedSessionKeys) {
+      if (typeof key === "string") localStorage.removeItem(key);
+    }
+  }
+
+  await deleteZeroDevIndexedDbState();
+}
 
 export default function DashboardPage() {
   const router = useRouter();
-  const [activeTab, setActiveTab] = useState<ActiveTab>("transaction");
+  const [activeExperience, setActiveExperience] =
+    useState<ExperienceId>("transact");
   const [balance, setBalance] = useState<string>("0");
+  const [usdcBalance, setUsdcBalance] = useState<string>("0");
+  const [nftCount, setNftCount] = useState(0);
   const [copied, setCopied] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
   const [showExportPrivateKeyModal, setShowExportPrivateKeyModal] = useState(false);
-  // Toggle for whether SignatureRequest is mounted. When mounted, the kit
-  // gates signing calls on user confirmation; when not, calls go through
-  // silently (background mode). Default off; persisted in localStorage.
+  const [walletLookupDebug, setWalletLookupDebug] = useState<string | null>(null);
   const [confirmationEnabled, setConfirmationEnabled] = useState<boolean>(() => {
     if (typeof window === "undefined") return false;
     return localStorage.getItem("zd:signingConfirmation") === "true";
   });
+
+  // Wagmi hooks
+  const { address, status, chain } = useAccount();
+  const wagmiConfig = useConfig();
+  const { disconnectAsync } = useDisconnect();
+  const publicClient = usePublicClient({ chainId: chain?.id });
+  const safeAddress = isUsableAddress(address) ? address : null;
 
   useEffect(() => {
     localStorage.setItem(
@@ -61,48 +211,100 @@ export default function DashboardPage() {
     );
   }, [confirmationEnabled]);
 
-  // Wagmi hooks
-  const { address, status, chain } = useAccount();
-  const { disconnectAsync } = useDisconnect();
-  const publicClient = usePublicClient({ chainId: chain?.id });
-  const { data: authenticatorData, isLoading: isAuthenticatorDataLoading } = useAuthenticators({})
-
-  useQuery(
-    {
-      queryKey: ["submitMarketingConsent", authenticatorData?.emailContacts?.[0]?.email],
-      queryFn: async () => {
-        const email = authenticatorData?.emailContacts?.[0]?.email
-        if (!email) {
-          return null;
-        }
-
-        await submitToHubSpot(email, true)
-        return true
-      },
-      enabled: !!authenticatorData?.emailContacts?.[0]?.email && !isAuthenticatorDataLoading,
-      staleTime: Infinity,
-      refetchOnMount: false,
-      refetchOnReconnect: false,
-      refetchOnWindowFocus: false,
-      retry: false,
-    }
-  )
-
   useEffect(() => {
     const loadBalance = async () => {
-      if (address && isAddress(address)) {
-        try {
-          if (!publicClient) return;
-          const balanceWei = await publicClient.getBalance({ address: address as Address });
-          setBalance(formatEther(balanceWei));
-        } catch (err) {
-          console.error("Dashboard: Failed to load balance:", err);
-          setBalance("0");
-        }
+      if (!safeAddress || !publicClient) {
+        setBalance("0");
+        return;
+      }
+
+      try {
+        const balanceWei = await publicClient.getBalance({ address: safeAddress });
+        setBalance(formatEther(balanceWei));
+      } catch (err) {
+        console.error("Dashboard: Failed to load balance:", err);
+        setBalance("0");
       }
     };
     loadBalance();
-  }, [address, chain, publicClient]);
+  }, [safeAddress, chain, publicClient]);
+
+  useEffect(() => {
+    if (status !== "connected" || safeAddress) {
+      setWalletLookupDebug(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const inspectWalletLookup = async () => {
+      try {
+        const connector = getZeroDevConnector(wagmiConfig);
+        const store = await getZeroDevStore(connector);
+        const wallet = getZeroDevWallet(store);
+        const session = await wallet.getSession();
+
+        if (!session) {
+          if (!cancelled) setWalletLookupDebug("No active ZeroDev session found.");
+          return;
+        }
+
+        const response = await wallet.client.getUserWallet({
+          organizationId: session.organizationId,
+          projectId: process.env.NEXT_PUBLIC_ZERODEV_PROJECT_ID!,
+          token: session.token,
+        });
+
+        if (!cancelled) {
+          setWalletLookupDebug(
+            `user-wallet returned: ${response.walletAddresses.join(", ") || "no wallet addresses"}`,
+          );
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setWalletLookupDebug(
+            err instanceof Error ? err.message : "Unable to inspect user-wallet lookup.",
+          );
+        }
+      }
+    };
+
+    inspectWalletLookup();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [safeAddress, status, wagmiConfig]);
+
+  useEffect(() => {
+    const loadUsdcBalance = async () => {
+      if (!safeAddress || !publicClient || !chain?.id) {
+        setUsdcBalance("0");
+        return;
+      }
+
+      const usdcAddress = usdcContracts[chain.id];
+      if (!usdcAddress) {
+        setUsdcBalance("0");
+        return;
+      }
+
+      try {
+        const rawBalance = await publicClient.readContract({
+          address: usdcAddress,
+          abi: erc20BalanceAbi,
+          functionName: "balanceOf",
+          args: [safeAddress],
+        });
+        setUsdcBalance(formatUnits(rawBalance, 6));
+      } catch (err) {
+        console.error("Dashboard: Failed to load USDC balance:", err);
+        setUsdcBalance("0");
+      }
+    };
+
+    loadUsdcBalance();
+  }, [safeAddress, chain, publicClient]);
 
   const handleCopy = async () => {
     if (!address) return;
@@ -121,6 +323,18 @@ export default function DashboardPage() {
       return;
     }
     router.push('/?logged_out=true');
+  };
+
+  const handleHardReset = async () => {
+    setLoggingOut(true);
+    localStorage.setItem("zd:loggedOut", "true");
+    try {
+      await disconnectAsync();
+    } catch {
+      // Still clear local SDK state if wagmi disconnect cannot complete.
+    }
+    await clearWalletBrowserState();
+    window.location.assign("/?logged_out=true");
   };
 
   // Redirect to login if disconnected (session expired)
@@ -142,7 +356,11 @@ export default function DashboardPage() {
   }, [status, hasConnected, router]);
 
   // Show loading while connecting or reconnecting
-  if (status === 'connecting' || status === 'reconnecting' || status === 'disconnected' || !address) {
+  if (
+    status === 'connecting' ||
+    status === 'reconnecting' ||
+    status === 'disconnected'
+  ) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="flex items-center gap-2">
@@ -155,136 +373,64 @@ export default function DashboardPage() {
     );
   }
 
+  const serviceIssue =
+    address && !safeAddress
+      ? walletLookupDebug ?? "Wallet lookup is temporarily unavailable."
+      : null;
+
   return (
     <>
       <LogoutOverlay visible={loggingOut}/>
       <ExportWalletModal isOpen={showExportModal} onClose={() => setShowExportModal(false)} />
       <ExportPrivateKeyModal isOpen={showExportPrivateKeyModal} onClose={() => setShowExportPrivateKeyModal(false)} />
       {confirmationEnabled && (
-        <SignatureRequest className='fixed inset-0 z-50 sm:absolute sm:inset-auto sm:right-2 sm:top-18 sm:w-[400px] sm:h-[600px]' />
+        <SignatureRequest className="fixed inset-0 z-50 sm:absolute sm:inset-auto sm:right-2 sm:top-18 sm:h-[600px] sm:w-[400px]" />
       )}
       <div className="min-h-screen bg-white animate-[dashboard-enter_360ms_ease-out_both]">
-        {/* Main Content */}
-        <div className="max-w-5xl mx-auto px-3 sm:px-6 lg:px-8 py-4 sm:py-8">
-          {/* Wallet Card */}
-          <div className="bg-white rounded-lg border border-gray-200 p-4 sm:p-6 lg:p-8 mb-4 sm:mb-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between mb-4">
-              <div className="flex items-center gap-2">
-                <Wallet className="h-5 w-5 text-gray-700" />
-                <div>
-                  <h1 className="text-lg font-semibold text-gray-900">Wallet created</h1>
-                  <p className="text-sm text-gray-500">
-                    Smart account ready for sponsored actions.
-                  </p>
-                </div>
+        {serviceIssue && (
+          <div className="border-b border-red-200 bg-red-50 text-red-950">
+            <div className="mx-auto flex min-h-10 max-w-7xl flex-col gap-2 px-3 py-2 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
+              <div className="flex min-w-0 items-center gap-2">
+                <AlertTriangle className="h-4 w-4 shrink-0 text-red-600" />
+                <p className="min-w-0 text-sm font-medium">
+                  Service outage: live wallet data is unavailable. Mock values
+                  are shown for now; come back later to try the full experience.
+                </p>
               </div>
-              <div className="flex flex-wrap items-center gap-2">
-                <ChainSelector />
-                <button
-                  onClick={() => setShowExportModal(true)}
-                  className={cn(
-                    "px-3 py-1.5 rounded-lg text-sm font-medium transition-all cursor-pointer",
-                    "border border-gray-200 text-gray-700 hover:bg-gray-50",
-                    "flex items-center gap-2"
-                  )}
-                  title="Export Seed Phrase"
-                >
-                  <Upload className="h-4 w-4" />
-                  <span className="hidden sm:inline">Seed Phrase</span>
-                </button>
-                <button
-                  onClick={() => setShowExportPrivateKeyModal(true)}
-                  className={cn(
-                    "px-3 py-1.5 rounded-lg text-sm font-medium transition-all cursor-pointer",
-                    "border border-gray-200 text-gray-700 hover:bg-gray-50",
-                    "flex items-center gap-2"
-                  )}
-                  title="Export Private Key"
-                >
-                  <Key className="h-4 w-4" />
-                  <span className="hidden sm:inline">Private Key</span>
-                </button>
-                <button
-                  onClick={handleLogout}
-                  disabled={loggingOut}
-                  className={cn(
-                    "px-3 py-1.5 rounded-lg text-sm font-medium transition-all cursor-pointer",
-                    "border border-gray-200 text-gray-700 hover:bg-gray-50",
-                    "flex items-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed"
-                  )}
-                  title="Logout"
-                >
-                  <LogOut className="h-4 w-4" />
-                  <span className="hidden sm:inline">Logout</span>
-                </button>
-              </div>
-            </div>
-            <div className="flex items-center gap-2 text-sm text-gray-600 mb-4">
-              <span className="font-mono text-xs sm:text-sm break-all">{address}</span>
               <button
-                onClick={handleCopy}
-                className="text-gray-400 hover:text-gray-600 shrink-0 cursor-pointer"
-                title="Copy address"
+                type="button"
+                onClick={handleLogout}
+                className="inline-flex h-7 shrink-0 items-center justify-center rounded-md border border-red-300 bg-white px-2.5 text-xs font-semibold text-red-950 transition-colors hover:bg-red-100"
               >
-                {copied ? (
-                  <Check className="h-3.5 w-3.5 text-green-600" />
-                ) : (
-                  <Copy className="h-3.5 w-3.5" />
-                )}
+                Logout
               </button>
             </div>
-            <div className="flex items-baseline gap-2">
-              <span className="text-3xl font-bold text-gray-900">{parseFloat(balance).toFixed(4)}</span>
-              <span className="text-lg text-gray-500 font-medium">ETH</span>
-            </div>
-            <p className="text-sm text-gray-500 mt-1">{chain?.name ?? 'Current network'}</p>
-            <label className="mt-3 flex items-center gap-2 cursor-pointer text-sm leading-none">
-              <input
-                type="checkbox"
-                checked={confirmationEnabled}
-                onChange={(e) => setConfirmationEnabled(e.target.checked)}
-                className="h-3 w-3 m-0"
-              />
-              <span className="text-gray-700">Show transaction review</span>
-            </label>
           </div>
+        )}
 
-          <GaslessTransactionIntro
-            chainName={chain?.name}
-            onTry={() => setActiveTab("transaction")}
+        {/* Main Content */}
+        <div className="max-w-7xl mx-auto px-3 sm:px-6 lg:px-8 py-4 sm:py-6">
+          <TryItExperience
+            address={safeAddress}
+            safeAddress={safeAddress}
+            activeExperience={activeExperience}
+            balance={balance}
+            chainId={chain?.id}
+            copied={copied}
+            isAddressLoading={false}
+            loggingOut={loggingOut}
+            confirmationEnabled={confirmationEnabled}
+            serviceIssue={serviceIssue}
+            nftCount={nftCount}
+            usdcBalance={usdcBalance}
+            onCopyAddress={handleCopy}
+            onSelect={setActiveExperience}
+            onExportPrivateKey={() => setShowExportPrivateKeyModal(true)}
+            onExportWallet={() => setShowExportModal(true)}
+            onLogout={handleLogout}
+            onNftCountChange={setNftCount}
+            onToggleConfirmation={setConfirmationEnabled}
           />
-
-          {/* Tabs */}
-          <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
-            <div className="border-b border-gray-200">
-              <nav className="flex">
-                {tabs.map((tab) => {
-                  const Icon = tab.icon;
-                  const isActive = activeTab === tab.id;
-                  return (
-                    <button
-                      key={tab.id}
-                      onClick={() => setActiveTab(tab.id)}
-                      className={cn(
-                        "flex-1 flex items-center justify-center gap-1.5 sm:gap-2 px-2 sm:px-4 py-2.5 sm:py-3 text-xs sm:text-sm font-medium transition-all duration-200 cursor-pointer",
-                        isActive
-                          ? "text-gray-900 underline decoration-2 decoration-blue-600 underline-offset-8"
-                          : "text-gray-500 hover:text-gray-700 hover:bg-gray-50"
-                      )}
-                    >
-                      <Icon className="h-4 w-4 shrink-0" />
-                      <span className="truncate">{tab.name}</span>
-                    </button>
-                  );
-                })}
-              </nav>
-            </div>
-
-            <div className="p-4 sm:p-6 lg:p-8">
-              {activeTab === "signing" && <SigningTest />}
-              {activeTab === "transaction" && <SendTransactionTest />}
-            </div>
-          </div>
         </div>
 
         {/* GitHub Footer */}
@@ -303,62 +449,512 @@ export default function DashboardPage() {
   );
 }
 
-function GaslessTransactionIntro({
-  chainName,
-  onTry,
+function TryItExperience({
+  address,
+  safeAddress,
+  activeExperience,
+  balance,
+  chainId,
+  copied,
+  confirmationEnabled,
+  isAddressLoading,
+  loggingOut,
+  onCopyAddress,
+  onSelect,
+  onExportPrivateKey,
+  onExportWallet,
+  onLogout,
+  onNftCountChange,
+  onToggleConfirmation,
+  serviceIssue,
+  nftCount,
+  usdcBalance,
 }: {
-  chainName?: string
-  onTry: () => void
+  address: Address | null
+  safeAddress: Address | null
+  activeExperience: ExperienceId
+  balance: string
+  chainId?: number
+  copied: boolean
+  confirmationEnabled: boolean
+  isAddressLoading: boolean
+  loggingOut: boolean
+  onCopyAddress: () => void
+  onSelect: (id: ExperienceId) => void
+  onExportPrivateKey: () => void
+  onExportWallet: () => void
+  onLogout: () => void
+  onNftCountChange: (count: number) => void
+  onToggleConfirmation: (enabled: boolean) => void
+  serviceIssue: string | null
+  nftCount: number
+  usdcBalance: string
 }) {
+  const [walletActionsOpen, setWalletActionsOpen] = useState(false)
+  const [walletSettingsOpen, setWalletSettingsOpen] = useState(false)
+  const liveWalletAvailable = Boolean(safeAddress)
+  const ethAmount = liveWalletAvailable ? parseFloat(balance).toFixed(4) : "0.0000"
+  const usdcAmount = liveWalletAvailable ? Number(usdcBalance).toFixed(2) : "0.00"
+  const ethFaucet = chainId ? ethFaucets[chainId] : undefined
+  const displayAddress =
+    address ??
+    (serviceIssue
+      ? zeroAddress
+      : isAddressLoading
+        ? "Resolving account..."
+        : "Address unavailable")
+  const visibleAddress = formatShortAddress(displayAddress)
+  const explorerAddress = address ?? (serviceIssue ? zeroAddress : null)
+
   return (
-    <section className="mb-4 overflow-hidden rounded-lg border border-gray-200 bg-white sm:mb-6">
-      <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_420px]">
-        <div className="p-4 sm:p-6 lg:p-8">
-          <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-blue-100 bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-600">
-            <Fuel className="h-3.5 w-3.5"/>
-            7702 smart account
-          </div>
-          <h1 className="max-w-xl text-2xl font-semibold tracking-tight text-gray-950 sm:text-3xl">
-            Try a gasless contract write
-          </h1>
-          <p className="mt-3 max-w-2xl text-sm leading-6 text-gray-600 sm:text-base sm:leading-7">
-            This embedded wallet is a 7702 smart account by default. Sponsor
-            gas for users so they can write to contracts on{' '}
-            {chainName ? `${chainName} ` : ''}without holding native ETH for
-            fees.
-          </p>
-          <div className="mt-5 flex flex-wrap items-center gap-3">
-            <button
-              type="button"
-              onClick={onTry}
-              className="inline-flex h-10 items-center rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white transition-colors hover:bg-gray-800 cursor-pointer"
-            >
-              Try it below
-            </button>
-            <span className="text-sm text-gray-500">
-              Uses the connected wallet you just created.
-            </span>
+    <div>
+      <section className="rounded-lg border border-gray-200 bg-white shadow-sm">
+        <div className="border-b border-gray-200 px-4 py-5 sm:px-6 lg:px-8">
+          <div className="space-y-4">
+            <h2 className="text-2xl font-semibold tracking-tight text-gray-950">
+              Wallet playground
+            </h2>
+            <div className="relative rounded-lg border border-gray-200 bg-gray-50/80 p-1.5">
+              <div className="flex flex-col gap-2 xl:flex-row xl:items-center xl:justify-between">
+                <div className="flex min-w-0 flex-1 flex-col gap-2 lg:flex-row lg:items-center">
+                  <div className="shrink-0">
+                    <ChainSelector />
+                  </div>
+                  <div className="flex h-10 min-w-0 flex-1 items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 lg:max-w-[360px]">
+                    <span className="text-xs font-medium text-gray-500">Address</span>
+                    <span className="min-w-0 flex-1 truncate font-mono text-sm text-gray-950">
+                      {visibleAddress}
+                    </span>
+                    {explorerAddress && (
+                      <button
+                        onClick={() => {
+                          if (address) {
+                            onCopyAddress()
+                            return
+                          }
+                          navigator.clipboard.writeText(displayAddress).catch(() => {})
+                        }}
+                        className="shrink-0 text-gray-400 transition-colors hover:text-gray-700 cursor-pointer"
+                        title="Copy address"
+                      >
+                        {copied ? (
+                          <Check className="h-3.5 w-3.5 text-green-600" />
+                        ) : (
+                          <Copy className="h-3.5 w-3.5" />
+                        )}
+                      </button>
+                    )}
+                    {explorerAddress && (
+                      <a
+                        href={`https://sepolia.arbiscan.io/address/${explorerAddress}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="shrink-0 text-gray-400 transition-colors hover:text-gray-700"
+                        title="View on Arbiscan"
+                      >
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </a>
+                    )}
+                  </div>
+                </div>
+                <div className="flex shrink-0 flex-wrap gap-2 xl:justify-end">
+                  <div className="relative">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setWalletActionsOpen((open) => !open)
+                        setWalletSettingsOpen(false)
+                      }}
+                      className="inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-800 transition-colors hover:bg-gray-100 cursor-pointer"
+                      aria-expanded={walletActionsOpen}
+                    >
+                      Actions
+                      <ChevronDown
+                        className={cn(
+                          "h-4 w-4 transition-transform",
+                          walletActionsOpen && "rotate-180",
+                        )}
+                      />
+                    </button>
+                    {walletActionsOpen && (
+                      <div className="absolute right-0 top-full z-20 mt-2 w-64 rounded-lg border border-gray-200 bg-white p-3 shadow-lg">
+                        <p className="text-xs font-medium text-gray-500">Wallet actions</p>
+                        <div className="mt-2 grid gap-2">
+                          <button
+                            type="button"
+                            onClick={onExportWallet}
+                            className="inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-800 transition-colors hover:bg-gray-100 cursor-pointer"
+                          >
+                            <Key className="h-4 w-4" />
+                            Export keys
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => onSelect("transact")}
+                            className="inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-800 transition-colors hover:bg-gray-100 cursor-pointer"
+                          >
+                            <Upload className="h-4 w-4 rotate-90" />
+                            Withdraw
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                  <div className="relative">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setWalletSettingsOpen((open) => !open)
+                        setWalletActionsOpen(false)
+                      }}
+                      className="inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-800 transition-colors hover:bg-gray-100 cursor-pointer"
+                      aria-expanded={walletSettingsOpen}
+                    >
+                      <Settings className="h-4 w-4" />
+                      Settings
+                      <ChevronDown
+                        className={cn(
+                          "h-4 w-4 transition-transform",
+                          walletSettingsOpen && "rotate-180",
+                        )}
+                      />
+                    </button>
+                    {walletSettingsOpen && (
+                      <div className="absolute right-0 top-full z-20 mt-2 w-80 rounded-lg border border-gray-200 bg-white p-3 shadow-lg">
+                        <label className="flex cursor-pointer items-start justify-between gap-4 rounded-lg border border-gray-200 bg-white p-3">
+                          <span>
+                            <span className="block text-sm font-semibold text-gray-950">
+                              Transaction confirmation
+                            </span>
+                            <span className="mt-1 block text-xs leading-5 text-gray-500">
+                              Show the review UI when wallet operations require signatures.
+                            </span>
+                          </span>
+                          <input
+                            type="checkbox"
+                            checked={confirmationEnabled}
+                            onChange={(event) => onToggleConfirmation(event.target.checked)}
+                            className="mt-1 h-4 w-4 shrink-0"
+                          />
+                        </label>
+                      </div>
+                    )}
+                  </div>
+                  <button
+                    onClick={onLogout}
+                    disabled={loggingOut}
+                    className={cn(
+                      "inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-red-200 bg-red-50 px-3 text-sm font-semibold text-red-700 transition-colors hover:bg-red-100 cursor-pointer",
+                      "disabled:cursor-not-allowed disabled:opacity-60",
+                    )}
+                    title="Logout"
+                  >
+                    <LogOut className="h-4 w-4" />
+                    Logout
+                  </button>
+                </div>
+              </div>
+              <div className="mt-2 flex min-w-0 flex-col gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 md:flex-row md:items-center">
+                <span className="shrink-0 text-xs font-medium text-gray-500">
+                  Assets
+                </span>
+                <div className="flex min-w-0 flex-1 flex-wrap gap-x-4 gap-y-2">
+                  <CompactWalletMetric
+                    faucet={ethFaucet ?? ethFaucets[421614]}
+                    icon={tokenMetadata.eth.icon}
+                    label="ETH"
+                    value={ethAmount}
+                    walletAddress={explorerAddress}
+                  />
+                  <CompactWalletMetric
+                    faucet={tokenMetadata.usdc.faucet}
+                    icon={tokenMetadata.usdc.icon}
+                    label="USDC"
+                    value={`$${usdcAmount}`}
+                    walletAddress={explorerAddress}
+                  />
+                  <CompactWalletMetric
+                    icon={null}
+                    label="NFTs"
+                    onClick={() => {
+                      onSelect("transact")
+                      requestAnimationFrame(() => {
+                        document
+                          .getElementById("minted-nfts")
+                          ?.scrollIntoView({ behavior: "smooth", block: "start" })
+                      })
+	                    }}
+	                    value={String(nftCount)}
+	                    walletAddress={explorerAddress}
+	                  />
+                </div>
+              </div>
+            </div>
           </div>
         </div>
-        <div className="border-t border-gray-200 bg-gray-950 p-4 sm:p-6 lg:border-l lg:border-t-0">
-          <div className="mb-3 flex items-center justify-between">
-            <p className="text-sm font-semibold text-white">Gasless write</p>
-            <span className="text-xs text-gray-500">React</span>
+
+        <div className="grid overflow-hidden rounded-b-lg lg:grid-cols-[320px_minmax(0,1fr)]">
+          <aside className="border-b border-gray-200 bg-gray-50 p-3 lg:border-b-0 lg:border-r">
+            <nav className="flex gap-2 overflow-x-auto lg:flex-col lg:overflow-visible">
+              {experiences.map((item) => {
+                const Icon = item.icon
+                const isActive = activeExperience === item.id
+
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    onClick={() => onSelect(item.id)}
+                    className={cn(
+                      "flex min-w-[230px] items-center gap-3 rounded-lg px-4 py-3 text-left transition-all duration-200 cursor-pointer lg:min-w-0",
+                      isActive
+                        ? "translate-x-0 bg-white text-gray-950 shadow-sm ring-1 ring-gray-200 lg:translate-x-1"
+                        : "text-gray-600 hover:bg-white hover:text-gray-950",
+                    )}
+                  >
+                    <Icon className="h-4 w-4 shrink-0" />
+                    <span className="text-sm font-semibold leading-6">
+                      {item.title}
+                    </span>
+                  </button>
+                )
+              })}
+            </nav>
+          </aside>
+
+          <div className="min-h-[560px] p-4 transition-[min-height] duration-300 sm:p-6 lg:p-8">
+            <div
+              key={activeExperience}
+              className="animate-[scenario-panel-enter_260ms_cubic-bezier(0.22,1,0.36,1)_both]"
+            >
+              <div className="mb-5">
+                <p className="max-w-2xl text-base leading-7 text-gray-600">
+                  {getScenarioCopy(activeExperience)}
+                </p>
+              </div>
+
+              <ScenarioPanel
+                accountAddress={safeAddress}
+                experience={activeExperience}
+                onNftCountChange={onNftCountChange}
+                onExportPrivateKey={onExportPrivateKey}
+                onExportWallet={onExportWallet}
+              />
+            </div>
           </div>
-          <pre className="overflow-x-auto text-sm leading-6 text-gray-100">
-            <code>{`import { useWriteContract } from 'wagmi'
+        </div>
+      </section>
+    </div>
+  )
+}
 
-const { writeContract } = useWriteContract()
+function getScenarioCopy(experience: ExperienceId) {
+  switch (experience) {
+    case "transact":
+      return "A user signs in, receives a smart wallet, and mints an NFT even if the wallet has no native ETH for gas.";
+    case "stables":
+      return "A user holds a stablecoin and can still complete an onchain action without first learning how to acquire native gas.";
+    case "sign":
+      return "A developer can use familiar wagmi signing hooks while the kit provides a review layer for messages and typed data.";
+    case "export":
+      return "The app can prove the wallet is user-owned by letting the user export the seed phrase or account private key.";
+    case "customize":
+      return "Teams can ship the prebuilt wallet UI first, then progressively replace auth and signing surfaces for enterprise flows.";
+  }
+}
 
-writeContract({
-  address: nftAddress,
-  abi,
-  functionName: 'mint',
-  args: [userAddress],
-})`}</code>
-          </pre>
+function CompactWalletMetric({
+  faucet,
+  icon,
+  label,
+  onClick,
+  value,
+  walletAddress,
+}: {
+  faucet?: string
+  icon: string | null
+  label: string
+  onClick?: () => void
+  value: string
+  walletAddress: Address | null
+}) {
+  const content = (
+    <>
+      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-gray-50">
+        {icon ? (
+          <img alt="" className="h-4 w-4" src={icon} />
+        ) : (
+          <ImageIcon className="h-4 w-4 text-gray-500" />
+        )}
+      </span>
+      <span className="text-xs font-medium text-gray-500">{label}</span>
+      <span className="whitespace-nowrap text-sm font-semibold text-gray-950">
+        {value}
+      </span>
+      {faucet && (
+        <a
+          href={faucet}
+          onClick={() => {
+            if (walletAddress) {
+              navigator.clipboard.writeText(walletAddress).catch(() => {})
+            }
+          }}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex shrink-0 items-center gap-1 rounded-md px-1 py-0.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
+          title={`${label} faucet`}
+        >
+          Faucet
+          <ExternalLink className="h-3 w-3" />
+        </a>
+      )}
+    </>
+  )
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex min-w-0 items-center gap-2 rounded-md px-1 py-0.5 text-left transition-colors hover:bg-gray-100 cursor-pointer"
+      >
+        {content}
+      </button>
+    )
+  }
+
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      {content}
+    </div>
+  )
+}
+
+function ScenarioPanel({
+  accountAddress,
+  experience,
+  onNftCountChange,
+  onExportPrivateKey,
+  onExportWallet,
+}: {
+  accountAddress: Address | null
+  experience: ExperienceId
+  onNftCountChange: (count: number) => void
+  onExportPrivateKey: () => void
+  onExportWallet: () => void
+}) {
+  if (experience === "transact") {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white p-4">
+        <SendTransactionTest
+          accountAddress={accountAddress}
+          onNftCountChange={onNftCountChange}
+        />
+      </div>
+    )
+  }
+
+  if (experience === "sign") {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white p-4">
+        <SigningTest accountAddress={accountAddress} />
+      </div>
+    )
+  }
+
+  if (experience === "export") {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+        <p className="text-sm font-semibold text-gray-950">
+          Let users prove ownership
+        </p>
+        <p className="mt-2 text-sm leading-6 text-gray-600">
+          Export is a trust moment: the wallet is embedded and easy to use,
+          but the user can still take their keys with them.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={onExportWallet}
+            className="inline-flex h-10 items-center gap-2 rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white transition-colors hover:bg-gray-800 cursor-pointer"
+          >
+            <Upload className="h-4 w-4" />
+            Export seed phrase
+          </button>
+          <button
+            type="button"
+            onClick={onExportPrivateKey}
+            className="inline-flex h-10 items-center gap-2 rounded-lg border border-gray-200 bg-white px-4 text-sm font-semibold text-gray-800 transition-colors hover:bg-gray-100 cursor-pointer"
+          >
+            <Key className="h-4 w-4" />
+            Export private key
+          </button>
         </div>
       </div>
-    </section>
+    )
+  }
+
+  if (experience === "customize") {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+        <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+          <div className="mb-4 flex items-center justify-between">
+            <p className="text-sm font-semibold text-gray-950">
+              Custom checkout auth
+            </p>
+            <span className="rounded-full bg-blue-50 px-2 py-1 text-xs font-medium text-blue-600">
+              White-label
+            </span>
+          </div>
+          <div className="space-y-3">
+            <div className="h-10 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-500">
+              user@company.com
+            </div>
+            <button className="flex h-10 w-full items-center justify-center rounded-lg bg-gray-950 text-sm font-semibold text-white">
+              Continue with smart wallet
+            </button>
+          </div>
+        </div>
+        <p className="mt-3 text-sm leading-6 text-gray-600">
+          The user experience can look native to the app while the wallet
+          stack stays integrated underneath.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+        <div className="rounded-lg border border-gray-200 bg-white p-4">
+          <p className="text-sm font-semibold text-gray-950">
+            Stablecoin checkout preview
+          </p>
+          <div className="mt-4 space-y-2 text-sm">
+            <MockRow label="User balance" value="25.00 USDC" />
+            <MockRow label="Native gas" value="0.0000 ETH" />
+            <MockRow label="User pays" value="12.00 USDC" />
+            <MockRow label="Gas experience" value="No ETH required" />
+          </div>
+          <button className="mt-4 inline-flex h-10 items-center gap-2 rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white">
+            Complete mock payment
+            <ArrowRight className="h-4 w-4" />
+          </button>
+        </div>
+        <p className="mt-3 text-xs leading-5 text-gray-500">
+          Mock scenario: wire this to a configured ERC-20 paymaster policy when
+          the stablecoin route is ready.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function MockRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-md bg-gray-50 px-3 py-2">
+      <span className="text-gray-500">{label}</span>
+      <span className="font-medium text-gray-950">{value}</span>
+    </div>
   )
 }

--- a/apps/zerodev-signer-demo/src/app/dashboard/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/dashboard/page.tsx
@@ -156,6 +156,10 @@ const tokenMetadata = {
     name: "ETH",
     icon: "https://cryptologos.cc/logos/ethereum-eth-logo.svg",
   },
+  uni: {
+    name: "Uniswap",
+    icon: "https://cryptologos.cc/logos/uniswap-uni-logo.svg",
+  },
   usdc: {
     name: "USDC",
     icon: "https://cryptologos.cc/logos/usd-coin-usdc-logo.svg",
@@ -1735,9 +1739,7 @@ function StableGasSwapTest({
                             {step.token === "usdc" ? (
                               <img alt="" className="h-5 w-5" src={tokenMetadata.usdc.icon} />
                             ) : step.token === "swap" ? (
-                              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-pink-500 text-[11px] font-black text-white">
-                                U
-                              </span>
+                              <img alt="" className="h-5 w-5" src={tokenMetadata.uni.icon} />
                             ) : (
                               <img alt="" className="h-5 w-5" src={tokenMetadata.eth.icon} />
                             )}
@@ -1757,11 +1759,6 @@ function StableGasSwapTest({
                             {executionMode === "batch" && (
                               <span className="ml-2 rounded-full bg-green-50 px-2 py-0.5 text-[10px] font-semibold uppercase text-green-700">
                                 Gas sponsored
-                              </span>
-                            )}
-                            {step.token === "swap" && (
-                              <span className="ml-2 rounded-full bg-pink-50 px-2 py-0.5 text-[10px] font-semibold uppercase text-pink-700">
-                                Uniswap
                               </span>
                             )}
                           </p>

--- a/apps/zerodev-signer-demo/src/app/dashboard/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/dashboard/page.tsx
@@ -8,7 +8,6 @@ import {
 } from "@zerodev/wallet-react";
 import { SignatureRequest } from "@zerodev/wallet-react-kit";
 import {
-  ArrowRight,
   AlertTriangle,
   Check,
   Copy,
@@ -21,13 +20,23 @@ import {
   Key,
   Loader2,
   LogOut,
+  RefreshCw,
   Settings,
   ShieldCheck,
   Upload,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import { Address, formatEther, formatUnits, isAddress, zeroAddress } from "viem";
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import {
+  Address,
+  encodeFunctionData,
+  formatEther,
+  formatUnits,
+  isAddress,
+  parseAbi,
+  parseUnits,
+  zeroAddress,
+} from "viem";
 import { useAccount, useConfig, useDisconnect, usePublicClient } from "wagmi";
 import { ChainSelector } from "../components/ChainSelector";
 import { ExportPrivateKeyModal } from "../components/ExportPrivateKeyModal";
@@ -80,7 +89,11 @@ const experiences = [
 ];
 
 const usdcContracts: Record<number, Address> = {
+  // Circle USDC on Arbitrum Sepolia.
+  // Source: https://developers.circle.com/stablecoins/usdc-contract-addresses
   421614: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
+  // Circle USDC on Ethereum Sepolia.
+  // Source: https://developers.circle.com/stablecoins/usdc-contract-addresses
   11155111: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
 };
 
@@ -94,6 +107,43 @@ const erc20BalanceAbi = [
   },
 ] as const;
 
+// Arbitrum Sepolia chain id from Arbitrum/Uniswap deployment references.
+// Source: https://developers.uniswap.org/docs/protocols/v3/deployments/v3-arbitrum-deployments
+const ARBITRUM_SEPOLIA_CHAIN_ID = 421614;
+
+// Uniswap v3 SwapRouter02 on Arbitrum Sepolia.
+// Source: https://developers.uniswap.org/docs/protocols/v3/deployments/v3-arbitrum-deployments
+const ARBITRUM_SEPOLIA_SWAP_ROUTER: Address = "0x101F443B4d1b059569D643917553c771E1b9663E";
+
+// WETH9 on Arbitrum Sepolia, used because Uniswap swaps ERC-20s; native ETH
+// requires a follow-up WETH.withdraw(...) unwrap.
+// Source: https://developers.uniswap.org/docs/protocols/v3/deployments/v3-arbitrum-deployments
+const ARBITRUM_SEPOLIA_WETH: Address = "0x980B62Da83eFf3D4576C647993b0c1D7faf17c73";
+
+// Circle's USDC/WETH 0.3% fee tier currently has liquidity on Arbitrum Sepolia.
+// Maintenance: if this route fails, re-check getPool(USDC, WETH, fee) on the
+// UniswapV3Factory and verify the returned pool has nonzero liquidity.
+// Factory source: https://developers.uniswap.org/docs/protocols/v3/deployments/v3-arbitrum-deployments
+const ARBITRUM_SEPOLIA_USDC_WETH_FEE = 3000;
+
+const usdcSwapAbi = parseAbi([
+  "function approve(address spender, uint256 amount) external returns (bool)",
+  "function allowance(address owner, address spender) external view returns (uint256)",
+]);
+
+const swapRouterAbi = parseAbi([
+  // SwapRouter02 uses IV3SwapRouter.ExactInputSingleParams, which does not
+  // include the legacy V3 SwapRouter `deadline` field.
+  // Source: https://github.com/Uniswap/swap-router-contracts/blob/main/contracts/interfaces/IV3SwapRouter.sol
+  "function exactInputSingle((address tokenIn,address tokenOut,uint24 fee,address recipient,uint256 amountIn,uint256 amountOutMinimum,uint160 sqrtPriceLimitX96) params) payable returns (uint256 amountOut)",
+  // Used to keep swap + unwrap atomic: swap WETH into the router, then unwrap
+  // and forward native ETH to the wallet inside the same router call.
+  // Source: https://github.com/Uniswap/swap-router-contracts/blob/main/contracts/interfaces/IMulticallExtended.sol
+  "function multicall(bytes[] data) payable returns (bytes[] results)",
+  // Source: https://github.com/Uniswap/swap-router-contracts/blob/main/contracts/interfaces/IPeripheryPaymentsWithFeeExtended.sol
+  "function unwrapWETH9(uint256 amountMinimum,address recipient) payable",
+]);
+
 const tokenMetadata = {
   eth: {
     name: "ETH",
@@ -102,22 +152,27 @@ const tokenMetadata = {
   usdc: {
     name: "USDC",
     icon: "https://cryptologos.cc/logos/usd-coin-usdc-logo.svg",
+    // Public Circle testnet faucet. No URL params are relied on here because
+    // the faucet UI does not document stable address/network prefill support.
+    // Source: https://faucet.circle.com/
     faucet: "https://faucet.circle.com/",
   },
 };
 
 const ethFaucets: Record<number, string> = {
-  421614: "https://faucet.triangleplatform.com/arbitrum/sepolia",
-  11155111: "https://faucet.triangleplatform.com/ethereum/sepolia",
+  // Paste-address native ETH faucet used for Arbitrum Sepolia test ETH.
+  // Maintenance: this intentionally uses Alchemy because Triangle was unreliable
+  // and QuickNode/Chainlink require wallet/social steps. Alchemy documents a
+  // wallet-address flow with no auth, but still applies eligibility checks.
+  // Source: https://www.alchemy.com/faucets/arbitrum-sepolia
+  421614: "https://www.alchemy.com/faucets/arbitrum-sepolia",
+  // Paste-address native ETH faucet used for Ethereum Sepolia test ETH.
+  // Source: https://www.alchemy.com/faucets/ethereum-sepolia
+  11155111: "https://www.alchemy.com/faucets/ethereum-sepolia",
 };
 
 function isUsableAddress(value: string | null | undefined): value is Address {
   return Boolean(value && isAddress(value) && value.toLowerCase() !== zeroAddress)
-}
-
-function formatShortAddress(value: string) {
-  if (!isAddress(value)) return value;
-  return `${value.slice(0, 6)}...${value.slice(-4)}`;
 }
 
 async function deleteZeroDevIndexedDbState() {
@@ -187,6 +242,9 @@ export default function DashboardPage() {
   const [balance, setBalance] = useState<string>("0");
   const [usdcBalance, setUsdcBalance] = useState<string>("0");
   const [nftCount, setNftCount] = useState(0);
+  const [assetsRefreshKey, setAssetsRefreshKey] = useState(0);
+  const [isRefreshingAssets, setIsRefreshingAssets] = useState(false);
+  const [nftFocusRequest, setNftFocusRequest] = useState(0);
   const [copied, setCopied] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
@@ -211,22 +269,19 @@ export default function DashboardPage() {
     );
   }, [confirmationEnabled]);
 
-  useEffect(() => {
-    const loadBalance = async () => {
-      if (!safeAddress || !publicClient) {
-        setBalance("0");
-        return;
-      }
+  const loadNativeBalance = useCallback(async () => {
+    if (!safeAddress || !publicClient) {
+      setBalance("0");
+      return;
+    }
 
-      try {
-        const balanceWei = await publicClient.getBalance({ address: safeAddress });
-        setBalance(formatEther(balanceWei));
-      } catch (err) {
-        console.error("Dashboard: Failed to load balance:", err);
-        setBalance("0");
-      }
-    };
-    loadBalance();
+    try {
+      const balanceWei = await publicClient.getBalance({ address: safeAddress });
+      setBalance(formatEther(balanceWei));
+    } catch (err) {
+      console.error("Dashboard: Failed to load balance:", err);
+      setBalance("0");
+    }
   }, [safeAddress, chain, publicClient]);
 
   useEffect(() => {
@@ -276,35 +331,53 @@ export default function DashboardPage() {
     };
   }, [safeAddress, status, wagmiConfig]);
 
-  useEffect(() => {
-    const loadUsdcBalance = async () => {
-      if (!safeAddress || !publicClient || !chain?.id) {
-        setUsdcBalance("0");
-        return;
-      }
+  const loadUsdcBalance = useCallback(async () => {
+    if (!safeAddress || !publicClient || !chain?.id) {
+      setUsdcBalance("0");
+      return;
+    }
 
-      const usdcAddress = usdcContracts[chain.id];
-      if (!usdcAddress) {
-        setUsdcBalance("0");
-        return;
-      }
+    const usdcAddress = usdcContracts[chain.id];
+    if (!usdcAddress) {
+      setUsdcBalance("0");
+      return;
+    }
 
-      try {
-        const rawBalance = await publicClient.readContract({
-          address: usdcAddress,
-          abi: erc20BalanceAbi,
-          functionName: "balanceOf",
-          args: [safeAddress],
-        });
-        setUsdcBalance(formatUnits(rawBalance, 6));
-      } catch (err) {
-        console.error("Dashboard: Failed to load USDC balance:", err);
-        setUsdcBalance("0");
-      }
-    };
-
-    loadUsdcBalance();
+    try {
+      const rawBalance = await publicClient.readContract({
+        address: usdcAddress,
+        abi: erc20BalanceAbi,
+        functionName: "balanceOf",
+        args: [safeAddress],
+      });
+      setUsdcBalance(formatUnits(rawBalance, 6));
+    } catch (err) {
+      console.error("Dashboard: Failed to load USDC balance:", err);
+      setUsdcBalance("0");
+    }
   }, [safeAddress, chain, publicClient]);
+
+  const refreshAssets = useCallback(async () => {
+    setIsRefreshingAssets(true);
+    setAssetsRefreshKey((key) => key + 1);
+    try {
+      await Promise.all([loadNativeBalance(), loadUsdcBalance()]);
+    } finally {
+      setIsRefreshingAssets(false);
+    }
+  }, [loadNativeBalance, loadUsdcBalance]);
+
+  useEffect(() => {
+    refreshAssets();
+  }, [refreshAssets]);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      refreshAssets();
+    }, 10000);
+
+    return () => window.clearInterval(interval);
+  }, [refreshAssets]);
 
   const handleCopy = async () => {
     if (!address) return;
@@ -340,20 +413,70 @@ export default function DashboardPage() {
   // Redirect to login if disconnected (session expired)
   // Use a delay to avoid redirecting during initial reconnection
   const [hasConnected, setHasConnected] = useState(false);
+  const [reconnectTimedOut, setReconnectTimedOut] = useState(false);
+  const [showLoadingRecovery, setShowLoadingRecovery] = useState(false);
   useEffect(() => {
     if (status === 'connected') {
       setHasConnected(true);
+      setReconnectTimedOut(false);
+      setShowLoadingRecovery(false);
     }
   }, [status]);
   useEffect(() => {
-    if (status === 'disconnected' && hasConnected) {
+    if (status !== 'disconnected') return;
+
+    const timeout = window.setTimeout(() => {
       if (localStorage.getItem('zd:loggedOut') === 'true') {
         router.push("/?logged_out=true");
         return;
       }
-      router.push("/?session_expired=true");
-    }
+      router.push(hasConnected ? "/?session_expired=true" : "/");
+    }, 1200);
+
+    return () => window.clearTimeout(timeout);
   }, [status, hasConnected, router]);
+
+  useEffect(() => {
+    if (status !== 'reconnecting' && status !== 'connecting') {
+      setReconnectTimedOut(false);
+      setShowLoadingRecovery(false);
+      return;
+    }
+
+    const recoveryTimeout = window.setTimeout(() => {
+      setShowLoadingRecovery(true);
+    }, 3500);
+    const timeout = window.setTimeout(() => {
+      setReconnectTimedOut(true);
+    }, 8000);
+
+    return () => {
+      window.clearTimeout(recoveryTimeout);
+      window.clearTimeout(timeout);
+    };
+  }, [status]);
+
+  if (reconnectTimedOut) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+        <div className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-6 text-center shadow-sm">
+          <p className="text-lg font-semibold text-gray-950">
+            Wallet session needs a refresh
+          </p>
+          <p className="mt-2 text-sm leading-6 text-gray-600">
+            The wallet did not finish reconnecting. Reset the session and sign in again.
+          </p>
+          <button
+            type="button"
+            onClick={handleHardReset}
+            className="mt-5 inline-flex h-10 items-center justify-center rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white transition-colors hover:bg-gray-800"
+          >
+            Reset session
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   // Show loading while connecting or reconnecting
   if (
@@ -363,11 +486,30 @@ export default function DashboardPage() {
   ) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="flex items-center gap-2">
-          <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
-          <span className="text-sm text-gray-600">
-            {status === 'reconnecting' ? 'Reconnecting...' : 'Loading wallet...'}
-          </span>
+        <div className="flex max-w-md flex-col items-center gap-3 px-4 text-center">
+          <div className="flex items-center gap-2">
+            <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
+            <span className="text-sm text-gray-600">
+              {status === 'reconnecting' ? 'Reconnecting...' : 'Loading wallet...'}
+            </span>
+          </div>
+          {showLoadingRecovery && (
+            <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+              <p className="text-sm font-medium text-gray-950">
+                Taking longer than expected?
+              </p>
+              <p className="mt-1 text-xs leading-5 text-gray-600">
+                Reset the local wallet session and sign in again.
+              </p>
+              <button
+                type="button"
+                onClick={handleHardReset}
+                className="mt-3 inline-flex h-9 items-center justify-center rounded-lg bg-gray-950 px-3 text-xs font-semibold text-white transition-colors hover:bg-gray-800"
+              >
+                Reset session
+              </button>
+            </div>
+          )}
         </div>
       </div>
     );
@@ -384,7 +526,7 @@ export default function DashboardPage() {
       <ExportWalletModal isOpen={showExportModal} onClose={() => setShowExportModal(false)} />
       <ExportPrivateKeyModal isOpen={showExportPrivateKeyModal} onClose={() => setShowExportPrivateKeyModal(false)} />
       {confirmationEnabled && (
-        <SignatureRequest className="fixed inset-0 z-50 sm:absolute sm:inset-auto sm:right-2 sm:top-18 sm:h-[600px] sm:w-[400px]" />
+        <SignatureRequestOverlay />
       )}
       <div className="min-h-screen bg-white animate-[dashboard-enter_360ms_ease-out_both]">
         {serviceIssue && (
@@ -421,6 +563,9 @@ export default function DashboardPage() {
             loggingOut={loggingOut}
             confirmationEnabled={confirmationEnabled}
             serviceIssue={serviceIssue}
+            assetsRefreshKey={assetsRefreshKey}
+            isRefreshingAssets={isRefreshingAssets}
+            nftFocusRequest={nftFocusRequest}
             nftCount={nftCount}
             usdcBalance={usdcBalance}
             onCopyAddress={handleCopy}
@@ -429,6 +574,8 @@ export default function DashboardPage() {
             onExportWallet={() => setShowExportModal(true)}
             onLogout={handleLogout}
             onNftCountChange={setNftCount}
+            onRefreshAssets={refreshAssets}
+            onRequestNftFocus={() => setNftFocusRequest((request) => request + 1)}
             onToggleConfirmation={setConfirmationEnabled}
           />
         </div>
@@ -449,6 +596,47 @@ export default function DashboardPage() {
   );
 }
 
+function SignatureRequestOverlay() {
+  return (
+    <SignatureRequest>
+      {({ pendingRequest, confirm, reject }) => {
+        if (!pendingRequest) return null;
+
+        return (
+          <SignatureRequestModal>
+            <SignatureRequest
+              request={pendingRequest}
+              onConfirm={confirm}
+              onReject={reject}
+              className="h-[min(720px,calc(100vh-48px))] w-full max-w-[430px] overflow-hidden rounded-[2rem] shadow-2xl"
+            />
+          </SignatureRequestModal>
+        );
+      }}
+    </SignatureRequest>
+  );
+}
+
+function SignatureRequestModal({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, []);
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center overflow-hidden bg-gray-950/55 px-4 py-6 backdrop-blur-sm">
+      <div className="absolute inset-0" aria-hidden="true" />
+      <div className="relative z-10 flex w-full justify-center">
+        {children}
+      </div>
+    </div>
+  );
+}
+
 function TryItExperience({
   address,
   safeAddress,
@@ -458,13 +646,18 @@ function TryItExperience({
   copied,
   confirmationEnabled,
   isAddressLoading,
+  assetsRefreshKey,
+  isRefreshingAssets,
   loggingOut,
+  nftFocusRequest,
   onCopyAddress,
   onSelect,
   onExportPrivateKey,
   onExportWallet,
   onLogout,
   onNftCountChange,
+  onRefreshAssets,
+  onRequestNftFocus,
   onToggleConfirmation,
   serviceIssue,
   nftCount,
@@ -478,13 +671,18 @@ function TryItExperience({
   copied: boolean
   confirmationEnabled: boolean
   isAddressLoading: boolean
+  assetsRefreshKey: number
+  isRefreshingAssets: boolean
   loggingOut: boolean
+  nftFocusRequest: number
   onCopyAddress: () => void
   onSelect: (id: ExperienceId) => void
   onExportPrivateKey: () => void
   onExportWallet: () => void
   onLogout: () => void
   onNftCountChange: (count: number) => void
+  onRefreshAssets: () => void
+  onRequestNftFocus: () => void
   onToggleConfirmation: (enabled: boolean) => void
   serviceIssue: string | null
   nftCount: number
@@ -503,27 +701,26 @@ function TryItExperience({
       : isAddressLoading
         ? "Resolving account..."
         : "Address unavailable")
-  const visibleAddress = formatShortAddress(displayAddress)
   const explorerAddress = address ?? (serviceIssue ? zeroAddress : null)
 
   return (
     <div>
-      <section className="rounded-lg border border-gray-200 bg-white shadow-sm">
-        <div className="border-b border-gray-200 px-4 py-5 sm:px-6 lg:px-8">
-          <div className="space-y-4">
+      <section className="overflow-hidden rounded-xl border border-white/70 bg-white/75 shadow-[0_18px_50px_rgba(15,23,42,0.08)] backdrop-blur-xl">
+        <div className="bg-white/55 px-4 pt-5 sm:px-6 lg:px-8">
+          <div className="space-y-3">
             <h2 className="text-2xl font-semibold tracking-tight text-gray-950">
               Wallet playground
             </h2>
-            <div className="relative rounded-lg border border-gray-200 bg-gray-50/80 p-1.5">
+            <div className="relative bg-gray-50/80 p-1.5">
               <div className="flex flex-col gap-2 xl:flex-row xl:items-center xl:justify-between">
                 <div className="flex min-w-0 flex-1 flex-col gap-2 lg:flex-row lg:items-center">
                   <div className="shrink-0">
                     <ChainSelector />
                   </div>
-                  <div className="flex h-10 min-w-0 flex-1 items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 lg:max-w-[360px]">
-                    <span className="text-xs font-medium text-gray-500">Address</span>
-                    <span className="min-w-0 flex-1 truncate font-mono text-sm text-gray-950">
-                      {visibleAddress}
+	                  <div className="flex h-10 w-fit max-w-full items-center gap-2 rounded-lg border border-gray-200 bg-white px-3">
+	                    <span className="text-xs font-medium text-gray-500">Address</span>
+	                    <span className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-sm text-gray-950">
+	                      {displayAddress}
                     </span>
                     {explorerAddress && (
                       <button
@@ -654,11 +851,32 @@ function TryItExperience({
                   </button>
                 </div>
               </div>
-              <div className="mt-2 flex min-w-0 flex-col gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 md:flex-row md:items-center">
-                <span className="shrink-0 text-xs font-medium text-gray-500">
-                  Assets
-                </span>
-                <div className="flex min-w-0 flex-1 flex-wrap gap-x-4 gap-y-2">
+              <div className="mt-2 flex min-w-0 flex-col gap-2 px-1 pb-1 md:flex-row md:items-center">
+                <div className="flex shrink-0 items-center gap-2">
+                  <span className="text-xs font-medium text-gray-500">
+                    Assets
+                  </span>
+                  <div className="group/refresh relative">
+                    <button
+                      type="button"
+                      onClick={onRefreshAssets}
+                      disabled={isRefreshingAssets}
+                      className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-60"
+                      aria-label="Refresh balances"
+                    >
+                      <RefreshCw
+                        className={cn(
+                          "h-3.5 w-3.5",
+                          isRefreshingAssets && "animate-spin",
+                        )}
+                      />
+                    </button>
+                    <span className="pointer-events-none absolute left-1/2 top-full z-20 mt-2 hidden -translate-x-1/2 whitespace-nowrap rounded-md border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm group-hover/refresh:block group-focus-within/refresh:block">
+                      Refresh balances
+                    </span>
+                  </div>
+                </div>
+                <div className="flex min-w-0 flex-1 flex-wrap gap-x-5 gap-y-2">
                   <CompactWalletMetric
                     faucet={ethFaucet ?? ethFaucets[421614]}
                     icon={tokenMetadata.eth.icon}
@@ -678,11 +896,7 @@ function TryItExperience({
                     label="NFTs"
                     onClick={() => {
                       onSelect("transact")
-                      requestAnimationFrame(() => {
-                        document
-                          .getElementById("minted-nfts")
-                          ?.scrollIntoView({ behavior: "smooth", block: "start" })
-                      })
+                      onRequestNftFocus()
 	                    }}
 	                    value={String(nftCount)}
 	                    walletAddress={explorerAddress}
@@ -693,9 +907,9 @@ function TryItExperience({
           </div>
         </div>
 
-        <div className="grid overflow-hidden rounded-b-lg lg:grid-cols-[320px_minmax(0,1fr)]">
-          <aside className="border-b border-gray-200 bg-gray-50 p-3 lg:border-b-0 lg:border-r">
-            <nav className="flex gap-2 overflow-x-auto lg:flex-col lg:overflow-visible">
+        <div className="mt-3 grid overflow-hidden bg-white/35 lg:grid-cols-[320px_minmax(0,1fr)]">
+          <aside className="bg-gray-50/60 p-3 lg:bg-transparent lg:p-0">
+            <nav className="flex gap-2 overflow-x-auto lg:flex-col lg:gap-1 lg:overflow-visible">
               {experiences.map((item) => {
                 const Icon = item.icon
                 const isActive = activeExperience === item.id
@@ -706,10 +920,10 @@ function TryItExperience({
                     type="button"
                     onClick={() => onSelect(item.id)}
                     className={cn(
-                      "flex min-w-[230px] items-center gap-3 rounded-lg px-4 py-3 text-left transition-all duration-200 cursor-pointer lg:min-w-0",
+                      "flex min-w-[230px] items-center gap-3 rounded-xl px-4 py-3 text-left transition-[background-color,box-shadow,color] duration-150 cursor-pointer lg:min-w-0 lg:min-h-16",
                       isActive
-                        ? "translate-x-0 bg-white text-gray-950 shadow-sm ring-1 ring-gray-200 lg:translate-x-1"
-                        : "text-gray-600 hover:bg-white hover:text-gray-950",
+                        ? "liquid-use-case-tab text-gray-950 lg:-mr-3 lg:rounded-l-none lg:rounded-r-none lg:px-6"
+                        : "text-gray-600 hover:bg-white/55 hover:text-gray-950 lg:rounded-none lg:px-6",
                     )}
                   >
                     <Icon className="h-4 w-4 shrink-0" />
@@ -722,24 +936,28 @@ function TryItExperience({
             </nav>
           </aside>
 
-          <div className="min-h-[560px] p-4 transition-[min-height] duration-300 sm:p-6 lg:p-8">
+          <div className="liquid-content-pane min-h-[560px] rounded-tl-xl p-4 transition-[min-height] duration-300 sm:p-6 lg:px-8 lg:pb-8 lg:pt-0">
             <div
               key={activeExperience}
-              className="animate-[scenario-panel-enter_260ms_cubic-bezier(0.22,1,0.36,1)_both]"
+              className="transition-opacity duration-150"
             >
-              <div className="mb-5">
+              <div className="mb-5 flex min-h-16 items-center">
                 <p className="max-w-2xl text-base leading-7 text-gray-600">
                   {getScenarioCopy(activeExperience)}
                 </p>
               </div>
 
-              <ScenarioPanel
-                accountAddress={safeAddress}
-                experience={activeExperience}
-                onNftCountChange={onNftCountChange}
-                onExportPrivateKey={onExportPrivateKey}
-                onExportWallet={onExportWallet}
-              />
+            <ScenarioPanel
+              accountAddress={safeAddress}
+              assetsRefreshKey={assetsRefreshKey}
+              chainId={chainId}
+              experience={activeExperience}
+              nftFocusRequest={nftFocusRequest}
+              onNftCountChange={onNftCountChange}
+              onRefreshAssets={onRefreshAssets}
+              onExportPrivateKey={onExportPrivateKey}
+              onExportWallet={onExportWallet}
+            />
             </div>
           </div>
         </div>
@@ -816,7 +1034,7 @@ function CompactWalletMetric({
       <button
         type="button"
         onClick={onClick}
-        className="flex min-w-0 items-center gap-2 rounded-md px-1 py-0.5 text-left transition-colors hover:bg-gray-100 cursor-pointer"
+        className="flex min-w-0 items-center gap-2 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-white cursor-pointer"
       >
         {content}
       </button>
@@ -824,22 +1042,752 @@ function CompactWalletMetric({
   }
 
   return (
-    <div className="flex min-w-0 items-center gap-2">
+    <div className="flex min-w-0 items-center gap-2 px-1.5 py-1">
       {content}
+    </div>
+  )
+}
+
+function formatShortTx(value: `0x${string}`) {
+  return `${value.slice(0, 6)}...${value.slice(-4)}`
+}
+
+function isTransactionHash(value: string): value is `0x${string}` {
+  return /^0x[a-fA-F0-9]{64}$/.test(value)
+}
+
+function toTransactionHash(value: unknown): `0x${string}` | null {
+  return typeof value === "string" && isTransactionHash(value) ? value : null
+}
+
+function getSwapErrorMessage(error: unknown) {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "Unable to complete the USDC to native ETH flow."
+
+  if (
+    message.includes("UserOperation reverted") ||
+    message.includes("paymaster") ||
+    message.includes("during simulation")
+  ) {
+    return "This batch was rejected during sponsorship simulation. The wallet can batch approval + swap, but the current gas policy needs to allow the Uniswap router and WETH unwrap calls."
+  }
+
+  if (message.toLowerCase().includes("insufficient")) {
+    return "You do not have enough USDC for this conversion."
+  }
+
+  if (message.toLowerCase().includes("user rejected")) {
+    return "Transaction confirmation was rejected."
+  }
+
+  return message
+}
+
+type StableGasReceipt = {
+  hash?: `0x${string}`
+  id?: string
+  label: string
+  simulatedStep?: boolean
+}
+
+type StableGasMode = "batch" | "manual"
+
+type StableGasStep = {
+  detail: string
+  label: string
+  token: "eth" | "swap" | "usdc"
+  threshold: number
+}
+
+const stableGasModes: Array<{
+  badge: string
+  label: string
+  mode: StableGasMode
+}> = [
+  { mode: "batch", label: "ZeroDev wallet", badge: "Recommended" },
+  { mode: "manual", label: "EOA wallet", badge: "Traditional" },
+]
+
+const stableGasSteps: StableGasStep[] = [
+  { label: "Fund gas", detail: "native ETH required", threshold: 25, token: "eth" },
+  { label: "Approve USDC", detail: "allow Uniswap to spend USDC", threshold: 50, token: "usdc" },
+  { label: "Swap to WETH", detail: "USDC -> WETH on Uniswap", threshold: 75, token: "swap" },
+  { label: "Unwrap to ETH", detail: "WETH -> native wallet ETH", threshold: 100, token: "eth" },
+]
+
+function StableGasSwapTest({
+  accountAddress,
+  chainId,
+  onRefreshAssets,
+}: {
+  accountAddress: Address | null
+  chainId?: number
+  onRefreshAssets: () => void
+}) {
+  const [amount, setAmount] = useState("1")
+  const [executionMode, setExecutionMode] = useState<StableGasMode>("batch")
+  const [status, setStatus] = useState<"idle" | "checking" | "swapping" | "complete">("idle")
+  const [error, setError] = useState("")
+  const [txs, setTxs] = useState<StableGasReceipt[]>([])
+  const [availableUsdc, setAvailableUsdc] = useState("0")
+  const [receivedEth, setReceivedEth] = useState<string | null>(null)
+  const [batchDurationMs, setBatchDurationMs] = useState<number | null>(null)
+  const [progressMessage, setProgressMessage] = useState("Ready")
+  const [activeCallIndex, setActiveCallIndex] = useState<number | null>(null)
+  const runVersionRef = useRef(0)
+  const publicClient = usePublicClient({ chainId })
+  const wagmiConfig = useConfig()
+
+  const isArbitrumSepolia = chainId === ARBITRUM_SEPOLIA_CHAIN_ID
+  const usdcAddress = usdcContracts[ARBITRUM_SEPOLIA_CHAIN_ID]
+  let amountIn = BigInt(0)
+  try {
+    amountIn = amount.trim() ? parseUnits(amount, 6) : BigInt(0)
+  } catch {
+    amountIn = BigInt(0)
+  }
+  const isRunning = status !== "idle" && status !== "complete"
+  const explorerBaseUrl = "https://sepolia.arbiscan.io"
+  const availableUsdcNumber = Math.max(0, Number(availableUsdc) || 0)
+  const maxUsdc = Math.max(1, Math.floor(availableUsdcNumber))
+
+  useEffect(() => {
+    if (!accountAddress || !publicClient || !isArbitrumSepolia) return
+
+    let cancelled = false
+    const loadAvailableUsdc = async () => {
+      try {
+        const balance = await publicClient.readContract({
+          address: usdcAddress,
+          abi: erc20BalanceAbi,
+          functionName: "balanceOf",
+          args: [accountAddress],
+        })
+        if (!cancelled) setAvailableUsdc(formatUnits(balance, 6))
+      } catch {
+        if (!cancelled) setAvailableUsdc("0")
+      }
+    }
+
+    loadAvailableUsdc()
+    return () => {
+      cancelled = true
+    }
+  }, [accountAddress, isArbitrumSepolia, publicClient, usdcAddress])
+
+  const updateAmount = (value: string) => {
+    const numeric = Number(value)
+    if (!Number.isFinite(numeric)) {
+      setAmount("1")
+      return
+    }
+    const clamped = Math.min(Math.max(numeric, 1), maxUsdc)
+    setAmount(String(clamped))
+  }
+
+  const getKernelClient = async () => {
+    const store = await getZeroDevStore(getZeroDevConnector(wagmiConfig))
+    const kernelClient = store
+      .getState()
+      .kernelClients.get(ARBITRUM_SEPOLIA_CHAIN_ID)
+    if (!kernelClient) {
+      throw new Error("Smart account client is not ready for Arbitrum Sepolia. Switch networks and try again.")
+    }
+    return kernelClient
+  }
+
+  const resetStableGasRun = () => {
+    runVersionRef.current += 1
+    setError("")
+    setTxs([])
+    setReceivedEth(null)
+    setBatchDurationMs(null)
+    setProgressMessage("Ready")
+    setStatus("idle")
+    setActiveCallIndex(null)
+  }
+
+  const completeSimulatedEoaStep = async (index: number, label: string) => {
+    const runVersion = runVersionRef.current + 1
+    runVersionRef.current = runVersion
+    setError("")
+    setStatus("swapping")
+    setActiveCallIndex(index)
+    setProgressMessage(index === 0 ? "Funding native gas" : `Signing ${label}`)
+
+    await new Promise((resolve) => window.setTimeout(resolve, 650))
+    if (runVersionRef.current !== runVersion) return
+    setTxs((current) => [
+      ...current,
+      {
+        id: `eoa-step-${index}`,
+        label,
+        simulatedStep: true,
+      },
+    ])
+    if (index === 3) {
+      setReceivedEth("0.0003")
+      setStatus("complete")
+      setProgressMessage("Native ETH received")
+    } else {
+      setStatus("idle")
+      setProgressMessage(index === 0 ? "Native gas funded" : `${label} signed`)
+    }
+    setActiveCallIndex(null)
+  }
+
+  const handleSwapToNativeEth = async () => {
+    if (!accountAddress || !publicClient || amountIn <= BigInt(0)) return
+
+    const runVersion = runVersionRef.current + 1
+    runVersionRef.current = runVersion
+    setError("")
+    setTxs([])
+    setReceivedEth(null)
+    setBatchDurationMs(null)
+    setProgressMessage("Checking USDC balance and allowance")
+    setStatus("checking")
+    setActiveCallIndex(0)
+
+    try {
+      const usdcBalance = await publicClient.readContract({
+        address: usdcAddress,
+        abi: erc20BalanceAbi,
+        functionName: "balanceOf",
+        args: [accountAddress],
+      })
+      if (runVersionRef.current !== runVersion) return
+      if (usdcBalance < amountIn) {
+        throw new Error(`You only have ${formatUnits(usdcBalance, 6)} USDC available.`)
+      }
+      setAvailableUsdc(formatUnits(usdcBalance, 6))
+
+      const allowance = await publicClient.readContract({
+        address: usdcAddress,
+        abi: usdcSwapAbi,
+        functionName: "allowance",
+        args: [accountAddress, ARBITRUM_SEPOLIA_SWAP_ROUTER],
+      })
+      if (runVersionRef.current !== runVersion) return
+      const ethBefore = await publicClient.getBalance({ address: accountAddress })
+      if (runVersionRef.current !== runVersion) return
+
+      setStatus("swapping")
+      setProgressMessage("Submitting sponsored smart-account batch")
+      setActiveCallIndex(1)
+      const calls: Array<{ to: Address; data: `0x${string}` }> = []
+      if (allowance < amountIn) {
+        calls.push({
+          to: usdcAddress,
+          data: encodeFunctionData({
+            abi: usdcSwapAbi,
+            functionName: "approve",
+            args: [ARBITRUM_SEPOLIA_SWAP_ROUTER, amountIn],
+          }),
+        })
+      }
+      const swapToRouterData = encodeFunctionData({
+        abi: swapRouterAbi,
+        functionName: "exactInputSingle",
+        args: [
+          {
+            tokenIn: usdcAddress,
+            tokenOut: ARBITRUM_SEPOLIA_WETH,
+            fee: ARBITRUM_SEPOLIA_USDC_WETH_FEE,
+            recipient: ARBITRUM_SEPOLIA_SWAP_ROUTER,
+            amountIn,
+            amountOutMinimum: BigInt(1),
+            sqrtPriceLimitX96: BigInt(0),
+          },
+        ],
+      })
+      const unwrapToWalletData = encodeFunctionData({
+        abi: swapRouterAbi,
+        functionName: "unwrapWETH9",
+        args: [BigInt(1), accountAddress],
+      })
+      calls.push({
+        to: ARBITRUM_SEPOLIA_SWAP_ROUTER,
+        data: encodeFunctionData({
+          abi: swapRouterAbi,
+          functionName: "multicall",
+          args: [[swapToRouterData, unwrapToWalletData]],
+        }),
+      })
+
+      const kernelClient = await getKernelClient()
+      if (runVersionRef.current !== runVersion) return
+      const submittedAt = performance.now()
+      const batchHash = toTransactionHash(
+        await kernelClient.sendTransaction({
+          calls: calls.map((call) => ({
+            ...call,
+            value: BigInt(0),
+          })),
+        }),
+      )
+      if (runVersionRef.current !== runVersion) return
+      if (!batchHash) {
+        throw new Error("The smart account did not return a transaction hash for the batched call.")
+      }
+      setTxs([
+        {
+          label: allowance < amountIn
+            ? "Atomic approval + swap + unwrap"
+            : "Atomic swap + unwrap",
+          hash: batchHash,
+        },
+      ])
+      setProgressMessage("Waiting for Arbiscan confirmation")
+      setActiveCallIndex(2)
+      await publicClient.waitForTransactionReceipt({ hash: batchHash })
+      if (runVersionRef.current !== runVersion) return
+      setBatchDurationMs(Math.max(0, Math.round(performance.now() - submittedAt)))
+      const ethAfter = await publicClient.getBalance({ address: accountAddress })
+      if (runVersionRef.current !== runVersion) return
+      if (ethAfter > ethBefore) {
+        setReceivedEth(formatEther(ethAfter - ethBefore))
+      }
+
+      setStatus("complete")
+      setProgressMessage("Native ETH received")
+      setActiveCallIndex(null)
+      onRefreshAssets()
+    } catch (err) {
+      setError(getSwapErrorMessage(err))
+      setProgressMessage("Ready")
+      setStatus("idle")
+      setActiveCallIndex(null)
+    }
+  }
+
+  const zeroDevProgress =
+    status === "complete" ? 100 : status === "swapping" ? 78 : status === "checking" ? 34 : 0
+  const visualProgress =
+    executionMode === "batch"
+      ? zeroDevProgress
+      : status === "complete"
+        ? 100
+        : activeCallIndex !== null
+          ? Math.min(92, activeCallIndex * 25 + 14)
+          : Math.min(100, txs.length * 25)
+  const manualStepHandlers = [
+    () => completeSimulatedEoaStep(0, "Native gas funding"),
+    () => completeSimulatedEoaStep(1, "USDC approval"),
+    () => completeSimulatedEoaStep(2, "USDC to WETH swap"),
+    () => completeSimulatedEoaStep(3, "WETH unwrap"),
+  ]
+  const flowLocked =
+    isRunning ||
+    (executionMode === "manual" &&
+      status !== "complete" &&
+      txs.length > 0)
+  const canResetStableGasRun = isRunning || txs.length > 0 || Boolean(error) || status === "complete"
+  const receivedEthDisplay = receivedEth
+    ? Number(receivedEth).toLocaleString(undefined, {
+        maximumSignificantDigits: 6,
+      })
+    : null
+  const batchDurationDisplay = batchDurationMs
+    ? `${(batchDurationMs / 1000).toFixed(batchDurationMs < 10000 ? 1 : 0)}s`
+    : null
+  const successReceiptHash = txs.find((tx) => tx.hash)?.hash
+  const getStepReceipt = (index: number) => {
+    if (executionMode === "batch") {
+      return txs[0] && (status === "complete" || index <= 2) ? txs[0] : undefined
+    }
+    return txs[index]
+  }
+  const getStepDetail = (index: number) => {
+    if (index === 0) {
+      return executionMode === "batch"
+        ? "Gas is sponsored by the ZeroDev policy."
+        : "EOA wallets need native ETH before the first transaction."
+    }
+    if (index === 1) return `Approve ${amount} USDC for the Uniswap router.`
+    if (index === 2) return `Swap ${amount} USDC through the USDC/WETH 0.3% pool.`
+    return "Unwrap WETH into native ETH in the wallet."
+  }
+  const renderAmountSlider = (disabled: boolean) => (
+    <div className="min-w-0 flex-1">
+      <input
+        type="range"
+        min="1"
+        max={maxUsdc}
+        step="1"
+        value={Math.min(Math.max(Number(amount) || 1, 1), maxUsdc)}
+        onChange={(event) => updateAmount(event.target.value)}
+        disabled={disabled}
+        className="w-full accent-gray-950 disabled:cursor-not-allowed disabled:opacity-50"
+      />
+      <div className="mt-1 flex items-center justify-between text-xs font-medium text-gray-500">
+        <span>1 USDC min</span>
+        <span>{disabled ? "amount locked" : `${maxUsdc} USDC max`}</span>
+      </div>
+    </div>
+  )
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="max-w-3xl text-sm leading-6 text-gray-600">
+          Convert USDC to native ETH for gas. ZeroDev can sponsor and batch the
+          route behind one signature.
+        </p>
+        <div className="flex min-w-full flex-wrap items-center justify-end gap-2 sm:min-w-fit">
+          <button
+            type="button"
+            onClick={resetStableGasRun}
+            disabled={!canResetStableGasRun}
+            className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-3 text-xs font-semibold text-gray-600 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+            Reset
+          </button>
+          <div className="grid min-w-full grid-cols-2 rounded-lg bg-gray-100 p-1 sm:min-w-[360px]">
+            {stableGasModes.map(({ badge, label, mode }) => (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => {
+                  if (flowLocked) return
+                  resetStableGasRun()
+                  setExecutionMode(mode)
+                }}
+                disabled={flowLocked}
+                className={cn(
+                  "flex min-h-11 flex-col items-center justify-center rounded-md px-3 text-xs font-semibold transition-colors",
+                  executionMode === mode && mode === "batch"
+                    ? "bg-green-50 text-green-800 shadow-sm ring-1 ring-green-200"
+                    : executionMode === mode
+                      ? "bg-white text-gray-950 shadow-sm"
+                      : "text-gray-500 hover:text-gray-800",
+                  flowLocked && "cursor-not-allowed opacity-60",
+                )}
+              >
+                <span>{label}</span>
+                <span
+                  className={cn(
+                    "mt-0.5 text-[10px] font-semibold uppercase tracking-wide",
+                    mode === "batch" ? "text-green-600" : "text-gray-400",
+                  )}
+                >
+                  {badge}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-lg border border-gray-200 bg-gray-50 p-3">
+        <label className="text-xs font-semibold uppercase text-gray-500">
+          {executionMode === "batch" ? "Convert" : "Route"}
+        </label>
+        <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="flex min-w-[130px] items-baseline justify-between gap-4 rounded-lg bg-white px-3 py-2">
+            <span className="text-2xl font-semibold tracking-tight text-gray-950">
+              {amount}
+            </span>
+            <span className="text-sm font-semibold text-gray-500">USDC</span>
+          </div>
+          {executionMode === "batch" ? renderAmountSlider(flowLocked) : (
+            <div className="mt-1 text-xs font-medium text-gray-500">
+              Pick the amount inside the approval and swap steps.
+            </div>
+          )}
+        </div>
+        <div className="mt-2 text-xs font-medium text-gray-500">
+          Route: {amount} USDC -&gt; WETH -&gt; ETH, 0.3% pool
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="text-xs font-semibold uppercase text-green-700">
+            {executionMode === "batch"
+              ? "ZeroDev smart wallet"
+              : "EOA embedded wallet"}
+          </p>
+          <span className="rounded-full bg-gray-50 px-2.5 py-1 text-xs font-semibold text-gray-500">
+            {executionMode === "batch" ? "1 signature" : "4 steps"}
+          </span>
+        </div>
+        <div className="mt-3 grid gap-2">
+              {stableGasSteps.map((step, index) => {
+                  const isDone =
+                    executionMode === "batch"
+                      ? zeroDevProgress >= step.threshold
+                      : txs.length > index || (status === "complete" && index === 3)
+                  const currentStep = stableGasSteps.find(
+                    (item) => visualProgress < item.threshold,
+                  )
+                  const canRunManualStep =
+                    executionMode === "manual" &&
+                    !isRunning &&
+                    !isDone &&
+                    txs.length === index
+                  const isNextManualStep =
+                    executionMode === "manual" &&
+                    status === "idle" &&
+                    txs.length === index
+                  const isCurrent =
+                    status !== "idle" &&
+                    status !== "complete" &&
+                    (executionMode === "batch"
+                      ? currentStep?.label === step.label
+                      : activeCallIndex === index)
+                  const isOpen = isCurrent || isDone || isNextManualStep
+                  const stepReceipt = getStepReceipt(index)
+                  const showStepAmountPicker =
+                    executionMode === "manual" &&
+                    (index === 1 || index === 2) &&
+                    (isNextManualStep || isCurrent)
+                  const isStepAmountLocked =
+                    isRunning ||
+                    status === "complete" ||
+                    (executionMode === "manual" && txs.length > 1)
+
+                  return (
+                    <div
+                      key={step.label}
+                      className={cn(
+                        "rounded-lg border border-gray-200 bg-white px-3 py-3 transition-all duration-500",
+                        isDone && "border-green-200 bg-green-50",
+                        isCurrent && "border-blue-200 bg-blue-50 shadow-sm",
+                      )}
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div className="flex min-w-0 items-center gap-2">
+                          <span
+                            className={cn(
+                              "relative flex h-8 w-8 items-center justify-center rounded-full bg-gray-100 text-gray-500",
+                              isDone && "bg-green-100 text-green-700",
+                              isCurrent && "bg-blue-100 text-blue-700",
+                            )}
+                          >
+                            {step.token === "usdc" ? (
+                              <img alt="" className="h-5 w-5" src={tokenMetadata.usdc.icon} />
+                            ) : step.token === "swap" ? (
+                              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-pink-500 text-[11px] font-black text-white">
+                                U
+                              </span>
+                            ) : (
+                              <img alt="" className="h-5 w-5" src={tokenMetadata.eth.icon} />
+                            )}
+                            {(isCurrent || isDone) && (
+                              <span className="absolute -bottom-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-white shadow-sm">
+                                {isCurrent ? (
+                                  <Loader2 className="h-3 w-3 animate-spin text-blue-700" />
+                                ) : (
+                                  <Check className="h-3 w-3 text-green-700" />
+                                )}
+                              </span>
+                            )}
+                          </span>
+                          <div className="min-w-0">
+                          <p className="truncate text-sm font-semibold text-gray-950">
+                            {step.label}
+                            {step.token === "swap" && (
+                              <span className="ml-2 rounded-full bg-pink-50 px-2 py-0.5 text-[10px] font-semibold uppercase text-pink-700">
+                                Uniswap
+                              </span>
+                            )}
+                          </p>
+                            <p className="truncate text-xs text-gray-500">
+                              {step.detail}
+                            </p>
+                          </div>
+                        </div>
+                        {executionMode === "manual" && (
+                          <button
+                            type="button"
+                            onClick={manualStepHandlers[index]}
+                            disabled={
+                              !accountAddress ||
+                              !isArbitrumSepolia ||
+                              (index !== 0 && availableUsdcNumber < 1) ||
+                              (index !== 0 && amountIn <= BigInt(0)) ||
+                              !canRunManualStep
+                            }
+                            className="inline-flex h-9 items-center justify-center rounded-lg bg-gray-950 px-3 text-xs font-semibold text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            {isCurrent
+                              ? index === 0
+                                ? "Checking..."
+                                : "Signing..."
+                              : index === 0
+                                ? "Check gas"
+                                : `Sign ${step.label}`}
+                          </button>
+                        )}
+                      </div>
+                      {isOpen && (
+                        <div className="mt-3 rounded-md bg-gray-50 px-3 py-2 text-xs text-gray-600">
+                          {showStepAmountPicker && (
+                            <div className="mb-3 rounded-md bg-white px-3 py-2">
+                              <div className="mb-2 flex items-baseline justify-between gap-3">
+                                <span className="text-xs font-semibold uppercase text-gray-500">
+                                  Amount
+                                </span>
+                                <span className="text-sm font-semibold text-gray-950">
+                                  {amount} USDC
+                                </span>
+                              </div>
+                              {renderAmountSlider(isStepAmountLocked)}
+                            </div>
+                          )}
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <span>{getStepDetail(index)}</span>
+                            {stepReceipt?.hash ? (
+                              <a
+                                href={`${explorerBaseUrl}/tx/${stepReceipt.hash}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-1 font-mono text-gray-500 transition-colors hover:text-gray-950"
+                              >
+                                {formatShortTx(stepReceipt.hash)}
+                                <ExternalLink className="h-3 w-3" />
+                              </a>
+                            ) : stepReceipt?.simulatedStep ? (
+                              <span className="rounded-full bg-white px-2 py-1 font-semibold text-green-700">
+                                complete
+                              </span>
+                            ) : isCurrent ? (
+                              <span className="font-semibold text-blue-700">
+                                {progressMessage}
+                              </span>
+                            ) : null}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )
+              })}
+            </div>
+          </div>
+
+          {status === "complete" && receivedEth && (
+            <div className="mt-4 rounded-lg border border-green-200 bg-green-50 px-4 py-3">
+              <div className="flex items-start gap-2">
+                <Check className="mt-0.5 h-4 w-4 shrink-0 text-green-600" />
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-green-900">
+                    ETH received
+                  </p>
+                  <p className="mt-1 text-sm text-green-700">
+                    {receivedEthDisplay} ETH added to this wallet
+                    {batchDurationDisplay ? ` in ${batchDurationDisplay}` : ""}.
+                  </p>
+                  {successReceiptHash && (
+                    <a
+                      href={`${explorerBaseUrl}/tx/${successReceiptHash}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-2 inline-flex items-center gap-1 font-mono text-xs font-semibold text-green-800 transition-colors hover:text-green-950"
+                    >
+                      View tx {formatShortTx(successReceiptHash)} on Arbiscan
+                      <ExternalLink className="h-3 w-3" />
+                    </a>
+                  )}
+                </div>
+              </div>
+              {executionMode === "manual" && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    resetStableGasRun()
+                    setExecutionMode("batch")
+                  }}
+                  className="mt-3 inline-flex h-9 items-center justify-center rounded-lg bg-green-700 px-3 text-xs font-semibold text-white transition-colors hover:bg-green-800"
+                >
+                  Try the one-click ZeroDev flow
+                </button>
+              )}
+            </div>
+          )}
+          {availableUsdcNumber < 1 && (
+            <a
+              href={tokenMetadata.usdc.faucet}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-blue-100 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-100"
+            >
+              Get test USDC
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          )}
+          {!isArbitrumSepolia && (
+            <div className="mt-3 rounded-lg border border-yellow-200 bg-yellow-50 px-3 py-2 text-sm text-yellow-800">
+              Switch to Arbitrum Sepolia to use this route.
+            </div>
+          )}
+          {error && (
+            <div className="mt-3 rounded-lg border border-red-100 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+          {executionMode === "batch" && (
+            <button
+              type="button"
+              onClick={handleSwapToNativeEth}
+              disabled={
+                !accountAddress ||
+                !isArbitrumSepolia ||
+                amountIn <= BigInt(0) ||
+                availableUsdcNumber < 1 ||
+                isRunning
+              }
+              className={cn(
+                "mt-4 flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white transition-colors hover:bg-gray-800",
+                "disabled:cursor-not-allowed disabled:opacity-50",
+              )}
+            >
+              {isRunning ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  {status === "checking" && "Checking USDC..."}
+                  {status === "swapping" && "Swapping and unwrapping..."}
+                </>
+              ) : status === "complete" ? (
+                <>
+                  <Check className="h-4 w-4" />
+                  Atomic route complete
+                </>
+              ) : (
+                <>
+                  <Coins className="h-4 w-4" />
+                  Run sponsored batch
+                </>
+              )}
+            </button>
+          )}
     </div>
   )
 }
 
 function ScenarioPanel({
   accountAddress,
+  assetsRefreshKey,
+  chainId,
   experience,
+  nftFocusRequest,
   onNftCountChange,
+  onRefreshAssets,
   onExportPrivateKey,
   onExportWallet,
 }: {
   accountAddress: Address | null
+  assetsRefreshKey: number
+  chainId?: number
   experience: ExperienceId
+  nftFocusRequest: number
   onNftCountChange: (count: number) => void
+  onRefreshAssets: () => void
   onExportPrivateKey: () => void
   onExportWallet: () => void
 }) {
@@ -848,6 +1796,8 @@ function ScenarioPanel({
       <div className="rounded-lg border border-gray-200 bg-white p-4">
         <SendTransactionTest
           accountAddress={accountAddress}
+          refreshKey={assetsRefreshKey}
+          nftFocusRequest={nftFocusRequest}
           onNftCountChange={onNftCountChange}
         />
       </div>
@@ -859,6 +1809,16 @@ function ScenarioPanel({
       <div className="rounded-lg border border-gray-200 bg-white p-4">
         <SigningTest accountAddress={accountAddress} />
       </div>
+    )
+  }
+
+  if (experience === "stables") {
+    return (
+      <StableGasSwapTest
+        accountAddress={accountAddress}
+        chainId={chainId}
+        onRefreshAssets={onRefreshAssets}
+      />
     )
   }
 
@@ -923,38 +1883,5 @@ function ScenarioPanel({
     )
   }
 
-  return (
-    <div className="space-y-4">
-      <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <p className="text-sm font-semibold text-gray-950">
-            Stablecoin checkout preview
-          </p>
-          <div className="mt-4 space-y-2 text-sm">
-            <MockRow label="User balance" value="25.00 USDC" />
-            <MockRow label="Native gas" value="0.0000 ETH" />
-            <MockRow label="User pays" value="12.00 USDC" />
-            <MockRow label="Gas experience" value="No ETH required" />
-          </div>
-          <button className="mt-4 inline-flex h-10 items-center gap-2 rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white">
-            Complete mock payment
-            <ArrowRight className="h-4 w-4" />
-          </button>
-        </div>
-        <p className="mt-3 text-xs leading-5 text-gray-500">
-          Mock scenario: wire this to a configured ERC-20 paymaster policy when
-          the stablecoin route is ready.
-        </p>
-      </div>
-    </div>
-  )
-}
-
-function MockRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex items-center justify-between gap-4 rounded-md bg-gray-50 px-3 py-2">
-      <span className="text-gray-500">{label}</span>
-      <span className="font-medium text-gray-950">{value}</span>
-    </div>
-  )
+  return null
 }

--- a/apps/zerodev-signer-demo/src/app/dashboard/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/dashboard/page.tsx
@@ -12,12 +12,12 @@ import {
   Check,
   Copy,
   Coins,
-  Component,
   ChevronDown,
   ExternalLink,
   Fuel,
   ImageIcon,
   Key,
+  KeyRound,
   Loader2,
   LogOut,
   RefreshCw,
@@ -46,7 +46,9 @@ import { ExportPrivateKeyModal } from "../components/ExportPrivateKeyModal";
 import { ExportWalletModal } from "../components/ExportWalletModal";
 import { LogoutOverlay } from "../components/LogoutOverlay";
 import { SendTransactionTest } from "../components/SendTransactionTest";
+import { FaucetLink } from "../components/FaucetLink";
 import { SigningTest } from "../components/SigningTest";
+import { TreasuryPermissionsTest } from "../components/TreasuryPermissionsTest";
 import { cn } from "../lib/utils";
 
 export const dynamic = 'force-dynamic';
@@ -54,9 +56,9 @@ export const dynamic = 'force-dynamic';
 type ExperienceId =
   | "transact"
   | "stables"
+  | "permissions"
   | "sign"
-  | "export"
-  | "customize";
+  | "export";
 
 const experiences = [
   {
@@ -72,6 +74,12 @@ const experiences = [
     icon: Coins,
   },
   {
+    id: "permissions" as const,
+    title: "Delegate a budget",
+    description: "Grant a scoped session key that can only spend a set amount of USDC to specific wallets.",
+    icon: KeyRound,
+  },
+  {
     id: "sign" as const,
     title: "Sign anything",
     description: "Review and sign messages, typed data, and app requests.",
@@ -82,12 +90,6 @@ const experiences = [
     title: "Own and export keys",
     description: "Show that the wallet is non-custodial and user-owned.",
     icon: Key,
-  },
-  {
-    id: "customize" as const,
-    title: "Customize the flow",
-    description: "Start with prebuilt UI, then progressively replace every surface.",
-    icon: Component,
   },
 ];
 
@@ -256,15 +258,15 @@ export default function DashboardPage() {
   const [assetsRefreshKey, setAssetsRefreshKey] = useState(0);
   const [isRefreshingAssets, setIsRefreshingAssets] = useState(false);
   const [nftFocusRequest, setNftFocusRequest] = useState(0);
+  const [sendFocusRequest, setSendFocusRequest] = useState(0);
+  const [sendFocusAsset, setSendFocusAsset] = useState<"usdc" | "eth">("usdc");
   const [copied, setCopied] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
   const [showExportPrivateKeyModal, setShowExportPrivateKeyModal] = useState(false);
   const [walletLookupDebug, setWalletLookupDebug] = useState<string | null>(null);
-  const [confirmationEnabled, setConfirmationEnabled] = useState<boolean>(() => {
-    if (typeof window === "undefined") return false;
-    return localStorage.getItem("zd:signingConfirmation") === "true";
-  });
+  const [confirmationEnabled, setConfirmationEnabled] = useState(false);
+  const skipConfirmationPersist = useRef(true);
 
   // Wagmi hooks
   const { address, status, chain } = useAccount();
@@ -274,6 +276,14 @@ export default function DashboardPage() {
   const safeAddress = isUsableAddress(address) ? address : null;
 
   useEffect(() => {
+    setConfirmationEnabled(localStorage.getItem("zd:signingConfirmation") === "true");
+  }, []);
+
+  useEffect(() => {
+    if (skipConfirmationPersist.current) {
+      skipConfirmationPersist.current = false;
+      return;
+    }
     localStorage.setItem(
       "zd:signingConfirmation",
       String(confirmationEnabled),
@@ -587,6 +597,12 @@ export default function DashboardPage() {
             onNftCountChange={setNftCount}
             onRefreshAssets={refreshAssets}
             onRequestNftFocus={() => setNftFocusRequest((request) => request + 1)}
+            sendFocusRequest={sendFocusRequest}
+            sendFocusAsset={sendFocusAsset}
+            onRequestSendFocus={(nextAsset) => {
+              setSendFocusAsset(nextAsset)
+              setSendFocusRequest((request) => request + 1)
+            }}
             onToggleConfirmation={setConfirmationEnabled}
           />
         </div>
@@ -669,6 +685,9 @@ function TryItExperience({
   onNftCountChange,
   onRefreshAssets,
   onRequestNftFocus,
+  sendFocusRequest,
+  sendFocusAsset,
+  onRequestSendFocus,
   onToggleConfirmation,
   serviceIssue,
   nftCount,
@@ -694,12 +713,14 @@ function TryItExperience({
   onNftCountChange: (count: number) => void
   onRefreshAssets: () => void
   onRequestNftFocus: () => void
+  sendFocusRequest: number
+  sendFocusAsset: "usdc" | "eth"
+  onRequestSendFocus: (asset: "usdc" | "eth") => void
   onToggleConfirmation: (enabled: boolean) => void
   serviceIssue: string | null
   nftCount: number
   usdcBalance: string
 }) {
-  const [walletActionsOpen, setWalletActionsOpen] = useState(false)
   const [walletSettingsOpen, setWalletSettingsOpen] = useState(false)
   const liveWalletAvailable = Boolean(safeAddress)
   const ethAmount = liveWalletAvailable ? parseFloat(balance).toFixed(4) : "0.0000"
@@ -769,52 +790,7 @@ function TryItExperience({
                   <div className="relative">
                     <button
                       type="button"
-                      onClick={() => {
-                        setWalletActionsOpen((open) => !open)
-                        setWalletSettingsOpen(false)
-                      }}
-                      className="inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-800 transition-colors hover:bg-gray-100 cursor-pointer"
-                      aria-expanded={walletActionsOpen}
-                    >
-                      Actions
-                      <ChevronDown
-                        className={cn(
-                          "h-4 w-4 transition-transform",
-                          walletActionsOpen && "rotate-180",
-                        )}
-                      />
-                    </button>
-                    {walletActionsOpen && (
-                      <div className="absolute right-0 top-full z-20 mt-2 w-64 rounded-lg border border-gray-200 bg-white p-3 shadow-lg">
-                        <p className="text-xs font-medium text-gray-500">Wallet actions</p>
-                        <div className="mt-2 grid gap-2">
-                          <button
-                            type="button"
-                            onClick={onExportWallet}
-                            className="inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-800 transition-colors hover:bg-gray-100 cursor-pointer"
-                          >
-                            <Key className="h-4 w-4" />
-                            Export keys
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => onSelect("transact")}
-                            className="inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-800 transition-colors hover:bg-gray-100 cursor-pointer"
-                          >
-                            <Upload className="h-4 w-4 rotate-90" />
-                            Withdraw
-                          </button>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                  <div className="relative">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setWalletSettingsOpen((open) => !open)
-                        setWalletActionsOpen(false)
-                      }}
+                      onClick={() => setWalletSettingsOpen((open) => !open)}
                       className="inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-800 transition-colors hover:bg-gray-100 cursor-pointer"
                       aria-expanded={walletSettingsOpen}
                     >
@@ -894,6 +870,10 @@ function TryItExperience({
                     label="ETH"
                     value={ethAmount}
                     walletAddress={explorerAddress}
+                    onClick={() => {
+                      onSelect("sign")
+                      onRequestSendFocus("eth")
+                    }}
                   />
                   <CompactWalletMetric
                     faucet={tokenMetadata.usdc.faucet}
@@ -901,6 +881,10 @@ function TryItExperience({
                     label="USDC"
                     value={`$${usdcAmount}`}
                     walletAddress={explorerAddress}
+                    onClick={() => {
+                      onSelect("sign")
+                      onRequestSendFocus("usdc")
+                    }}
                   />
                   <CompactWalletMetric
                     icon={null}
@@ -912,6 +896,11 @@ function TryItExperience({
 	                    value={String(nftCount)}
 	                    walletAddress={explorerAddress}
 	                  />
+                  <SessionKeyBadge
+                    chainId={chainId}
+                    owner={safeAddress}
+                    onClick={() => onSelect("permissions")}
+                  />
                 </div>
               </div>
             </div>
@@ -964,6 +953,8 @@ function TryItExperience({
               chainId={chainId}
               experience={activeExperience}
               nftFocusRequest={nftFocusRequest}
+              sendFocusRequest={sendFocusRequest}
+              sendFocusAsset={sendFocusAsset}
               onNftCountChange={onNftCountChange}
               onRefreshAssets={onRefreshAssets}
               onExportPrivateKey={onExportPrivateKey}
@@ -987,9 +978,114 @@ function getScenarioCopy(experience: ExperienceId) {
       return "A developer can use familiar wagmi signing hooks while the kit provides a review layer for messages and typed data.";
     case "export":
       return "The app can prove the wallet is user-owned by letting the user export the seed phrase or account private key.";
-    case "customize":
-      return "Teams can ship the prebuilt wallet UI first, then progressively replace auth and signing surfaces for enterprise flows.";
+    case "permissions":
+      return "A user grants a scoped, rate-limited session key that can spend a set amount of USDC to specific wallets — then the account enforces those limits on-chain.";
   }
+}
+
+type ActiveSessionKey = {
+  sessionAddress: string
+  amountEach: string
+  count: number
+  used: number
+  intervalSec: number
+  recipientCount: number
+}
+
+// Polls localStorage for an active (granted, non-exhausted) treasury session key
+// so the header can surface it. The permissions tab is the source of truth: it
+// writes on grant and removes on revoke/reset.
+function useActiveSessionKey(chainId?: number, owner?: Address | null) {
+  const [info, setInfo] = useState<ActiveSessionKey | null>(null)
+
+  useEffect(() => {
+    if (!chainId || !owner) {
+      setInfo(null)
+      return
+    }
+    const key = `zd:treasury-session:${chainId}:${owner.toLowerCase()}`
+    const read = () => {
+      try {
+        const raw = window.localStorage.getItem(key)
+        if (!raw) {
+          setInfo(null)
+          return
+        }
+        const g = JSON.parse(raw)
+        const used = g.used ?? 0
+        if (
+          !g ||
+          typeof g.sessionAddress !== "string" ||
+          typeof g.count !== "number" ||
+          used >= g.count
+        ) {
+          setInfo(null)
+          return
+        }
+        setInfo({
+          sessionAddress: g.sessionAddress,
+          amountEach: String(g.amountEach ?? "0"),
+          count: g.count,
+          used,
+          intervalSec: g.intervalSec ?? 0,
+          recipientCount: Array.isArray(g.recipients) ? g.recipients.length : 0,
+        })
+      } catch {
+        setInfo(null)
+      }
+    }
+    read()
+    const id = window.setInterval(read, 2500)
+    return () => window.clearInterval(id)
+  }, [chainId, owner])
+
+  return info
+}
+
+function SessionKeyBadge({
+  chainId,
+  owner,
+  onClick,
+}: {
+  chainId?: number
+  owner: Address | null
+  onClick: () => void
+}) {
+  const session = useActiveSessionKey(chainId, owner)
+  if (!session) return null
+
+  const remaining = Math.max(0, session.count - session.used)
+  return (
+    <div className="group/sk relative">
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex items-center gap-1.5 rounded-md border border-emerald-200 bg-emerald-50 px-2 py-1 text-xs font-medium text-emerald-800 transition-colors hover:bg-emerald-100 cursor-pointer"
+      >
+        <span className="relative flex h-2 w-2">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+        </span>
+        Session key active
+      </button>
+      <div className="pointer-events-none absolute left-0 top-full z-30 mt-2 hidden w-64 rounded-lg border border-gray-200 bg-white p-3 text-left shadow-lg group-hover/sk:block">
+        <p className="flex items-center gap-1.5 text-xs font-semibold text-gray-900">
+          <KeyRound className="h-3.5 w-3.5 text-gray-500" />
+          {formatShortTx(session.sessionAddress as `0x${string}`)}
+        </p>
+        <p className="mt-1.5 text-[11px] leading-4 text-gray-600">
+          A delegated key can spend up to{" "}
+          <strong>{session.amountEach} USDC</strong> per payout, to{" "}
+          <strong>{session.recipientCount}</strong> allow-listed wallet
+          {session.recipientCount === 1 ? "" : "s"}, every {session.intervalSec}s.
+        </p>
+        <p className="mt-1.5 text-[11px] font-medium text-gray-700">
+          {remaining} of {session.count} payouts remaining
+        </p>
+        <p className="mt-1.5 text-[11px] text-gray-400">Click to manage</p>
+      </div>
+    </div>
+  )
 }
 
 function CompactWalletMetric({
@@ -1021,34 +1117,38 @@ function CompactWalletMetric({
         {value}
       </span>
       {faucet && (
-        <a
-          href={faucet}
-          onClick={() => {
-            if (walletAddress) {
-              navigator.clipboard.writeText(walletAddress).catch(() => {})
-            }
-          }}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex shrink-0 items-center gap-1 rounded-md px-1 py-0.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
-          title={`${label} faucet`}
-        >
-          Faucet
-          <ExternalLink className="h-3 w-3" />
-        </a>
+        // Keep faucet clicks from triggering the metric's onClick navigation.
+        <span onClick={(e) => e.stopPropagation()}>
+          <FaucetLink
+            href={faucet}
+            address={walletAddress}
+            className="inline-flex shrink-0 items-center gap-1 rounded-md px-1 py-0.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer"
+          >
+            Faucet
+            <ExternalLink className="h-3 w-3" />
+          </FaucetLink>
+        </span>
       )}
     </>
   )
 
   if (onClick) {
+    // A div (not a button) so it can safely contain the faucet button.
     return (
-      <button
-        type="button"
+      <div
+        role="button"
+        tabIndex={0}
         onClick={onClick}
-        className="flex min-w-0 items-center gap-2 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-white cursor-pointer"
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault()
+            onClick()
+          }
+        }}
+        className="flex min-w-0 cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-white"
       >
         {content}
-      </button>
+      </div>
     )
   }
 
@@ -1875,15 +1975,14 @@ function StableGasSwapTest({
             </div>
           )}
           {availableUsdcNumber < 1 && (
-            <a
+            <FaucetLink
               href={tokenMetadata.usdc.faucet}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-blue-100 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-100"
+              address={accountAddress}
+              className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-blue-100 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-100 cursor-pointer"
             >
               Get test USDC
               <ExternalLink className="h-3.5 w-3.5" />
-            </a>
+            </FaucetLink>
           )}
           {!isArbitrumSepolia && (
             <div className="mt-3 rounded-lg border border-yellow-200 bg-yellow-50 px-3 py-2 text-sm text-yellow-800">
@@ -1940,6 +2039,8 @@ function ScenarioPanel({
   chainId,
   experience,
   nftFocusRequest,
+  sendFocusRequest,
+  sendFocusAsset,
   onNftCountChange,
   onRefreshAssets,
   onExportPrivateKey,
@@ -1950,6 +2051,8 @@ function ScenarioPanel({
   chainId?: number
   experience: ExperienceId
   nftFocusRequest: number
+  sendFocusRequest: number
+  sendFocusAsset: "usdc" | "eth"
   onNftCountChange: (count: number) => void
   onRefreshAssets: () => void
   onExportPrivateKey: () => void
@@ -1968,10 +2071,22 @@ function ScenarioPanel({
     )
   }
 
+  if (experience === "permissions") {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white p-4">
+        <TreasuryPermissionsTest accountAddress={accountAddress} />
+      </div>
+    )
+  }
+
   if (experience === "sign") {
     return (
       <div className="rounded-lg border border-gray-200 bg-white p-4">
-        <SigningTest accountAddress={accountAddress} />
+        <SigningTest
+          accountAddress={accountAddress}
+          sendFocusRequest={sendFocusRequest}
+          sendFocusAsset={sendFocusAsset}
+        />
       </div>
     )
   }
@@ -2014,35 +2129,6 @@ function ScenarioPanel({
             Export private key
           </button>
         </div>
-      </div>
-    )
-  }
-
-  if (experience === "customize") {
-    return (
-      <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
-        <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
-          <div className="mb-4 flex items-center justify-between">
-            <p className="text-sm font-semibold text-gray-950">
-              Custom checkout auth
-            </p>
-            <span className="rounded-full bg-blue-50 px-2 py-1 text-xs font-medium text-blue-600">
-              White-label
-            </span>
-          </div>
-          <div className="space-y-3">
-            <div className="h-10 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-500">
-              user@company.com
-            </div>
-            <button className="flex h-10 w-full items-center justify-center rounded-lg bg-gray-950 text-sm font-semibold text-white">
-              Continue with smart wallet
-            </button>
-          </div>
-        </div>
-        <p className="mt-3 text-sm leading-6 text-gray-600">
-          The user experience can look native to the app while the wallet
-          stack stays integrated underneath.
-        </p>
       </div>
     )
   }

--- a/apps/zerodev-signer-demo/src/app/dashboard/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/dashboard/page.tsx
@@ -8,8 +8,10 @@ import {
   Check,
   Copy,
   FileSignature,
+  Fuel,
   Key,
   Loader2,
+  LogOut,
   Send,
   Upload,
   Wallet
@@ -17,9 +19,11 @@ import {
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Address, formatEther, isAddress } from "viem";
-import { useAccount, usePublicClient } from "wagmi";
+import { useAccount, useDisconnect, usePublicClient } from "wagmi";
+import { ChainSelector } from "../components/ChainSelector";
 import { ExportPrivateKeyModal } from "../components/ExportPrivateKeyModal";
 import { ExportWalletModal } from "../components/ExportWalletModal";
+import { LogoutOverlay } from "../components/LogoutOverlay";
 import { SendTransactionTest } from "../components/SendTransactionTest";
 import { SigningTest } from "../components/SigningTest";
 import { submitToHubSpot } from "../lib/hubspot";
@@ -39,6 +43,7 @@ export default function DashboardPage() {
   const [activeTab, setActiveTab] = useState<ActiveTab>("transaction");
   const [balance, setBalance] = useState<string>("0");
   const [copied, setCopied] = useState(false);
+  const [loggingOut, setLoggingOut] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
   const [showExportPrivateKeyModal, setShowExportPrivateKeyModal] = useState(false);
   // Toggle for whether SignatureRequest is mounted. When mounted, the kit
@@ -58,6 +63,7 @@ export default function DashboardPage() {
 
   // Wagmi hooks
   const { address, status, chain } = useAccount();
+  const { disconnectAsync } = useDisconnect();
   const publicClient = usePublicClient({ chainId: chain?.id });
   const { data: authenticatorData, isLoading: isAuthenticatorDataLoading } = useAuthenticators({})
 
@@ -105,6 +111,18 @@ export default function DashboardPage() {
     setTimeout(() => setCopied(false), 2000);
   };
 
+  const handleLogout = async () => {
+    setLoggingOut(true);
+    localStorage.setItem('zd:loggedOut', 'true');
+    try {
+      await disconnectAsync();
+    } catch {
+      setLoggingOut(false);
+      return;
+    }
+    router.push('/?logged_out=true');
+  };
+
   // Redirect to login if disconnected (session expired)
   // Use a delay to avoid redirecting during initial reconnection
   const [hasConnected, setHasConnected] = useState(false);
@@ -139,6 +157,7 @@ export default function DashboardPage() {
 
   return (
     <>
+      <LogoutOverlay visible={loggingOut}/>
       <ExportWalletModal isOpen={showExportModal} onClose={() => setShowExportModal(false)} />
       <ExportPrivateKeyModal isOpen={showExportPrivateKeyModal} onClose={() => setShowExportPrivateKeyModal(false)} />
       {confirmationEnabled && (
@@ -149,12 +168,18 @@ export default function DashboardPage() {
         <div className="max-w-5xl mx-auto px-3 sm:px-6 lg:px-8 py-4 sm:py-8">
           {/* Wallet Card */}
           <div className="bg-white rounded-lg border border-gray-200 p-4 sm:p-6 lg:p-8 mb-4 sm:mb-6">
-            <div className="flex items-center justify-between mb-2">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between mb-4">
               <div className="flex items-center gap-2">
                 <Wallet className="h-5 w-5 text-gray-700" />
-                <h1 className="text-lg font-semibold text-gray-900">Default Wallet</h1>
+                <div>
+                  <h1 className="text-lg font-semibold text-gray-900">Wallet created</h1>
+                  <p className="text-sm text-gray-500">
+                    Smart account ready for sponsored actions.
+                  </p>
+                </div>
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <ChainSelector />
                 <button
                   onClick={() => setShowExportModal(true)}
                   className={cn(
@@ -179,6 +204,19 @@ export default function DashboardPage() {
                   <Key className="h-4 w-4" />
                   <span className="hidden sm:inline">Private Key</span>
                 </button>
+                <button
+                  onClick={handleLogout}
+                  disabled={loggingOut}
+                  className={cn(
+                    "px-3 py-1.5 rounded-lg text-sm font-medium transition-all cursor-pointer",
+                    "border border-gray-200 text-gray-700 hover:bg-gray-50",
+                    "flex items-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed"
+                  )}
+                  title="Logout"
+                >
+                  <LogOut className="h-4 w-4" />
+                  <span className="hidden sm:inline">Logout</span>
+                </button>
               </div>
             </div>
             <div className="flex items-center gap-2 text-sm text-gray-600 mb-4">
@@ -199,7 +237,7 @@ export default function DashboardPage() {
               <span className="text-3xl font-bold text-gray-900">{parseFloat(balance).toFixed(4)}</span>
               <span className="text-lg text-gray-500 font-medium">ETH</span>
             </div>
-            <p className="text-sm text-gray-500 mt-1">{chain?.name} Testnet</p>
+            <p className="text-sm text-gray-500 mt-1">{chain?.name ?? 'Current network'}</p>
             <label className="mt-3 flex items-center gap-2 cursor-pointer text-sm leading-none">
               <input
                 type="checkbox"
@@ -210,6 +248,11 @@ export default function DashboardPage() {
               <span className="text-gray-700">Show transaction review</span>
             </label>
           </div>
+
+          <GaslessTransactionIntro
+            chainName={chain?.name}
+            onTry={() => setActiveTab("transaction")}
+          />
 
           {/* Tabs */}
           <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
@@ -258,4 +301,64 @@ export default function DashboardPage() {
       </div>
     </>
   );
+}
+
+function GaslessTransactionIntro({
+  chainName,
+  onTry,
+}: {
+  chainName?: string
+  onTry: () => void
+}) {
+  return (
+    <section className="mb-4 overflow-hidden rounded-lg border border-gray-200 bg-white sm:mb-6">
+      <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_420px]">
+        <div className="p-4 sm:p-6 lg:p-8">
+          <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-blue-100 bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-600">
+            <Fuel className="h-3.5 w-3.5"/>
+            7702 smart account
+          </div>
+          <h1 className="max-w-xl text-2xl font-semibold tracking-tight text-gray-950 sm:text-3xl">
+            Try a gasless contract write
+          </h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-gray-600 sm:text-base sm:leading-7">
+            This embedded wallet is a 7702 smart account by default. Sponsor
+            gas for users so they can write to contracts on{' '}
+            {chainName ? `${chainName} ` : ''}without holding native ETH for
+            fees.
+          </p>
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={onTry}
+              className="inline-flex h-10 items-center rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white transition-colors hover:bg-gray-800 cursor-pointer"
+            >
+              Try it below
+            </button>
+            <span className="text-sm text-gray-500">
+              Uses the connected wallet you just created.
+            </span>
+          </div>
+        </div>
+        <div className="border-t border-gray-200 bg-gray-950 p-4 sm:p-6 lg:border-l lg:border-t-0">
+          <div className="mb-3 flex items-center justify-between">
+            <p className="text-sm font-semibold text-white">Gasless write</p>
+            <span className="text-xs text-gray-500">React</span>
+          </div>
+          <pre className="overflow-x-auto text-sm leading-6 text-gray-100">
+            <code>{`import { useWriteContract } from 'wagmi'
+
+const { writeContract } = useWriteContract()
+
+writeContract({
+  address: nftAddress,
+  abi,
+  functionName: 'mint',
+  args: [userAddress],
+})`}</code>
+          </pre>
+        </div>
+      </div>
+    </section>
+  )
 }

--- a/apps/zerodev-signer-demo/src/app/globals.css
+++ b/apps/zerodev-signer-demo/src/app/globals.css
@@ -73,3 +73,50 @@ body {
     transform: translateY(0) scale(1);
   }
 }
+
+.liquid-use-case-tab {
+  position: relative;
+  isolation: isolate;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.64)),
+    radial-gradient(circle at 0% 0%, rgba(255, 255, 255, 0.72), transparent 34%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.82),
+    0 1px 2px rgba(15, 23, 42, 0.04);
+  backdrop-filter: blur(12px) saturate(1.08);
+}
+
+.liquid-use-case-tab::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 12px;
+  bottom: 12px;
+  width: 4px;
+  border-radius: 999px;
+  background: rgba(147, 197, 253, 0.56);
+}
+
+.liquid-use-case-tab::after {
+  content: "";
+  position: absolute;
+  display: none;
+  inset-block: 0;
+  right: -12px;
+  width: 12px;
+  background: rgba(255, 255, 255, 0.64);
+}
+
+.liquid-content-pane {
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.64), rgba(255, 255, 255, 0.5));
+  box-shadow:
+    inset 1px 1px 0 rgba(255, 255, 255, 0.72);
+  backdrop-filter: blur(12px) saturate(1.05);
+}
+
+@media (min-width: 1024px) {
+  .liquid-use-case-tab::after {
+    display: block;
+  }
+}

--- a/apps/zerodev-signer-demo/src/app/globals.css
+++ b/apps/zerodev-signer-demo/src/app/globals.css
@@ -62,3 +62,14 @@ body {
     transform: translateY(0);
   }
 }
+
+@keyframes scenario-panel-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.995);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}

--- a/apps/zerodev-signer-demo/src/app/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/page.tsx
@@ -88,13 +88,18 @@ function LandingPageInner() {
 
   return (
     <div className="relative flex-1">
+      <div
+        className="fixed inset-0 -z-10 h-screen w-screen bg-cover bg-center opacity-[0.18]"
+        style={{backgroundImage: 'url(/videos/hero-bg-poster.jpg)'}}
+      />
       <video
         autoPlay
         loop
         muted
         playsInline
-        onCanPlay={() => setVideoReady(true)}
-        className={`absolute inset-0 h-full w-full object-cover pointer-events-none transition-opacity duration-700 ${
+        preload="auto"
+        onLoadedData={() => setVideoReady(true)}
+        className={`fixed inset-0 -z-10 h-screen w-screen object-cover pointer-events-none transition-opacity duration-700 ${
           videoReady ? 'opacity-[0.18]' : 'opacity-0'
         }`}
         poster="/videos/hero-bg-poster.jpg"
@@ -124,39 +129,33 @@ function LandingPageInner() {
           </p>
         </div>
       </div>
-      {videoReady ? (
-        <div className="relative mx-auto grid w-full max-w-7xl flex-1 grid-cols-1 gap-8 px-4 py-5 sm:px-6 sm:py-7 lg:grid-cols-[minmax(0,500px)_390px] lg:items-start lg:justify-between lg:gap-12 animate-[auth-transition-card_400ms_ease-out_forwards]">
-          <DemoIntroPanel/>
+      <div className="relative mx-auto grid w-full max-w-7xl flex-1 grid-cols-1 gap-8 px-4 py-5 sm:px-6 sm:py-7 lg:grid-cols-[minmax(0,500px)_390px] lg:items-start lg:justify-between lg:gap-12 animate-[auth-transition-card_400ms_ease-out_forwards]">
+        <DemoIntroPanel/>
+        {sessionExpired && (
+          <div
+            className="order-3 px-4 py-3 rounded-lg text-sm text-center bg-yellow-50 text-yellow-700 border border-yellow-200 lg:hidden">
+            Your session has expired. Please log in again.
+          </div>
+        )}
+        <div className="relative order-first mx-auto flex w-full max-w-[390px] flex-col lg:order-none lg:mx-0 lg:pt-3">
+          <ModeSelector mode={demoMode} onModeChange={setDemoMode}/>
           {sessionExpired && (
             <div
-              className="order-3 px-4 py-3 rounded-lg text-sm text-center bg-yellow-50 text-yellow-700 border border-yellow-200 lg:hidden">
+              className="mb-4 hidden px-4 py-3 rounded-lg text-sm text-center bg-yellow-50 text-yellow-700 border border-yellow-200 lg:block">
               Your session has expired. Please log in again.
             </div>
           )}
-          <div className="relative order-first mx-auto flex w-full max-w-[390px] flex-col lg:order-none lg:mx-0 lg:pt-3">
-            <ModeSelector mode={demoMode} onModeChange={setDemoMode}/>
-            {sessionExpired && (
-              <div
-                className="mb-4 hidden px-4 py-3 rounded-lg text-sm text-center bg-yellow-50 text-yellow-700 border border-yellow-200 lg:block">
-                Your session has expired. Please log in again.
+          {demoMode === 'prebuilt' ? (
+            <div className="h-[544px] overflow-hidden sm:w-[390px] sm:h-[624px]">
+              <div className="w-[500px] h-[800px] origin-top-left flex flex-col scale-[0.68] sm:scale-[0.78]">
+                <AuthFlow/>
               </div>
-            )}
-            {demoMode === 'prebuilt' ? (
-              <div className="h-[544px] overflow-hidden sm:w-[390px] sm:h-[624px]">
-                <div className="w-[500px] h-[800px] origin-top-left flex flex-col scale-[0.68] sm:scale-[0.78]">
-                  <AuthFlow/>
-                </div>
-              </div>
-            ) : (
-              <WhiteLabelWalletPreview onConnect={handleReconnect}/>
-            )}
-          </div>
+            </div>
+          ) : (
+            <WhiteLabelWalletPreview onConnect={handleReconnect}/>
+          )}
         </div>
-      ) : (
-        <div className="flex flex-1 items-center justify-center" style={{minHeight: 'calc(100vh - 5rem)'}}>
-          <div className="h-8 w-8 rounded-full border-2 border-blue-100 border-t-blue-500 animate-spin"/>
-        </div>
-      )}
+      </div>
     </div>
   )
 }
@@ -170,9 +169,6 @@ function ModeSelector({
 }) {
   return (
     <div className="mb-4">
-      <p className="mb-2 text-sm font-medium text-gray-500">
-        Experience
-      </p>
       <div className="flex items-center gap-3">
         <div className="grid flex-1 grid-cols-2 rounded-lg border border-gray-200 bg-gray-50 p-1">
           {demoModes.map((item) => (
@@ -317,9 +313,6 @@ function DemoIntroPanel() {
 
   return (
     <aside className="w-full max-w-[500px] pt-1 lg:pt-3">
-      <p className="mb-3 text-sm font-medium text-blue-500">
-        Wallet Demo
-      </p>
       <h1 className="max-w-[500px] text-3xl font-semibold leading-tight text-gray-950">
         Auth in. Smart wallet out.
       </h1>

--- a/apps/zerodev-signer-demo/src/app/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/page.tsx
@@ -37,12 +37,14 @@ function LandingPageInner() {
   const [demoMode, setDemoMode] = useState<DemoMode>('prebuilt')
   const [authTransitioning, setAuthTransitioning] = useState(false)
   const [showLogoutToast, setShowLogoutToast] = useState(loggedOutSuccess)
-  const [loggedOut] = useState(() => {
-    if (typeof window === 'undefined') return false
+  const [loggedOut, setLoggedOut] = useState(false)
+  useEffect(() => {
     const value = localStorage.getItem('zd:loggedOut') === 'true'
-    if (value) localStorage.removeItem('zd:loggedOut')
-    return value
-  })
+    if (value) {
+      localStorage.removeItem('zd:loggedOut')
+      setLoggedOut(true)
+    }
+  }, [])
 
   const {connect, connectors, status: connectStatus} = useConnect()
   const {isConnected, status: accountStatus} = useAccount()
@@ -257,12 +259,10 @@ function ModeSelector({
 
 function EmailMethodSettings() {
   const [open, setOpen] = useState(false)
-  const [method, setMethod] = useState<EmailAuthMethod>(() => {
-    if (typeof window === 'undefined') return 'otp'
-    return localStorage.getItem('zd:emailAuthMethod') === 'magicLink'
-      ? 'magicLink'
-      : 'otp'
-  })
+  const [method, setMethod] = useState<EmailAuthMethod>('otp')
+  useEffect(() => {
+    setMethod(localStorage.getItem('zd:emailAuthMethod') === 'magicLink' ? 'magicLink' : 'otp')
+  }, [])
 
   const handleSave = (next: EmailAuthMethod) => {
     localStorage.setItem('zd:emailAuthMethod', next)

--- a/apps/zerodev-signer-demo/src/app/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/page.tsx
@@ -1,8 +1,15 @@
 'use client'
 
-import {AuthFlow} from '@zerodev/wallet-react-kit'
+import {AuthFlow, useAuth} from '@zerodev/wallet-react-kit'
 import {highlight} from 'sugar-high'
-import {ArrowRight, CheckCircle2, CircleHelp, Mail, Settings} from 'lucide-react'
+import {
+  ArrowRight,
+  CheckCircle2,
+  CircleHelp,
+  Loader2,
+  Mail,
+  Settings,
+} from 'lucide-react'
 import {useRouter, useSearchParams} from 'next/navigation'
 import type {FormEvent} from 'react'
 import {Suspense, useEffect, useState} from 'react'
@@ -30,17 +37,31 @@ function LandingPageInner() {
   const [demoMode, setDemoMode] = useState<DemoMode>('prebuilt')
   const [authTransitioning, setAuthTransitioning] = useState(false)
   const [showLogoutToast, setShowLogoutToast] = useState(loggedOutSuccess)
+  const [loggedOut] = useState(() => {
+    if (typeof window === 'undefined') return false
+    const value = localStorage.getItem('zd:loggedOut') === 'true'
+    if (value) localStorage.removeItem('zd:loggedOut')
+    return value
+  })
 
   const {connect, connectors, status: connectStatus} = useConnect()
   const {isConnected, status: accountStatus} = useAccount()
+  const {step: authStep} = useAuth()
+  const skipAutoConnect = sessionExpired || loggedOut || loggedOutSuccess
+  const isResolvingSession =
+    accountStatus === 'reconnecting' ||
+    accountStatus === 'connecting' ||
+    connectStatus === 'pending'
+  const showLoading = !isConnected && authStep === null && isResolvingSession
+  const showReconnect =
+    !isConnected &&
+    authStep === null &&
+    !isResolvingSession &&
+    (skipAutoConnect || connectStatus === 'error')
 
   const handleReconnect = () => {
     if (connectors[0]) connect({connector: connectors[0]})
   }
-
-  useEffect(() => {
-    localStorage.removeItem('zd:loggedOut')
-  }, [])
 
   useEffect(() => {
     if (!loggedOutSuccess) return
@@ -60,6 +81,16 @@ function LandingPageInner() {
   }, [loggedOutSuccess, router])
 
   useEffect(() => {
+    if (!sessionExpired) return
+
+    const cleanUrlTimer = window.setTimeout(() => {
+      router.replace('/')
+    }, 3500)
+
+    return () => window.clearTimeout(cleanUrlTimer)
+  }, [sessionExpired, router])
+
+  useEffect(() => {
     if (isConnected) {
       setAuthTransitioning(true)
       const timer = window.setTimeout(() => {
@@ -68,7 +99,7 @@ function LandingPageInner() {
 
       return () => window.clearTimeout(timer)
     }
-    if (demoMode === 'whiteLabel') return
+    if (demoMode === 'whiteLabel' || skipAutoConnect || authStep !== null) return
     if (
       accountStatus === 'disconnected' &&
       connectStatus === 'idle' &&
@@ -84,6 +115,8 @@ function LandingPageInner() {
     connect,
     connectors,
     demoMode,
+    skipAutoConnect,
+    authStep,
   ])
 
   return (
@@ -146,10 +179,37 @@ function LandingPageInner() {
             </div>
           )}
           {demoMode === 'prebuilt' ? (
-            <div className="h-[544px] overflow-hidden sm:w-[390px] sm:h-[624px]">
+            <div className="relative h-[544px] overflow-hidden sm:w-[390px] sm:h-[624px]">
               <div className="w-[500px] h-[800px] origin-top-left flex flex-col scale-[0.68] sm:scale-[0.78]">
                 <AuthFlow/>
               </div>
+              {showLoading && (
+                <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/80 backdrop-blur-sm">
+                  <div className="flex items-center gap-2 rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-600 shadow-sm">
+                    <Loader2 className="h-4 w-4 animate-spin text-blue-500"/>
+                    Restoring session...
+                  </div>
+                </div>
+              )}
+              {showReconnect && (
+                <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/80 backdrop-blur-sm">
+                  <div className="flex max-w-[280px] flex-col items-center gap-3 rounded-xl border border-gray-200 bg-white p-5 text-center shadow-sm">
+                    <p className="text-sm font-medium text-gray-900">
+                      Ready to continue
+                    </p>
+                    <p className="text-xs leading-5 text-gray-500">
+                      Reconnect your session to open the wallet.
+                    </p>
+                    <button
+                      type="button"
+                      onClick={handleReconnect}
+                      className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-gray-800"
+                    >
+                      Reconnect
+                    </button>
+                  </div>
+                </div>
+              )}
             </div>
           ) : (
             <WhiteLabelWalletPreview onConnect={handleReconnect}/>

--- a/apps/zerodev-signer-demo/tsconfig.json
+++ b/apps/zerodev-signer-demo/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       '@zerodev/ecdsa-validator':
         specifier: ^5.4.9
         version: 5.4.9(@zerodev/sdk@5.5.4(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)))(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
+      '@zerodev/permissions':
+        specifier: ^5.6.3
+        version: 5.6.3(@zerodev/sdk@5.5.4(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)))(@zerodev/webauthn-key@5.5.0(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)))(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
       '@zerodev/sdk':
         specifier: ^5.0.0
         version: 5.5.4(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
@@ -3775,6 +3778,24 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@simplewebauthn/browser@8.3.7':
+    resolution: {integrity: sha512-ZtRf+pUEgOCvjrYsbMsJfiHOdKcrSZt2zrAnIIpfmA06r0FxBovFYq0rJ171soZbe13KmWzAoLKjSxVW7KxCdQ==}
+
+  '@simplewebauthn/browser@9.0.1':
+    resolution: {integrity: sha512-wD2WpbkaEP4170s13/HUxPcAV5y4ZXaKo1TfNklS5zDefPinIgXOpgz1kpEvobAsaLPa2KeH7AKKX/od1mrBJw==}
+
+  '@simplewebauthn/types@12.0.0':
+    resolution: {integrity: sha512-q6y8MkoV8V8jB4zzp18Uyj2I7oFp2/ONL8c3j8uT06AOWu3cIChc1au71QYHrP2b+xDapkGTiv+9lX7xkTlAsA==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  '@simplewebauthn/types@9.0.1':
+    resolution: {integrity: sha512-tGSRP1QvsAvsJmnOlRQyw/mvK9gnPtjEc5fg2+m8n+QUa+D7rvrKkOYyfpy42GTs90X3RDOnqJgfHt+qO67/+w==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  '@simplewebauthn/typescript-types@8.3.4':
+    resolution: {integrity: sha512-38xtca0OqfRVNloKBrFB5LEM6PN5vzFbJG6rAutPVrtGHFYxPdiV3btYWq0eAZAZmP+dqFPYJxJWeJrGfmYHng==}
+    deprecated: This package has been renamed to @simplewebauthn/types. Please install @simplewebauthn/types instead to ensure you receive future updates.
+
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
@@ -5214,8 +5235,20 @@ packages:
       '@zerodev/sdk': ^5.4.13
       viem: ^2.28.0
 
+  '@zerodev/permissions@5.6.3':
+    resolution: {integrity: sha512-MwW3Eo3rB5ViOKdY6NUoyvmQTV/bCbOZbmQMTYQqAT7B8rdI9jo44nNONMOHIhDkfF4VFhQ9+M50cCZLA/6zcg==}
+    peerDependencies:
+      '@zerodev/sdk': ^5.4.0
+      '@zerodev/webauthn-key': ^5.4.0
+      viem: ^2.28.0
+
   '@zerodev/sdk@5.5.4':
     resolution: {integrity: sha512-QB/YfemrHEyR0/B2l4ya+LOXLfLmkUvTjS2FEzhQ0hvfPtcS5wf3v7eZHy7qNjsBC4M/wYG7RQf3ZCbKMh4ZLw==}
+    peerDependencies:
+      viem: ^2.28.0
+
+  '@zerodev/webauthn-key@5.5.0':
+    resolution: {integrity: sha512-AbD2d/qrsX7AWxJMEfwxnLbp1TjiUjc1V4ne3Q40UJxKe+lW64Td+y8OD0qSFMqgN6rQxJZ0aOAXmat8H6xluA==}
     peerDependencies:
       viem: ^2.28.0
 
@@ -5590,8 +5623,14 @@ packages:
   big.js@6.2.2:
     resolution: {integrity: sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bl@5.1.0:
     resolution: {integrity: sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==}
+
+  bn.js@4.11.6:
+    resolution: {integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==}
 
   bn.js@4.12.3:
     resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
@@ -5678,6 +5717,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer-reverse@1.0.1:
+    resolution: {integrity: sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg==}
 
   buffer-xor@1.0.3:
     resolution: {integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==}
@@ -6048,6 +6090,9 @@ packages:
   crypto-browserify@3.12.1:
     resolution: {integrity: sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==}
     engines: {node: '>= 0.10'}
+
+  crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
   css-in-js-utils@3.1.0:
     resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
@@ -6805,8 +6850,15 @@ packages:
   eth-rpc-errors@4.0.3:
     resolution: {integrity: sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==}
 
+  ethereum-bloom-filters@1.2.0:
+    resolution: {integrity: sha512-28hyiE7HVsWubqhpVLVmZXFd4ITeHi+BUu05o9isf0GUpMtzBUi+8/gFrGaGYzvGAJQmJ3JKj77Mk9G98T84rA==}
+
   ethereum-cryptography@2.2.1:
     resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
+
+  ethjs-unit@0.1.6:
+    resolution: {integrity: sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==}
+    engines: {node: '>=6.5.0', npm: '>=3'}
 
   eval@0.1.8:
     resolution: {integrity: sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==}
@@ -7683,6 +7735,10 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hex-prefixed@1.0.0:
+    resolution: {integrity: sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==}
+    engines: {node: '>=6.5.0', npm: '>=3'}
+
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
@@ -8451,6 +8507,10 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  merkletreejs@0.3.11:
+    resolution: {integrity: sha512-LJKTl4iVNTndhL+3Uz/tfkjD0klIWsHlUzgtuNnNrsf7bAlXR30m+xYB7lHr5Z/l6e/yAIsr26Dabx6Buo4VGQ==}
+    engines: {node: '>= 7.6.0'}
+
   mermaid-isomorphic@3.1.0:
     resolution: {integrity: sha512-mzrvfEVjnJIkJlEqxp3eMuR1wS0TeLCH1VK5E/T5yzWaBwI3JqjJuw70yUIThSCDJ5bRs6O3rgfp00oBAbvSeQ==}
     peerDependencies:
@@ -9040,6 +9100,10 @@ packages:
 
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
+
+  number-to-bn@1.7.0:
+    resolution: {integrity: sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==}
+    engines: {node: '>=6.5.0', npm: '>=3'}
 
   nuqs@2.8.9:
     resolution: {integrity: sha512-8ou6AEwsxMWSYo2qkfZtYFVzngwbKmg4c00HVxC1fF6CEJv3Fwm6eoZmfVPALB+vw8Udo7KL5uy96PFcYe1BIQ==}
@@ -10432,6 +10496,10 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
+  strip-hex-prefix@1.0.0:
+    resolution: {integrity: sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==}
+    engines: {node: '>=6.5.0', npm: '>=3'}
+
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
@@ -10631,6 +10699,10 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  treeify@1.1.0:
+    resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
+    engines: {node: '>=0.6'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -10943,6 +11015,9 @@ packages:
   utf-8-validate@6.0.6:
     resolution: {integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==}
     engines: {node: '>=6.14.2'}
+
+  utf8@3.0.0:
+    resolution: {integrity: sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -11263,6 +11338,10 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web3-utils@1.10.4:
+    resolution: {integrity: sha512-tsu8FiKJLk2PzhDl9fXbGUWTkkVXYhtTA+SmEFkKft+9BgwLxfCRpU96sWv7ICC8zixBNd3JURVoiR3dUXgP8A==}
+    engines: {node: '>=8.0.0'}
 
   webextension-polyfill@0.10.0:
     resolution: {integrity: sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==}
@@ -15460,7 +15539,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.83.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      metro-config: 0.83.5(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      metro-config: 0.83.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       metro-core: 0.83.5
       semver: 7.7.3
     optionalDependencies:
@@ -16732,6 +16811,20 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@simplewebauthn/browser@8.3.7':
+    dependencies:
+      '@simplewebauthn/typescript-types': 8.3.4
+
+  '@simplewebauthn/browser@9.0.1':
+    dependencies:
+      '@simplewebauthn/types': 9.0.1
+
+  '@simplewebauthn/types@12.0.0': {}
+
+  '@simplewebauthn/types@9.0.1': {}
+
+  '@simplewebauthn/typescript-types@8.3.4': {}
 
   '@sinclair/typebox@0.27.10': {}
 
@@ -19970,6 +20063,14 @@ snapshots:
       '@zerodev/sdk': 5.5.4(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
       viem: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
 
+  '@zerodev/permissions@5.6.3(@zerodev/sdk@5.5.4(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)))(@zerodev/webauthn-key@5.5.0(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)))(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))':
+    dependencies:
+      '@simplewebauthn/browser': 9.0.1
+      '@zerodev/sdk': 5.5.4(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
+      '@zerodev/webauthn-key': 5.5.0(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
+      merkletreejs: 0.3.11
+      viem: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+
   '@zerodev/sdk@5.5.4(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       semver: 7.7.3
@@ -19978,6 +20079,13 @@ snapshots:
   '@zerodev/sdk@5.5.4(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))':
     dependencies:
       semver: 7.7.3
+      viem: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+
+  '@zerodev/webauthn-key@5.5.0(viem@2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@simplewebauthn/browser': 8.3.7
+      '@simplewebauthn/types': 12.0.0
       viem: 2.38.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
 
   abitype@1.0.6(typescript@5.9.3)(zod@3.25.76):
@@ -20451,11 +20559,15 @@ snapshots:
 
   big.js@6.2.2: {}
 
+  bignumber.js@9.3.1: {}
+
   bl@5.1.0:
     dependencies:
       buffer: 6.0.3
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  bn.js@4.11.6: {}
 
   bn.js@4.12.3: {}
 
@@ -20574,6 +20686,8 @@ snapshots:
       node-int64: 0.4.0
 
   buffer-from@1.1.2: {}
+
+  buffer-reverse@1.0.1: {}
 
   buffer-xor@1.0.3: {}
 
@@ -20975,6 +21089,8 @@ snapshots:
       public-encrypt: 4.0.3
       randombytes: 2.1.0
       randomfill: 1.0.4
+
+  crypto-js@4.2.0: {}
 
   css-in-js-utils@3.1.0:
     dependencies:
@@ -21936,12 +22052,21 @@ snapshots:
     dependencies:
       fast-safe-stringify: 2.1.1
 
+  ethereum-bloom-filters@1.2.0:
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   ethereum-cryptography@2.2.1:
     dependencies:
       '@noble/curves': 1.4.2
       '@noble/hashes': 1.4.0
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
+
+  ethjs-unit@0.1.6:
+    dependencies:
+      bn.js: 4.11.6
+      number-to-bn: 1.7.0
 
   eval@0.1.8:
     dependencies:
@@ -23257,6 +23382,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hex-prefixed@1.0.0: {}
+
   is-hexadecimal@2.0.1: {}
 
   is-inside-container@1.0.0:
@@ -24160,6 +24287,14 @@ snapshots:
 
   merge2@1.4.1: {}
 
+  merkletreejs@0.3.11:
+    dependencies:
+      bignumber.js: 9.3.1
+      buffer-reverse: 1.0.1
+      crypto-js: 4.2.0
+      treeify: 1.1.0
+      web3-utils: 1.10.4
+
   mermaid-isomorphic@3.1.0(playwright@1.57.0):
     dependencies:
       '@fortawesome/fontawesome-free': 6.7.2
@@ -24319,6 +24454,21 @@ snapshots:
       metro-cache: 0.83.3
       metro-core: 0.83.3
       metro-runtime: 0.83.3
+      yaml: 2.8.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro-config@0.83.5(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      connect: 3.7.0
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.83.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      metro-cache: 0.83.5
+      metro-core: 0.83.5
+      metro-runtime: 0.83.5
       yaml: 2.8.1
     transitivePeerDependencies:
       - bufferutil
@@ -24924,7 +25074,7 @@ snapshots:
       metro-babel-transformer: 0.83.5
       metro-cache: 0.83.5
       metro-cache-key: 0.83.5
-      metro-config: 0.83.5(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      metro-config: 0.83.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       metro-core: 0.83.5
       metro-file-map: 0.83.5
       metro-resolver: 0.83.5
@@ -25542,6 +25692,11 @@ snapshots:
       boolbase: 1.0.0
 
   nullthrows@1.1.1: {}
+
+  number-to-bn@1.7.0:
+    dependencies:
+      bn.js: 4.11.6
+      strip-hex-prefix: 1.0.0
 
   nuqs@2.8.9(next@15.3.8(@babel/core@7.29.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-router@7.13.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0):
     dependencies:
@@ -27641,6 +27796,10 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
+  strip-hex-prefix@1.0.0:
+    dependencies:
+      is-hex-prefixed: 1.0.0
+
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
@@ -27809,6 +27968,8 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+
+  treeify@1.1.0: {}
 
   trim-lines@3.0.1: {}
 
@@ -28107,6 +28268,8 @@ snapshots:
     dependencies:
       node-gyp-build: 4.8.4
     optional: true
+
+  utf8@3.0.0: {}
 
   util-deprecate@1.0.2: {}
 
@@ -28743,6 +28906,17 @@ snapshots:
       defaults: 1.0.4
 
   web-namespaces@2.0.1: {}
+
+  web3-utils@1.10.4:
+    dependencies:
+      '@ethereumjs/util': 8.1.0
+      bn.js: 5.2.2
+      ethereum-bloom-filters: 1.2.0
+      ethereum-cryptography: 2.2.1
+      ethjs-unit: 0.1.6
+      number-to-bn: 1.7.0
+      randombytes: 2.1.0
+      utf8: 3.0.0
 
   webextension-polyfill@0.10.0: {}
 


### PR DESCRIPTION
## Summary

Updates to the `zerodev-signer-demo` authenticated experience.

### New / reworked use cases
- **Delegate a budget (permissions):** scoped, rate-limited session keys via `@zerodev/permissions`. Flow is split into create key → grant allowance → live "drip" payouts on a timer → revoke & reset. On-chain enforcement is demonstrated (drip stops at the rate-limit cap; revoke kills the key). An "active session key" badge appears in the header with the granted scope on hover.
- **Sign anything:** guided flow — personal sign, EIP-712 typed data, and sign-to-send (USDC **or** native ETH), with explicit "sent X to 0x…" confirmations.

### Fixes
- NFT gallery persistence + loading: cache-clobber guard and a dedicated public-node `eth_getLogs` scan (the bundler RPC doesn't reliably support log queries).
- Hydration mismatches from `localStorage` reads in `useState` initializers.
- Notification bar rendered via portal so it pins below the navbar.

### UI
- Shared `FaucetLink` copies the wallet address before opening the faucet; clicking ETH/USDC in the header jumps to the send step.
- Full-width, grounded navbar.
- Removed the Actions dropdown (covered elsewhere) and the Customize-the-flow use case.

### Infra
- Add `@zerodev/permissions`; bump `tsconfig` target to ES2020.

### Notes
- On-chain paths (grant/drip/revoke, ETH/USDC send) verified to typecheck/lint/compile but need a quick logged-in browser pass. If a policy call reverts, `CallPolicyVersion.V0_0_4 → V0_0_5` is a one-line fallback.