### PR TITLE
fix(core): sign stamp-login against the parent org

### DIFF
--- a/apps/zerodev-signer-demo/src/app/wagmi-config.ts
+++ b/apps/zerodev-signer-demo/src/app/wagmi-config.ts
@@ -32,6 +32,11 @@ export const config = createConfig({
       projectId: process.env.NEXT_PUBLIC_ZERODEV_PROJECT_ID!,
       proxyBaseUrl: process.env.NEXT_PUBLIC_KMS_PROXY_BASE_URL!,
       chains: [arbitrumSepolia, sepolia],
+      // Local testing override: our docker backend's Turnkey base org differs
+      // from the SDK's hardcoded prod default, so point the connector at it.
+      ...(process.env.NEXT_PUBLIC_ZERODEV_ORG_ID && {
+        organizationId: process.env.NEXT_PUBLIC_ZERODEV_ORG_ID,
+      }),
       ...(mode && { mode }),
       config: {
         auth: {

--- a/e2e/helpers/backend-health.ts
+++ b/e2e/helpers/backend-health.ts
@@ -53,3 +53,20 @@ export async function getAuthProxyConfigId(baseUrl: string): Promise<string> {
   const data = await res.json()
   return data.authProxyConfigId
 }
+
+/**
+ * Fetches the Turnkey parent (base) organization ID. Stamp-login payloads must
+ * be signed against this org — the backend relays the stamp to Turnkey under
+ * the parent org and derives the sub-org from the credential. Tests fetch it so
+ * they work regardless of which base org the target backend is configured with.
+ */
+export async function getParentOrgId(baseUrl: string): Promise<string> {
+  const res = await fetch(`${baseUrl}/server-info/parent-org-id`)
+  if (!res.ok) {
+    throw new Error(
+      `Failed to get parent org ID: ${res.status} ${res.statusText}`,
+    )
+  }
+  const data = await res.json()
+  return data.parentOrgId
+}

--- a/e2e/integration/session-management.test.ts
+++ b/e2e/integration/session-management.test.ts
@@ -10,6 +10,7 @@ import { beforeAll, describe, expect, it } from 'vitest'
 import { parseSession } from '../../packages/core/src/utils/utils.js'
 import {
   getAuthProxyConfigId,
+  getParentOrgId,
   waitForBackend,
 } from '../helpers/backend-health.js'
 import { BACKEND_URL } from '../helpers/constants.js'
@@ -21,6 +22,7 @@ import { createTestStamper } from '../helpers/test-stamper.js'
 describe('Session Management', () => {
   let projectId: string
   let authProxyConfigId: string
+  let parentOrgId: string
   let skipReason = ''
 
   beforeAll(async () => {
@@ -39,6 +41,7 @@ describe('Session Management', () => {
     }
 
     authProxyConfigId = await getAuthProxyConfigId(BACKEND_URL)
+    parentOrgId = await getParentOrgId(BACKEND_URL)
 
     projectId = process.env.ZD_PROJECT_ID || ''
     if (!projectId) {
@@ -70,16 +73,21 @@ describe('Session Management', () => {
     const newPublicKey = (await newStamper.getPublicKey())!
 
     // Step 4: Login with stamp using the OLD stamper (active session key)
-    // targeting the NEW public key
+    // targeting the NEW public key. The stamp is signed against the PARENT
+    // org — the backend relays it to Turnkey under the parent and derives the
+    // sub-org from the credential. Signing the sub-org here would make the
+    // relayed payload mismatch the signature → Turnkey SIGNATURE_INVALID.
     const stampLoginResult = await client.loginWithStamp({
       projectId,
-      organizationId: session.organizationId,
+      organizationId: parentOrgId,
       targetPublicKey: newPublicKey,
     })
     expect(stampLoginResult.session).toBeTruthy()
     console.log('Stamp login successful')
 
-    // Step 5: Parse the new session and verify it
+    // Step 5: Parse the new session and verify it. The session itself is still
+    // scoped to the user's sub-org (Turnkey assigns it), even though we stamped
+    // against the parent.
     const newSession = parseSession(stampLoginResult.session)
     expect(newSession.userId).toBeTruthy()
     expect(newSession.organizationId).toBe(session.organizationId)

--- a/packages/core/src/actions/auth/auth.test.ts
+++ b/packages/core/src/actions/auth/auth.test.ts
@@ -215,13 +215,14 @@ describe('loginWithStamp', () => {
     })
     expect(stampPayload.timestampMs).toBeDefined()
 
-    // Verify request was made correctly
+    // Verify request was made correctly. The sub-org id is NOT sent — the
+    // backend derives it from the stamped credential; the org only lives in
+    // the signed stampPayload above.
     expect(mockClient.request).toHaveBeenCalledWith(
       expect.objectContaining({
         path: 'proj-456/auth/login/stamp',
         method: 'POST',
         body: expect.objectContaining({
-          subOrganizationId: 'org-123',
           targetPublicKey: '03abcdef1234567890',
           stamp: expect.objectContaining({
             stampHeaderName: 'X-Stamp',
@@ -230,6 +231,8 @@ describe('loginWithStamp', () => {
         }),
       }),
     )
+    const sentBody = vi.mocked(mockClient.request).mock.calls[0][0].body
+    expect(sentBody).not.toHaveProperty('subOrganizationId')
 
     expect(result).toEqual({ session: 'session-jwt' })
   })

--- a/packages/core/src/actions/auth/loginWithStamp.ts
+++ b/packages/core/src/actions/auth/loginWithStamp.ts
@@ -70,8 +70,11 @@ export async function loginWithStamp(
   return client.request({
     path: `${projectId}/auth/login/stamp`,
     method: 'POST',
+    // The sub-org id is intentionally not sent: the backend derives it from
+    // the stamped credential. `organizationId` (the parent org) is only
+    // signed into `stampPayload` above so the stamp matches the body the
+    // backend relays to Turnkey — it is not part of the wire request.
     body: {
-      subOrganizationId: organizationId,
       targetPublicKey,
       timestamp: timestampIso,
       stamp,

--- a/packages/core/src/core/createZeroDevWalletCore.ts
+++ b/packages/core/src/core/createZeroDevWalletCore.ts
@@ -190,7 +190,11 @@ export async function createZeroDevWalletCore(
         const data = await client.loginWithStamp({
           targetPublicKey: compressedPublicKeyHex,
           projectId,
-          organizationId: activeSession.organizationId,
+          // Stamp-login is signed against the Turnkey parent org; the backend
+          // resolves the sub-org from the stamped credential. Signing the
+          // sub-org here makes the relayed payload's org mismatch the
+          // signature → Turnkey SIGNATURE_INVALID.
+          organizationId,
           stampWith: 'apiKey',
         })
         await client.apiKeyStamper.commitKeyRotation()
@@ -270,7 +274,9 @@ export async function createZeroDevWalletCore(
             const loginData = await client.loginWithStamp({
               projectId,
               targetPublicKey: compressedPublicKeyHex,
-              organizationId: data.subOrganizationId,
+              // Sign against the parent org (see refreshSession note) — the
+              // backend derives the sub-org from the stamped credential.
+              organizationId,
             })
             await client.apiKeyStamper.commitKeyRotation()
             const parsedSession = parseSession(loginData.session)
@@ -302,6 +308,9 @@ export async function createZeroDevWalletCore(
             const loginData = await client.loginWithStamp({
               targetPublicKey: generatedPublicKey,
               projectId,
+              // Sign against the parent org, not the user's sub-org (see the
+              // refreshSession note). The backend derives the sub-org from the
+              // stamped passkey credential.
               organizationId,
               stampWith: 'passkey',
             })


### PR DESCRIPTION
## What

Coordinates with the doorway-kms backend change (OffchainLabs/doorway-kms#778) that removes the client-supplied sub-org id from `/auth/login/stamp`. The backend now relays the stamp-login to Turnkey under the **parent (base) org** and derives the user's sub-org from the stamped credential.

Because the X-Stamp signs a payload that includes the org id, the SDK must now sign against the **parent** org. Signing the sub-org makes the org in the relayed payload mismatch the signature, and Turnkey rejects it with `SIGNATURE_INVALID`.

## Changes

- `loginWithStamp` callsites in `createZeroDevWalletCore` — register bootstrap, session refresh, and passkey login — now sign `organizationId` (the connector's configured parent org) instead of the per-user sub-org. Passkey login already did; register-bootstrap and refresh were signing the sub-org and are the ones that broke.
- `loginWithStamp` no longer sends `subOrganizationId` in the request body — the backend derives it from the credential.
- The parent org is the connector's existing `organizationId` default, so there's **no extra round-trip** (the new `/server-info/parent-org-id` endpoint is not needed by the SDK).

## Verification

Ran the current SDK against a local backend on the #778 branch:
- **Before:** passkey register and email/OTP session refresh both fail — backend logs `StampLogin … SIGNATURE_INVALID` against the parent org.
- **After:** passkey register (browser e2e, virtual authenticator) and email session refresh (`session-management` integration test) both succeed.

Tests:
- `auth.test.ts` — asserts the stamp signs the parent and the body no longer carries `subOrganizationId`.
- `session-management.test.ts` — OTP login → refresh signs the parent (via new `getParentOrgId` helper) → whoami on the rotated session.

## Rollout

Coordinated, no compat window: the backend unconditionally stamps the parent, so this SDK must ship before #778 deploys.