### PR TITLE
feat(core): GET-with-stamp auth endpoints + project-config OTP/magic-link

### DIFF
--- a/apps/expo-example/src/app/verify-email.tsx
+++ b/apps/expo-example/src/app/verify-email.tsx
@@ -15,7 +15,6 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native'
-import { VERIFY_EMAIL_REDIRECT_URI } from '@/config/auth'
 import {
   clearPendingOtpMutationOptions,
   pendingOtpQueryOptions,
@@ -126,7 +125,6 @@ export default function VerifyEmail() {
     if (pending.method === 'magicLink') {
       sendMagicLink({
         email: pending.email,
-        redirectURL: VERIFY_EMAIL_REDIRECT_URI,
       })
     } else {
       sendOtp({ email: pending.email })

--- a/apps/expo-example/src/components/EmailAuth.tsx
+++ b/apps/expo-example/src/components/EmailAuth.tsx
@@ -10,7 +10,6 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native'
-import { VERIFY_EMAIL_REDIRECT_URI } from '@/config/auth'
 import {
   clearPendingOtpMutationOptions,
   pendingOtpQueryOptions,
@@ -144,7 +143,6 @@ export function EmailAuth() {
         onPress={() =>
           sendMagicLink({
             email: emailInput,
-            redirectURL: VERIFY_EMAIL_REDIRECT_URI,
           })
         }
         disabled={isSending || !emailInput}

--- a/apps/zerodev-signer-demo/src/app/wagmi-config.ts
+++ b/apps/zerodev-signer-demo/src/app/wagmi-config.ts
@@ -40,7 +40,6 @@ export const config = createConfig({
       ...(mode && { mode }),
       config: {
         auth: {
-          magicLinkBaseUrl: `${process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'}/verify`,
           enabledMethods: ['email', 'google', 'passkey'],
           emailAuthMethod: getEmailAuthMethod(),
         },

--- a/e2e/helpers/constants.ts
+++ b/e2e/helpers/constants.ts
@@ -6,7 +6,10 @@ export const DEMO_APP_URL = process.env.DEMO_APP_URL || 'http://localhost:3000'
 export const EMAIL_POLL_INTERVAL_MS = 5_000
 export const EMAIL_POLL_TIMEOUT_MS = 60_000
 
-export const OTP_CODE_LENGTH = 7
+// OTP code length is configured per-project on the backend (wallet.otp_configs);
+// the SDK no longer forces it. 6 is the backend default (defaultOtpCodeLength)
+// and what test/staging projects use, so parse OTP codes at that length.
+export const OTP_CODE_LENGTH = 6
 
 export const HEALTH_CHECK_RETRIES = 5
 export const HEALTH_CHECK_INTERVAL_MS = 2_000

--- a/e2e/helpers/otp-login.ts
+++ b/e2e/helpers/otp-login.ts
@@ -35,10 +35,6 @@ export async function completeOtpLogin(
     email: emailAccount.address,
     contact: { type: 'email', contact: emailAccount.address },
     projectId,
-    otpCodeCustomization: {
-      length: OTP_CODE_LENGTH as 6 | 7 | 8 | 9,
-      alphanumeric: false,
-    },
   })
 
   const emailContent = await searchForNewEmail(

--- a/e2e/helpers/otp-utils.ts
+++ b/e2e/helpers/otp-utils.ts
@@ -36,7 +36,7 @@ export function extractMagicLinkCode(content: string): string | null {
 /**
  * Extracts the OTP code from a magic link URL in email content.
  *
- * When using OTP with emailCustomization.magicLinkTemplate, Turnkey sends
+ * When a project is configured with a magic-link template, Turnkey sends
  * an email containing a URL with the OTP code embedded as a query parameter.
  * For example, with template "http://localhost:3000/callback?code=%s",
  * the email will contain "http://localhost:3000/callback?code=1234567".

--- a/e2e/integration/magic-link-flow.test.ts
+++ b/e2e/integration/magic-link-flow.test.ts
@@ -3,13 +3,16 @@
  *
  * Magic link is built on top of the OTP flow. Instead of sending a plain
  * OTP code, Turnkey embeds the code into a clickable URL in the email.
- * The SDK uses registerWithOTP with emailCustomization.magicLinkTemplate
- * where %s is replaced with the OTP code by Turnkey.
+ * Whether a magic link (vs a plain code) is sent — and the link's URL
+ * template — is configured per-project on the backend
+ * (`wallet.otp_configs.magic_link_template`); the SDK just calls
+ * registerWithOTP. This test extracts the code from the magic-link URL when
+ * present and otherwise falls back to plain-code extraction.
  *
  * Flow:
  * 1. Create temp email account
- * 2. Register with OTP + emailCustomization.magicLinkTemplate
- * 3. Extract OTP code from the magic link URL in the email
+ * 2. Register with OTP
+ * 3. Extract OTP code from the magic link URL in the email (or plain code)
  * 4. Verify OTP with Auth Proxy
  * 5. Build client signature
  * 6. Login with OTP via backend
@@ -42,12 +45,6 @@ import {
 } from '../helpers/temp-email.js'
 import { createTestClient } from '../helpers/test-client.js'
 import { createTestStamper } from '../helpers/test-stamper.js'
-
-// The magic link template URL must have an origin that matches the project's
-// ACL security policies. The test client uses Origin: http://localhost:3000
-// which should be allowed by the staging project.
-const MAGIC_LINK_REDIRECT_URL =
-  process.env.MAGIC_LINK_REDIRECT_URL || 'http://localhost:3000/auth/callback'
 
 describe('Magic Link Authentication Flow', () => {
   let projectId: string
@@ -95,19 +92,14 @@ describe('Magic Link Authentication Flow', () => {
     // Step 3: Create SDK client
     const client = createTestClient(stamper)
 
-    // Step 4: Register with OTP + magic link template
-    // The magic link template uses %s as a placeholder for the OTP code.
-    // Turnkey will replace %s with the actual code in the email.
-    const magicLinkTemplate = `${MAGIC_LINK_REDIRECT_URL}${MAGIC_LINK_REDIRECT_URL.includes('?') ? '&' : '?'}code=%s`
-    console.log(`Magic link template: ${magicLinkTemplate}`)
-
+    // Step 4: Register with OTP. Whether the email carries a magic link or a
+    // plain code (and the link template) is configured per-project on the
+    // backend (`wallet.otp_configs.magic_link_template`); the client no longer
+    // supplies a template.
     const registerResult = await client.registerWithOTP({
       email,
       contact: { type: 'email', contact: email },
       projectId,
-      emailCustomization: {
-        magicLinkTemplate,
-      },
     })
     expect(registerResult.otpId).toBeTruthy()
     expect(registerResult.otpEncryptionTargetBundle).toBeTruthy()

--- a/e2e/integration/otp-flow.test.ts
+++ b/e2e/integration/otp-flow.test.ts
@@ -92,10 +92,6 @@ describe('OTP Authentication Flow', () => {
       email,
       contact: { type: 'email', contact: email },
       projectId,
-      otpCodeCustomization: {
-        length: OTP_CODE_LENGTH as 6 | 7 | 8 | 9,
-        alphanumeric: false,
-      },
     })
     expect(registerResult.otpId).toBeTruthy()
     expect(registerResult.otpEncryptionTargetBundle).toBeTruthy()
@@ -185,10 +181,6 @@ describe('OTP Authentication Flow', () => {
       email,
       contact: { type: 'email', contact: email },
       projectId,
-      otpCodeCustomization: {
-        length: OTP_CODE_LENGTH as 6 | 7 | 8 | 9,
-        alphanumeric: false,
-      },
     })
 
     // Try to verify with a wrong code

--- a/e2e/integration/otp-init-shape.test.ts
+++ b/e2e/integration/otp-init-shape.test.ts
@@ -45,7 +45,6 @@ describe('OTP init wire shape', () => {
           type: 'email',
           contact: `smoke-${Date.now()}@example.com`,
         },
-        otpCodeCustomization: { length: 7, alphanumeric: false },
       }),
     })
     expect(res.ok).toBe(true)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -83,21 +83,12 @@ await wallet.auth({
 ### Email Magic Link
 
 ```typescript
-// Send magic link
+// Send magic link. The link URL template and OTP code format are configured
+// per-project on the backend (`wallet.otp_configs`).
 const { otpId } = await wallet.auth({
   type: 'magicLink',
   mode: 'send',
   email: 'user@example.com',
-  redirectURL: 'https://yourapp.com/verify',
-});
-
-// With custom OTP code settings
-const { otpId } = await wallet.auth({
-  type: 'magicLink',
-  mode: 'send',
-  email: 'user@example.com',
-  redirectURL: 'https://yourapp.com/verify',
-  otpCodeCustomization: { length: 8, alphanumeric: false },
 });
 
 // After user clicks link (on /verify page), extract code from URL
@@ -121,15 +112,6 @@ const { otpId } = await wallet.auth({
   contact: { type: 'email', contact: 'user@example.com' }
 });
 
-// With custom OTP code settings
-const { otpId } = await wallet.auth({
-  type: 'otp',
-  mode: 'sendOtp',
-  email: 'user@example.com',
-  contact: { type: 'email', contact: 'user@example.com' },
-  otpCodeCustomization: { length: 8, alphanumeric: false },
-});
-
 // Step 2: Verify OTP code
 await wallet.auth({
   type: 'otp',
@@ -138,15 +120,6 @@ await wallet.auth({
   otpCode: '12345678',
 });
 ```
-
-### OTP Code Customization
-
-Both OTP and magic link `send` modes accept an optional `otpCodeCustomization` parameter:
-
-| Field | Type | Description |
-|---|---|---|
-| `length` | `6 \| 7 \| 8 \| 9` | Code length (default: 6) |
-| `alphanumeric` | `boolean` | Use alphanumeric characters instead of digits only (default: false) |
 
 ### OAuth (Google)
 

--- a/packages/core/src/actions/auth/auth.test.ts
+++ b/packages/core/src/actions/auth/auth.test.ts
@@ -135,7 +135,6 @@ describe('authenticateWithEmail', () => {
       method: 'POST',
       body: {
         email: 'user@example.com',
-        emailCustomization: undefined,
         targetPublicKey: '03abcdef1234567890',
         projectId: 'proj-456',
       },
@@ -144,29 +143,6 @@ describe('authenticateWithEmail', () => {
       userId: 'user-123',
       requiresMagicLink: true,
     })
-  })
-
-  it('includes email customization when provided', async () => {
-    const mockClient = createMockClient(async () => ({}))
-
-    await authenticateWithEmail(mockClient, {
-      email: 'user@example.com',
-      projectId: 'proj-456',
-      targetPublicKey: '03abcdef',
-      emailCustomization: {
-        magicLinkTemplate: 'https://myapp.com/verify/%s',
-      },
-    })
-
-    expect(mockClient.request).toHaveBeenCalledWith(
-      expect.objectContaining({
-        body: expect.objectContaining({
-          emailCustomization: {
-            magicLinkTemplate: 'https://myapp.com/verify/%s',
-          },
-        }),
-      }),
-    )
   })
 
   it('returns turnkey session when available', async () => {
@@ -382,15 +358,12 @@ describe('getAuthenticators', () => {
 
     expect(mockClient.request).toHaveBeenCalledWith({
       path: 'proj-456/authenticators',
-      method: 'POST',
-      body: {
-        subOrganizationId: 'suborg-123',
-      },
+      method: 'GET',
       headers: {
         Authorization: 'Bearer test-token',
       },
       stamp: true,
-      stampPostion: 'headers',
+      stampPostion: 'timestamp',
     })
     expect(result).toEqual(mockResponse)
   })

--- a/packages/core/src/actions/auth/authenticateWithEmail.ts
+++ b/packages/core/src/actions/auth/authenticateWithEmail.ts
@@ -1,10 +1,5 @@
 import type { Client } from '../../client/types.js'
 
-export type EmailCustomization = {
-  /** A template for the URL to be used in a magic link button, e.g. `https://dapp.xyz/%s`. The auth bundle will be interpolated into the `%s`. */
-  magicLinkTemplate?: string
-}
-
 export type AuthenticateWithEmailParameters = {
   /** The email address to authenticate */
   email: string
@@ -12,8 +7,6 @@ export type AuthenticateWithEmailParameters = {
   projectId: string
   /** Target public key for authentication */
   targetPublicKey: string
-  /** Optional email customization settings */
-  emailCustomization?: EmailCustomization
 }
 
 export type AuthenticateWithEmailReturnType = {
@@ -37,14 +30,13 @@ export async function authenticateWithEmail(
   client: Client,
   params: AuthenticateWithEmailParameters,
 ): Promise<AuthenticateWithEmailReturnType> {
-  const { email, projectId, targetPublicKey, emailCustomization } = params
+  const { email, projectId, targetPublicKey } = params
 
   return await client.request({
     path: `${projectId}/auth/email-magic`,
     method: 'POST',
     body: {
       email,
-      emailCustomization,
       targetPublicKey,
       projectId,
     },

--- a/packages/core/src/actions/auth/getAuthenticators.ts
+++ b/packages/core/src/actions/auth/getAuthenticators.ts
@@ -72,18 +72,18 @@ export async function getAuthenticators(
   client: Client,
   params: GetAuthenticatorsParameters,
 ): Promise<GetAuthenticatorsReturnType> {
-  const { subOrganizationId, projectId, token } = params
+  const { projectId, token } = params
 
+  // GET behind StampCheckUser: the backend resolves the user from the stamped
+  // credential (+ session JWT), so no body / sub-org is sent. The stamp signs
+  // the X-Timestamp value (see transport `stampPostion: 'timestamp'`).
   return await client.request({
     path: `${projectId}/authenticators`,
-    method: 'POST',
-    body: {
-      subOrganizationId,
-    },
+    method: 'GET',
     headers: {
       Authorization: `Bearer ${token}`,
     },
     stamp: true,
-    stampPostion: 'headers',
+    stampPostion: 'timestamp',
   })
 }

--- a/packages/core/src/actions/auth/index.ts
+++ b/packages/core/src/actions/auth/index.ts
@@ -2,7 +2,6 @@ export {
   type AuthenticateWithEmailParameters,
   type AuthenticateWithEmailReturnType,
   authenticateWithEmail,
-  type EmailCustomization,
 } from './authenticateWithEmail.js'
 
 export {
@@ -44,7 +43,6 @@ export {
   loginWithStamp,
 } from './loginWithStamp.js'
 export {
-  type OtpCodeCustomization,
   type OtpContact,
   type RegisterWithOTPParameters,
   type RegisterWithOTPReturnType,

--- a/packages/core/src/actions/auth/loginWithStamp.ts
+++ b/packages/core/src/actions/auth/loginWithStamp.ts
@@ -3,11 +3,6 @@ import type { Client } from '../../client/types.js'
 import type { Stamp } from '../../stampers/types.js'
 import type { StamperType } from '../../types/session.js'
 
-export type EmailCustomization = {
-  /** A template for the URL to be used in a magic link button, e.g. `https://dapp.xyz/%s`. The auth bundle will be interpolated into the `%s`. */
-  magicLinkTemplate?: string
-}
-
 export type LoginWithStampParameters = {
   /** The project ID for the request */
   projectId: string

--- a/packages/core/src/actions/auth/otp.test.ts
+++ b/packages/core/src/actions/auth/otp.test.ts
@@ -57,42 +57,12 @@ describe('registerWithOTP', () => {
           type: 'email',
           contact: 'user@example.com',
         },
-        emailCustomization: undefined,
       },
     })
     expect(result).toEqual({
       otpId: 'otp-123',
       otpEncryptionTargetBundle: 'bundle-stub',
     })
-  })
-
-  it('includes email customization when provided', async () => {
-    const mockClient = createMockClient(async () => ({
-      otpId: 'otp-123',
-      otpEncryptionTargetBundle: 'bundle-stub',
-    }))
-
-    await registerWithOTP(mockClient, {
-      email: 'user@example.com',
-      contact: {
-        type: 'email',
-        contact: 'user@example.com',
-      },
-      projectId: 'proj-456',
-      emailCustomization: {
-        magicLinkTemplate: 'https://example.com/verify/%s',
-      },
-    })
-
-    expect(mockClient.request).toHaveBeenCalledWith(
-      expect.objectContaining({
-        body: expect.objectContaining({
-          emailCustomization: {
-            magicLinkTemplate: 'https://example.com/verify/%s',
-          },
-        }),
-      }),
-    )
   })
 
   it('supports SMS contact type', async () => {

--- a/packages/core/src/actions/auth/registerWithOTP.ts
+++ b/packages/core/src/actions/auth/registerWithOTP.ts
@@ -1,18 +1,10 @@
 import type { Client } from '../../client/types.js'
-import type { EmailCustomization } from './authenticateWithEmail.js'
 
 export type OtpContact = {
   /** The OTP delivery type (currently only 'email' is supported) */
   type: 'email' | 'sms'
   /** The contact information (email address or phone number) */
   contact: string
-}
-
-export type OtpCodeCustomization = {
-  /** The length of the OTP code (must be between 6 and 9 inclusive) */
-  length: 6 | 7 | 8 | 9
-  /** Whether the OTP code should be alphanumeric */
-  alphanumeric: boolean
 }
 
 export type RegisterWithOTPParameters = {
@@ -22,10 +14,6 @@ export type RegisterWithOTPParameters = {
   contact: OtpContact
   /** The project ID for the request */
   projectId: string
-  /** Optional email customization settings */
-  emailCustomization?: EmailCustomization
-  /** Optional OTP code customization settings */
-  otpCodeCustomization?: OtpCodeCustomization
 }
 
 export type RegisterWithOTPReturnType = {
@@ -42,6 +30,10 @@ export type RegisterWithOTPReturnType = {
 /**
  * Initiates OTP (One-Time Password) authentication
  * This will send an OTP code to the specified contact method
+ *
+ * OTP code length/format and, when enabled, the magic-link URL template are
+ * configured per-project on the backend (`wallet.otp_configs`). The client no
+ * longer sends customization fields — they are ignored server-side.
  *
  * @param client - The ZeroDev Wallet client
  * @param params - The parameters for OTP initiation
@@ -65,20 +57,7 @@ export async function registerWithOTP(
   client: Client,
   params: RegisterWithOTPParameters,
 ): Promise<RegisterWithOTPReturnType> {
-  const {
-    email,
-    contact,
-    projectId,
-    emailCustomization,
-    otpCodeCustomization,
-  } = params
-
-  if (
-    otpCodeCustomization &&
-    (otpCodeCustomization.length < 6 || otpCodeCustomization.length > 9)
-  ) {
-    throw new Error('OTP code length must be between 6 and 9')
-  }
+  const { email, contact, projectId } = params
 
   return await client.request({
     path: `${projectId}/auth/init/otp`,
@@ -86,8 +65,6 @@ export async function registerWithOTP(
     body: {
       email,
       contact,
-      emailCustomization,
-      otpCodeCustomization,
     },
   })
 }

--- a/packages/core/src/actions/auth/registerWithPasskey.ts
+++ b/packages/core/src/actions/auth/registerWithPasskey.ts
@@ -1,10 +1,5 @@
 import type { Client } from '../../client/types.js'
 
-export type EmailCustomization = {
-  /** A template for the URL to be used in a magic link button, e.g. `https://dapp.xyz/%s`. The auth bundle will be interpolated into the `%s`. */
-  magicLinkTemplate?: string
-}
-
 export type RegisterWithPasskeyParameters = {
   /** The project ID for the request */
   projectId: string

--- a/packages/core/src/actions/index.ts
+++ b/packages/core/src/actions/index.ts
@@ -8,7 +8,6 @@ export {
   authenticateWithEmail,
   authenticateWithOAuth,
   type EmailContact,
-  type EmailCustomization,
   type GetAuthenticatorsParameters,
   type GetAuthenticatorsReturnType,
   type GetAuthProxyConfigIdReturnType,

--- a/packages/core/src/actions/wallet/getUserWallet.ts
+++ b/packages/core/src/actions/wallet/getUserWallet.ts
@@ -37,17 +37,17 @@ export async function getUserWallet(
   client: Client,
   params: GetUserWalletParameters,
 ): Promise<GetUserWalletReturnType> {
-  const { organizationId, projectId, token } = params
+  const { projectId, token } = params
 
+  // GET behind StampCheckUser: user is resolved from the stamped credential
+  // (+ session JWT); no body sent. The stamp signs the X-Timestamp value.
   return await client.request({
     path: `${projectId}/user-wallet`,
-    body: {
-      organizationId,
-    },
+    method: 'GET',
     headers: {
       Authorization: `Bearer ${token}`,
     },
     stamp: true,
-    stampPostion: 'headers',
+    stampPostion: 'timestamp',
   })
 }

--- a/packages/core/src/actions/wallet/wallet.test.ts
+++ b/packages/core/src/actions/wallet/wallet.test.ts
@@ -665,14 +665,12 @@ describe('getUserWallet', () => {
 
     expect(mockClient.request).toHaveBeenCalledWith({
       path: 'proj-456/user-wallet',
-      body: {
-        organizationId: 'org-123',
-      },
+      method: 'GET',
       headers: {
         Authorization: 'Bearer bearer-token-jwt',
       },
       stamp: true,
-      stampPostion: 'headers',
+      stampPostion: 'timestamp',
     })
     expect(result).toEqual({
       walletAddresses: [
@@ -732,7 +730,7 @@ describe('getUserWallet', () => {
     )
   })
 
-  it('requests stamping in headers', async () => {
+  it('requests a timestamped stamp on a GET', async () => {
     const mockClient = createMockClient(async () => ({ walletAddresses: [] }))
 
     await getUserWallet(mockClient, {
@@ -743,8 +741,9 @@ describe('getUserWallet', () => {
 
     expect(mockClient.request).toHaveBeenCalledWith(
       expect.objectContaining({
+        method: 'GET',
         stamp: true,
-        stampPostion: 'headers',
+        stampPostion: 'timestamp',
       }),
     )
   })

--- a/packages/core/src/client/transports/rest.test.ts
+++ b/packages/core/src/client/transports/rest.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ApiKeyStamper, PasskeyStamper } from '../../stampers/types.js'
+import { rest } from './rest.js'
+
+function makeStamper(headerName: string) {
+  const stamp = vi.fn(async (payload: string) => ({
+    stampHeaderName: headerName,
+    // Echo the signed payload back so tests can assert what was signed.
+    stampHeaderValue: `signed:${payload}`,
+  }))
+  return { stamp } as unknown as ApiKeyStamper & { stamp: typeof stamp }
+}
+
+describe('rest transport — timestamp stamp position (GET behind StampCheckUser)', () => {
+  const apiKeyStamper = makeStamper('X-Stamp')
+  const passkeyStamper = makeStamper('X-Stamp-Webauthn')
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => 'application/json' },
+      json: async () => ({ ok: true }),
+      text: async () => '{"ok":true}',
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('signs the unix-millis string, sends X-Timestamp + stamp header, and no body', async () => {
+    const transport = rest('https://kms.test/api/v1', {
+      apiKeyStamper,
+      passkeyStamper,
+    })
+
+    await transport.request({
+      path: 'proj-456/user-wallet',
+      method: 'GET',
+      headers: { Authorization: 'Bearer jwt-token' },
+      stamp: true,
+      stampPostion: 'timestamp',
+    })
+
+    // The stamper signed exactly the X-Timestamp value (the raw millis string),
+    // matching the backend's FormatTimestamp(t) = strconv.FormatInt(UnixMilli, 10).
+    expect(apiKeyStamper.stamp).toHaveBeenCalledTimes(1)
+    const signedPayload = apiKeyStamper.stamp.mock.calls[0]![0] as string
+    expect(signedPayload).toMatch(/^\d+$/)
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe('https://kms.test/api/v1/proj-456/user-wallet')
+    expect(init.method).toBe('GET')
+    // GET has no request body.
+    expect(init.body).toBeNull()
+
+    const headers = init.headers as Record<string, string>
+    expect(headers['X-Timestamp']).toBe(signedPayload)
+    expect(headers['X-Stamp']).toBe(`signed:${signedPayload}`)
+    expect(headers.Authorization).toBe('Bearer jwt-token')
+  })
+
+  it('uses the passkey stamper when stampWith is passkey', async () => {
+    const transport = rest('https://kms.test/api/v1', {
+      apiKeyStamper,
+      passkeyStamper,
+    })
+
+    await transport.request({
+      path: 'proj-456/authenticators',
+      method: 'GET',
+      stamp: true,
+      stampWith: 'passkey',
+      stampPostion: 'timestamp',
+    })
+
+    expect(passkeyStamper.stamp).toHaveBeenCalledTimes(1)
+    expect(apiKeyStamper.stamp).not.toHaveBeenCalled()
+    const [, init] = fetchMock.mock.calls[0]!
+    const headers = init.headers as Record<string, string>
+    const ts = headers['X-Timestamp']!
+    expect(headers['X-Stamp-Webauthn']).toBe(`signed:${ts}`)
+  })
+})

--- a/packages/core/src/client/transports/rest.ts
+++ b/packages/core/src/client/transports/rest.ts
@@ -10,7 +10,14 @@ export type RestRequestArgs = {
   headers?: Record<string, string>
   stamp?: boolean
   stampWith?: StamperType
-  stampPostion?: 'body' | 'headers'
+  /**
+   * Where the stamp goes / what it signs:
+   * - `body`/`headers`: sign the canonicalized request body (POST endpoints).
+   * - `timestamp`: GET endpoints behind StampCheckUser — sign the current
+   *   unix-millis string, send it as the `X-Timestamp` header plus the stamp
+   *   header. No request body. Matches the backend's `FormatTimestamp`.
+   */
+  stampPostion?: 'body' | 'headers' | 'timestamp'
   /** Include credentials (cookies) in the request */
   credentials?: RequestCredentials
 }
@@ -49,8 +56,8 @@ export function rest(url: string, cfg: RestTransportConfig): RestTransport {
 
     try {
       let requestBody = args.body
-      let requestHeaders = {
-        ...(cfg.fetchOptions?.headers ?? {}),
+      let requestHeaders: Record<string, string> = {
+        ...((cfg.fetchOptions?.headers as Record<string, string>) ?? {}),
         ...(args.headers ?? {}),
         'content-type': 'application/json',
       }
@@ -65,32 +72,47 @@ export function rest(url: string, cfg: RestTransportConfig): RestTransport {
         } else {
           stamper = cfg.apiKeyStamper
         }
-        const { body, apiUrl } = args.body
-        const bodyString = canonicalizeEx(body ?? args.body)
-        const stamp = await stamper.stamp(bodyString)
 
-        // Restructure request body to match backend expectation
-        if (args.stampPostion === 'headers') {
+        // Timestamped stamp for GET endpoints behind StampCheckUser: the
+        // signed body is the unix-millis string itself (the backend rebuilds
+        // it from the X-Timestamp header via FormatTimestamp). No request body.
+        if (args.stampPostion === 'timestamp') {
+          const ts = Date.now().toString()
+          const stamp = await stamper.stamp(ts)
           requestHeaders = {
             ...requestHeaders,
+            'X-Timestamp': ts,
             [stamp.stampHeaderName]: stamp.stampHeaderValue,
           }
-        } else if (body) {
-          requestBody = {
-            body: bodyString,
-            stamp: {
-              stampHeaderName: stamp.stampHeaderName,
-              stampHeaderValue: stamp.stampHeaderValue,
-            },
-            apiUrl: apiUrl,
-          }
+          requestBody = undefined
         } else {
-          requestBody = {
-            ...args.body,
-            stamp: {
-              stampHeaderName: stamp.stampHeaderName,
-              stampHeaderValue: stamp.stampHeaderValue,
-            },
+          const { body, apiUrl } = args.body
+          const bodyString = canonicalizeEx(body ?? args.body)
+          const stamp = await stamper.stamp(bodyString)
+
+          // Restructure request body to match backend expectation
+          if (args.stampPostion === 'headers') {
+            requestHeaders = {
+              ...requestHeaders,
+              [stamp.stampHeaderName]: stamp.stampHeaderValue,
+            }
+          } else if (body) {
+            requestBody = {
+              body: bodyString,
+              stamp: {
+                stampHeaderName: stamp.stampHeaderName,
+                stampHeaderValue: stamp.stampHeaderValue,
+              },
+              apiUrl: apiUrl,
+            }
+          } else {
+            requestBody = {
+              ...args.body,
+              stamp: {
+                stampHeaderName: stamp.stampHeaderName,
+                stampHeaderValue: stamp.stampHeaderValue,
+              },
+            }
           }
         }
       }

--- a/packages/core/src/core/createZeroDevWalletCore.ts
+++ b/packages/core/src/core/createZeroDevWalletCore.ts
@@ -1,8 +1,4 @@
 import type { LocalAccount } from 'viem/accounts'
-import type {
-  EmailCustomization,
-  OtpCodeCustomization,
-} from '../actions/auth/index.js'
 import { toViemAccount } from '../adapters/viem.js'
 import {
   type CreateTransportOptions,
@@ -37,8 +33,6 @@ export interface ZeroDevWalletConfigCore {
   fetchOptions?: CreateTransportOptions['fetchOptions']
 }
 
-// Re-export EmailCustomization for convenience
-export type { EmailCustomization } from '../actions/auth/index.js'
 export type { StorageAdapter, StorageManager } from '../storage/manager.js'
 // Re-export new session types
 export type { StamperType, ZeroDevWalletSession } from '../types/session.js'
@@ -61,8 +55,6 @@ export type AuthParams =
         type: 'email' | 'sms'
         contact: string
       }
-      emailCustomization?: EmailCustomization
-      otpCodeCustomization?: OtpCodeCustomization
     }
   | {
       type: 'otp'
@@ -79,8 +71,6 @@ export type AuthParams =
       type: 'magicLink'
       mode: 'send'
       email: string
-      redirectURL: string
-      otpCodeCustomization?: OtpCodeCustomization
     }
   | {
       type: 'magicLink'
@@ -338,17 +328,14 @@ export async function createZeroDevWalletCore(
           let otpParams: Extract<AuthParams, { type: 'otp' }>
           if (params.type === 'magicLink') {
             if (params.mode === 'send') {
+              // Magic-link vs plain-OTP delivery and the link URL template are
+              // configured per-project on the backend (`wallet.otp_configs`);
+              // the client just initiates OTP and the backend decides.
               otpParams = {
                 type: 'otp',
                 mode: 'sendOtp',
                 email: params.email,
                 contact: { type: 'email', contact: params.email },
-                emailCustomization: {
-                  magicLinkTemplate: `${params.redirectURL}${params.redirectURL.includes('?') ? '&' : '?'}code=%s`,
-                },
-                ...(params.otpCodeCustomization && {
-                  otpCodeCustomization: params.otpCodeCustomization,
-                }),
               }
             } else {
               otpParams = {
@@ -364,15 +351,12 @@ export async function createZeroDevWalletCore(
           }
 
           if (otpParams.mode === 'sendOtp') {
-            const { email, contact, emailCustomization, otpCodeCustomization } =
-              otpParams
+            const { email, contact } = otpParams
 
             const data = await client.registerWithOTP({
               email,
               contact,
               projectId,
-              ...(emailCustomization && { emailCustomization }),
-              ...(otpCodeCustomization && { otpCodeCustomization }),
             })
 
             return data

--- a/packages/core/src/index.native.ts
+++ b/packages/core/src/index.native.ts
@@ -19,7 +19,6 @@ export type {
   AuthenticateWithOAuthParameters,
   AuthenticateWithOAuthReturnType,
   EmailContact,
-  EmailCustomization,
   GetAuthenticatorsParameters,
   GetAuthenticatorsReturnType,
   GetUserWalletParameters,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,7 +15,6 @@ export type {
   AuthenticateWithOAuthParameters,
   AuthenticateWithOAuthReturnType,
   EmailContact,
-  EmailCustomization,
   GetAuthenticatorsParameters,
   GetAuthenticatorsReturnType,
   // Wallet types

--- a/packages/react-kit/README.md
+++ b/packages/react-kit/README.md
@@ -27,7 +27,6 @@ pnpm add @zerodev/wallet-react-kit wagmi viem @tanstack/react-query
          chains: [sepolia],
          config: {
            auth: {
-             magicLinkBaseUrl: 'https://yourdomain.com/auth/verify',
              enabledMethods: ['email', 'google', 'passkey'],
            },
          },

--- a/packages/react-kit/docs/components/WalletProvider.tsx
+++ b/packages/react-kit/docs/components/WalletProvider.tsx
@@ -12,7 +12,6 @@ const config = createConfig({
       chains: [sepolia],
       config: {
         auth: {
-          magicLinkBaseUrl: 'http://localhost:5173/verify',
           enabledMethods: ['email', 'google', 'passkey'],
         },
       },

--- a/packages/react-kit/docs/pages/react-kit/configuration.mdx
+++ b/packages/react-kit/docs/pages/react-kit/configuration.mdx
@@ -25,7 +25,6 @@ zeroDevWallet({
   chains: [sepolia],
   config: {
     auth: {
-      magicLinkBaseUrl: 'https://yourdomain.com/auth/verify',
       enabledMethods: ['email', 'google', 'passkey'],
       termsAndConditionsUrl: 'https://yourdomain.com/terms',
       privacyPolicyUrl: 'https://yourdomain.com/privacy',
@@ -38,7 +37,6 @@ zeroDevWallet({
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `magicLinkBaseUrl` | `string` | The URL the magic link points to. |
 | `enabledMethods` | `AuthMethod[]` | Which methods to offer: `'email'`, `'google'`, `'passkey'`. |
 | `termsAndConditionsUrl` | `string` (optional) | Your terms and conditions URL. When set (alone or with `privacyPolicyUrl`), the auth UI shows a required agreement checkbox. |
 | `privacyPolicyUrl` | `string` (optional) | Your privacy policy URL. When set (alone or with `termsAndConditionsUrl`), the auth UI shows a required agreement checkbox. |

--- a/packages/react-kit/docs/pages/react-kit/features/authentication.mdx
+++ b/packages/react-kit/docs/pages/react-kit/features/authentication.mdx
@@ -24,7 +24,6 @@ zeroDevWallet({
   chains: [sepolia],
   config: {
     auth: {
-      magicLinkBaseUrl: 'https://yourdomain.com/auth/verify',
       enabledMethods: ['email', 'google', 'passkey'],
       termsAndConditionsUrl: 'https://yourdomain.com/terms',
       privacyPolicyUrl: 'https://yourdomain.com/privacy',
@@ -41,7 +40,6 @@ zeroDevWallet({
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `magicLinkBaseUrl` | `string` | The URL the magic link points to. Your app should call the verification handler at this path. |
 | `enabledMethods` | `AuthMethod[]` | Which methods to offer: `'email'`, `'google'`, `'passkey'`. |
 | `termsAndConditionsUrl` | `string` (optional) | URL for your terms and conditions page. When set (alone or with `privacyPolicyUrl`), the auth UI shows a required agreement checkbox before the user can continue. |
 | `privacyPolicyUrl` | `string` (optional) | URL for your privacy policy page. When set (alone or with `termsAndConditionsUrl`), the auth UI shows a required agreement checkbox before the user can continue. |

--- a/packages/react-kit/src/auth/authStoreSlice.test.ts
+++ b/packages/react-kit/src/auth/authStoreSlice.test.ts
@@ -4,7 +4,6 @@ import type { AuthConfig } from './types'
 
 function createMockAuthConfig(overrides?: Partial<AuthConfig>): AuthConfig {
   return {
-    magicLinkBaseUrl: 'https://example.com/auth/verify',
     enabledMethods: ['email', 'google', 'passkey'],
     onSuccess: () => {},
     onError: () => {},

--- a/packages/react-kit/src/auth/hooks/useAuth.test.ts
+++ b/packages/react-kit/src/auth/hooks/useAuth.test.ts
@@ -26,7 +26,6 @@ afterEach(() => {
 
 function createMockAuthConfig(overrides?: Partial<AuthConfig>): AuthConfig {
   return {
-    magicLinkBaseUrl: 'https://example.com/auth/verify',
     enabledMethods: ['email', 'google', 'passkey'],
     onSuccess: () => {},
     onError: () => {},

--- a/packages/react-kit/src/auth/pages/EmailVerification.tsx
+++ b/packages/react-kit/src/auth/pages/EmailVerification.tsx
@@ -6,7 +6,7 @@ import { Text } from '../../shared/components/Text'
 import { useAuth } from '../hooks/useAuth'
 
 export function EmailVerification() {
-  const { email, setOtpSession, config } = useAuth()
+  const { email, setOtpSession } = useAuth()
   const { mutateAsync: sendMagicLink, isPending: isSendPending } =
     useSendMagicLink()
 
@@ -31,7 +31,6 @@ export function EmailVerification() {
     try {
       const { otpId, otpEncryptionTargetBundle } = await sendMagicLink({
         email,
-        redirectURL: config?.magicLinkBaseUrl ?? '',
       })
       setOtpSession({ otpId, otpEncryptionTargetBundle })
       setSecondsLeftUntilResend(60)

--- a/packages/react-kit/src/auth/pages/SignUp.tsx
+++ b/packages/react-kit/src/auth/pages/SignUp.tsx
@@ -164,7 +164,6 @@ export function SignUp() {
     try {
       const { otpId, otpEncryptionTargetBundle } = await sendMagicLink({
         email: emailInput,
-        redirectURL: config?.magicLinkBaseUrl ?? '',
       })
       setEmail(emailInput)
       setOtpSession({ otpId, otpEncryptionTargetBundle })

--- a/packages/react-kit/src/auth/types.ts
+++ b/packages/react-kit/src/auth/types.ts
@@ -14,7 +14,6 @@ export type AuthStep =
 export type EmailAuthMethod = 'magicLink' | 'otp'
 
 export interface AuthConfig {
-  magicLinkBaseUrl: string
   enabledMethods: AuthMethod[]
   emailAuthMethod?: EmailAuthMethod
   termsAndConditionsUrl?: string

--- a/packages/react-kit/src/connector.test.ts
+++ b/packages/react-kit/src/connector.test.ts
@@ -231,7 +231,6 @@ describe('connector', () => {
   describe('auth integration', () => {
     it('initializes auth when config is provided', () => {
       const authConfig = {
-        magicLinkBaseUrl: 'https://example.com/auth/verify',
         enabledMethods: ['email' as const, 'google' as const],
         onSuccess: vi.fn(),
         onError: vi.fn(),
@@ -257,7 +256,6 @@ describe('connector', () => {
 
     it('auth config works with signing config', () => {
       const authConfig = {
-        magicLinkBaseUrl: 'https://example.com/auth/verify',
         enabledMethods: ['passkey' as const],
       }
       const connector = createKitConnector({
@@ -274,7 +272,6 @@ describe('connector', () => {
 
     it('disconnect resets auth state to null step', async () => {
       const authConfig = {
-        magicLinkBaseUrl: 'https://example.com/auth/verify',
         enabledMethods: ['email' as const],
       }
       const connector = createKitConnector({
@@ -297,7 +294,6 @@ describe('connector', () => {
 
     it('supports all auth methods in config', () => {
       const authConfig = {
-        magicLinkBaseUrl: 'https://example.com/auth/verify',
         enabledMethods: [
           'email' as const,
           'google' as const,
@@ -318,7 +314,6 @@ describe('connector', () => {
 
     it('auth state persists across signing operations', async () => {
       const authConfig = {
-        magicLinkBaseUrl: 'https://example.com/auth/verify',
         enabledMethods: ['email' as const],
       }
       const connector = createKitConnector({

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -158,17 +158,10 @@ await authenticateOAuth.mutateAsync({
 const sendMagicLink = useSendMagicLink()
 const verifyMagicLink = useVerifyMagicLink()
 
-// Send magic link
+// Send magic link. The link URL template and OTP code format are configured
+// per-project on the backend (`wallet.otp_configs`).
 const { otpId } = await sendMagicLink.mutateAsync({
   email: 'user@example.com',
-  redirectURL: 'https://yourapp.com/verify',
-})
-
-// With custom OTP code settings
-const { otpId } = await sendMagicLink.mutateAsync({
-  email: 'user@example.com',
-  redirectURL: 'https://yourapp.com/verify',
-  otpCodeCustomization: { length: 8, alphanumeric: false },
 })
 
 // Verify (on /verify page, extract code from URL)
@@ -187,27 +180,12 @@ const { otpId } = await sendOTP.mutateAsync({
   email: 'user@example.com'
 })
 
-// With custom OTP code settings
-const { otpId } = await sendOTP.mutateAsync({
-  email: 'user@example.com',
-  otpCodeCustomization: { length: 8, alphanumeric: false },
-})
-
 // Verify OTP code
 await verifyOTP.mutateAsync({
   code: '12345678',
   otpId,
 })
 ```
-
-### OTP Code Customization
-
-Both `useSendOTP` and `useSendMagicLink` accept an optional `otpCodeCustomization` parameter:
-
-| Field | Type | Description |
-|---|---|---|
-| `length` | `6 \| 7 \| 8 \| 9` | Code length (default: 6) |
-| `alphanumeric` | `boolean` | Use alphanumeric characters instead of digits only (default: false) |
 
 ## Configuration Options
 

--- a/packages/react/src/actions.test.ts
+++ b/packages/react/src/actions.test.ts
@@ -281,28 +281,6 @@ describe('React Actions', () => {
       })
     })
 
-    it('includes email customization when provided', async () => {
-      const wallet = createMockWallet()
-      const store = createMockStore(wallet)
-      const connector = createMockConnector(store)
-      const config = createMockConfig(connector)
-
-      await sendOTP(config, {
-        email: 'user@example.com',
-        emailCustomization: { magicLinkTemplate: 'https://app.com/verify/%s' },
-      })
-
-      expect(wallet.auth).toHaveBeenCalledWith({
-        type: 'otp',
-        mode: 'sendOtp',
-        email: 'user@example.com',
-        contact: { type: 'email', contact: 'user@example.com' },
-        emailCustomization: {
-          magicLinkTemplate: 'https://app.com/verify/%s',
-        },
-      })
-    })
-
     it('throws when wallet is not initialized', async () => {
       const store = createMockStore(null)
       const connector = createMockConnector(store)

--- a/packages/react/src/actions.ts
+++ b/packages/react/src/actions.ts
@@ -133,8 +133,6 @@ export async function sendOTP(
   config: Config,
   parameters: {
     email: string
-    emailCustomization?: { magicLinkTemplate?: string }
-    otpCodeCustomization?: { length: 6 | 7 | 8 | 9; alphanumeric: boolean }
     connector?: Connector
   },
 ): Promise<{ otpId: string; otpEncryptionTargetBundle: string }> {
@@ -147,12 +145,6 @@ export async function sendOTP(
     mode: 'sendOtp',
     email: parameters.email,
     contact: { type: 'email', contact: parameters.email },
-    ...(parameters.emailCustomization && {
-      emailCustomization: parameters.emailCustomization,
-    }),
-    ...(parameters.otpCodeCustomization && {
-      otpCodeCustomization: parameters.otpCodeCustomization,
-    }),
   })
 
   return {
@@ -164,8 +156,6 @@ export async function sendOTP(
 export declare namespace sendOTP {
   type Parameters = {
     email: string
-    emailCustomization?: { magicLinkTemplate?: string }
-    otpCodeCustomization?: { length: 6 | 7 | 8 | 9; alphanumeric: boolean }
     connector?: Connector
   }
   type ReturnType = { otpId: string; otpEncryptionTargetBundle: string }
@@ -295,8 +285,6 @@ export async function sendMagicLink(
   config: Config,
   parameters: {
     email: string
-    redirectURL: string
-    otpCodeCustomization?: { length: 6 | 7 | 8 | 9; alphanumeric: boolean }
     connector?: Connector
   },
 ): Promise<{ otpId: string; otpEncryptionTargetBundle: string }> {
@@ -308,10 +296,6 @@ export async function sendMagicLink(
     type: 'magicLink',
     mode: 'send',
     email: parameters.email,
-    redirectURL: parameters.redirectURL,
-    ...(parameters.otpCodeCustomization && {
-      otpCodeCustomization: parameters.otpCodeCustomization,
-    }),
   })
 
   return {
@@ -323,8 +307,6 @@ export async function sendMagicLink(
 export declare namespace sendMagicLink {
   type Parameters = {
     email: string
-    redirectURL: string
-    otpCodeCustomization?: { length: 6 | 7 | 8 | 9; alphanumeric: boolean }
     connector?: Connector
   }
   type ReturnType = { otpId: string; otpEncryptionTargetBundle: string }


### PR DESCRIPTION
Adapts the SDK to two auth changes already on `doorway-kms` `main`.

## 1. GET-behind-`StampCheckUser` (`/authenticators`, `/user-wallet`)

These endpoints moved from POST-with-body to **GET** behind `StampCheckUser`, which requires an `X-Timestamp` header plus a stamp whose signed body is that timestamp value (`FormatTimestamp(t) = strconv.FormatInt(t.UnixMilli(), 10)`).

- `rest` transport: new `stampPostion: 'timestamp'` — signs `Date.now()` (unix-millis string), sends it as `X-Timestamp` + the stamp header, no request body.
- `getAuthenticators` / `getUserWallet`: switched to `GET` + `stampPostion: 'timestamp'`.

## 2. OTP / magic-link customization is now project-config-driven

The backend now sources OTP length/format **and** the magic-link URL template from the project's `wallet.otp_configs` row, and the request DTOs (`InitOtpRequest` = `{ contact }`) no longer accept client customization — it's silently ignored. So this drops the dead params:

- Remove `otpCodeCustomization` and `emailCustomization` from `registerWithOTP`, `authenticateWithEmail`, the core wallet wrapper, and the react `sendOTP` / `sendMagicLink` actions (and their exported types).
- Magic-link redirect is now project-config: remove `redirectURL` from `sendMagicLink` and `magicLinkBaseUrl` from react-kit's `AuthConfig` + auth UI (+ docs).

> ⚠️ **Operational note:** with this, magic-link requires the project's `wallet.otp_configs.magic_link_template` to be set — there's no client-side fallback. Projects without it degrade to plain OTP.

## Verification

- Typecheck + build: `wallet-core`, `wallet-react`, `wallet-react-kit`, and the demo — all clean.
- Unit tests: **741/741** (incl. a new `rest.test.ts` locking the timestamp-stamp wire contract).
- Live e2e against a local `main` backend: OTP register/login (no customization sent) → `getUserWallet` (GET) → `signMessage` / `whoami`, and the full browser flow (login → dashboard → gasless tx) — all green.

## Notes

- Changeset intentionally omitted — to be added via `pnpm changeset`.
- The two changes are in one commit because `auth.test.ts` is touched by both and can't be cleanly hunk-split; happy to split into two PRs if preferred.
