### PR TITLE
release(core/react/react-kit): @zerodev/wallet-core@0.0.1-alpha.24, @zerodev/wallet-react@0.0.1-alpha.27, @zerodev/wallet-react-kit@0.0.1-alpha.4

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -33,6 +33,7 @@
     "neat-birds-count",
     "plenty-glasses-wear",
     "rare-buttons-rescue",
+    "seven-ads-relax",
     "shaggy-ants-lay",
     "shy-chefs-behave",
     "six-hats-yawn",

--- a/.changeset/seven-ads-relax.md
+++ b/.changeset/seven-ads-relax.md
@@ -1,0 +1,10 @@
+---
+"@zerodev/wallet-core": patch
+"@zerodev/wallet-react": patch
+"@zerodev/wallet-react-kit": patch
+---
+
+Adapt to doorway-kms backend auth changes:
+  - getAuthenticators and getUserWallet now use GET with an X-Timestamp + stamp header (new `timestamp` stamp position) to match StampCheckUser
+  - OTP code length and the magic-link URL template are now configured per-project on the backend; drop the client-supplied `otpCodeCustomization` /
+  `emailCustomization`, the magic-link `redirectURL`, and react-kit's `magicLinkBaseUrl`

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prepare": "husky",
     "changeset": "changeset",
     "changeset:version": "changeset version && pnpm install --lockfile-only",
-    "changeset:release": "pnpm build && bash scripts/remove-type.sh && changeset publish --tag alpha && bash scripts/restore-type.sh && pnpm format"
+    "changeset:release": "pnpm build && bash scripts/remove-type.sh && changeset publish && bash scripts/restore-type.sh && pnpm format"
   },
   "keywords": [
     "monorepo",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @zerodev/wallet-core
 
+## 0.0.1-alpha.24
+
+### Patch Changes
+
+- Adapt to doorway-kms backend auth changes:
+  - getAuthenticators and getUserWallet now use GET with an X-Timestamp + stamp header (new `timestamp` stamp position) to match StampCheckUser
+  - OTP code length and the magic-link URL template are now configured per-project on the backend; drop the client-supplied `otpCodeCustomization` /
+    `emailCustomization`, the magic-link `redirectURL`, and react-kit's `magicLinkBaseUrl`
+
 ## 0.0.1-alpha.23
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-core",
-  "version": "0.0.1-alpha.23",
+  "version": "0.0.1-alpha.24",
   "description": "ZeroDev Wallet SDK built on Turnkey",
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",

--- a/packages/react-kit/CHANGELOG.md
+++ b/packages/react-kit/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @zerodev/wallet-react-kit
 
+## 0.0.1-alpha.4
+
+### Patch Changes
+
+- Adapt to doorway-kms backend auth changes:
+  - getAuthenticators and getUserWallet now use GET with an X-Timestamp + stamp header (new `timestamp` stamp position) to match StampCheckUser
+  - OTP code length and the magic-link URL template are now configured per-project on the backend; drop the client-supplied `otpCodeCustomization` /
+    `emailCustomization`, the magic-link `redirectURL`, and react-kit's `magicLinkBaseUrl`
+- Updated dependencies
+  - @zerodev/wallet-core@0.0.1-alpha.24
+  - @zerodev/wallet-react@0.0.1-alpha.27
+
 ## 0.0.1-alpha.3
 
 ### Patch Changes

--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-react-kit",
-  "version": "0.0.1-alpha.3",
+  "version": "0.0.1-alpha.4",
   "description": "React UI components for ZeroDev Wallet SDK",
   "sideEffects": [
     "**/*.css"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @zerodev/wallet-react
 
+## 0.0.1-alpha.27
+
+### Patch Changes
+
+- Adapt to doorway-kms backend auth changes:
+  - getAuthenticators and getUserWallet now use GET with an X-Timestamp + stamp header (new `timestamp` stamp position) to match StampCheckUser
+  - OTP code length and the magic-link URL template are now configured per-project on the backend; drop the client-supplied `otpCodeCustomization` /
+    `emailCustomization`, the magic-link `redirectURL`, and react-kit's `magicLinkBaseUrl`
+- Updated dependencies
+  - @zerodev/wallet-core@0.0.1-alpha.24
+
 ## 0.0.1-alpha.26
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-react",
-  "version": "0.0.1-alpha.26",
+  "version": "0.0.1-alpha.27",
   "description": "React hooks for ZeroDev Wallet SDK",
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",


### PR DESCRIPTION
Records the alpha release of the doorway-kms auth adaptation (#271) and fixes the release script.

## Versions (already published to npm)
- `@zerodev/wallet-core` → **0.0.1-alpha.24**
- `@zerodev/wallet-react` → **0.0.1-alpha.27**
- `@zerodev/wallet-react-kit` → **0.0.1-alpha.4**

The packages are live on npm; the `alpha` dist-tag has been moved to these versions. This PR just lands the version bumps + CHANGELOGs + `pre.json` so `main` matches the registry.

## Release-script fix
changesets was upgraded to **2.29.7**, which rejects an explicit `--tag` in pre mode (*"Releasing under custom tag is not allowed in pre mode"*) — that broke `pnpm changeset:release`. Dropped `--tag alpha` from the script; publish runs clean and the `alpha` dist-tag is moved separately (`npm dist-tag add`), since in pre mode changesets routes prerelease-only packages to `latest`.

## Notes
- The `seven-ads-relax` changeset is intentionally retained (pre mode keeps changesets until `changeset pre exit`).
- Integration/E2E checks will be red until doorway-kms ships the GET-stamp endpoints to staging — same env-coupling as #271 (not a code issue).
