### PR TITLE
release(core/react/react-kit): @zerodev/wallet-core@0.0.1-alpha.23, @zerodev/wallet-react@0.0.1-alpha.26, @zerodev/wallet-react-kit@0.0.1-alpha.3

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -35,6 +35,7 @@
     "rare-buttons-rescue",
     "shaggy-ants-lay",
     "shy-chefs-behave",
+    "six-hats-yawn",
     "thin-trees-grow",
     "warm-files-post",
     "warm-foxes-fix",

--- a/.changeset/six-hats-yawn.md
+++ b/.changeset/six-hats-yawn.md
@@ -1,0 +1,5 @@
+---
+"@zerodev/wallet-core": patch
+---
+
+fix: sign stamp-login against the parent org so it works with the sub-org-less backend

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prepare": "husky",
     "changeset": "changeset",
     "changeset:version": "changeset version && pnpm install --lockfile-only",
-    "changeset:release": "pnpm build && bash scripts/remove-type.sh && changeset publish && bash scripts/restore-type.sh && pnpm format"
+    "changeset:release": "pnpm build && bash scripts/remove-type.sh && changeset publish --tag alpha && bash scripts/restore-type.sh && pnpm format"
   },
   "keywords": [
     "monorepo",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @zerodev/wallet-core
 
+## 0.0.1-alpha.23
+
+### Patch Changes
+
+- fix: sign stamp-login against the parent org so it works with the sub-org-less backend
+
 ## 0.0.1-alpha.22
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,9 +2,6 @@
   "name": "@zerodev/wallet-core",
   "version": "0.0.1-alpha.23",
   "description": "ZeroDev Wallet SDK built on Turnkey",
-  "publishConfig": {
-    "tag": "alpha"
-  },
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,10 @@
 {
   "name": "@zerodev/wallet-core",
-  "version": "0.0.1-alpha.22",
+  "version": "0.0.1-alpha.23",
   "description": "ZeroDev Wallet SDK built on Turnkey",
+  "publishConfig": {
+    "tag": "alpha"
+  },
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",

--- a/packages/react-kit/CHANGELOG.md
+++ b/packages/react-kit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @zerodev/wallet-react-kit
 
+## 0.0.1-alpha.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @zerodev/wallet-core@0.0.1-alpha.23
+  - @zerodev/wallet-react@0.0.1-alpha.26
+
 ## 0.0.1-alpha.2
 
 ### Patch Changes

--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -2,9 +2,6 @@
   "name": "@zerodev/wallet-react-kit",
   "version": "0.0.1-alpha.3",
   "description": "React UI components for ZeroDev Wallet SDK",
-  "publishConfig": {
-    "tag": "alpha"
-  },
   "sideEffects": [
     "**/*.css"
   ],

--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -1,7 +1,10 @@
 {
   "name": "@zerodev/wallet-react-kit",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "description": "React UI components for ZeroDev Wallet SDK",
+  "publishConfig": {
+    "tag": "alpha"
+  },
   "sideEffects": [
     "**/*.css"
   ],

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @zerodev/wallet-react
 
+## 0.0.1-alpha.26
+
+### Patch Changes
+
+- Updated dependencies
+  - @zerodev/wallet-core@0.0.1-alpha.23
+
 ## 0.0.1-alpha.25
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,10 @@
 {
   "name": "@zerodev/wallet-react",
-  "version": "0.0.1-alpha.25",
+  "version": "0.0.1-alpha.26",
   "description": "React hooks for ZeroDev Wallet SDK",
+  "publishConfig": {
+    "tag": "alpha"
+  },
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,9 +2,6 @@
   "name": "@zerodev/wallet-react",
   "version": "0.0.1-alpha.26",
   "description": "React hooks for ZeroDev Wallet SDK",
-  "publishConfig": {
-    "tag": "alpha"
-  },
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",


### PR DESCRIPTION
## Versions

- `@zerodev/wallet-core` → **0.0.1-alpha.23**
  - fix: sign stamp-login against the parent org so it works with the sub-org-less backend (#255)
- `@zerodev/wallet-react` → **0.0.1-alpha.26** — dependency bump (`@zerodev/wallet-core@0.0.1-alpha.23`)
- `@zerodev/wallet-react-kit` → **0.0.1-alpha.3** — dependency bumps (`core@0.0.1-alpha.23`, `react@0.0.1-alpha.26`)

## Also

Adds `publishConfig.tag: "alpha"` to all three published packages so `changeset publish` tags prereleases as `alpha` instead of `latest` — removes the manual `npm dist-tag add alpha …` step after every release. Drop the field per-package when a package eventually GAs.