### PR TITLE
feat(react-ui,react-wallet-ui): namespace Tailwind utilities with zd: prefix

### DIFF
--- a/packages/react-ui/.storybook/preview.tsx
+++ b/packages/react-ui/.storybook/preview.tsx
@@ -2,7 +2,7 @@ import type { Decorator, Preview } from '@storybook/react-vite'
 import '../src/styles.css'
 
 const withCenteredContainer: Decorator = (Story) => (
-  <div className="min-h-[300px] min-w-[400px] grid place-items-center p-6">
+  <div className="zd:min-h-[300px] zd:min-w-[400px] zd:grid zd:place-items-center zd:p-6">
     {/* Wrapper insulates Story from grid alignment — some components
         (e.g. Badge) hard-code `self-start`, which would otherwise
         override `place-items-center`. */}

--- a/packages/react-ui/src/components/Badge/Badge.stories.tsx
+++ b/packages/react-ui/src/components/Badge/Badge.stories.tsx
@@ -81,16 +81,16 @@ export const AllVariants = {
     text: 'Example',
   },
   render: () => (
-    <div className="flex flex-col gap-4">
-      <div className="flex gap-2 flex-wrap">
+    <div className="zd:flex zd:flex-col zd:gap-4">
+      <div className="zd:flex zd:gap-2 zd:flex-wrap">
         <Badge text="Primary" variant="primary" />
         <Badge text="Secondary" variant="secondary" />
       </div>
-      <div className="flex gap-2 flex-wrap">
+      <div className="zd:flex zd:gap-2 zd:flex-wrap">
         <Badge text="With Icon" variant="secondary" leadingIcon="check" />
         <Badge text="Trailing" variant="primary" trailingIcon="chevronRight" />
       </div>
-      <div className="flex gap-2 flex-wrap">
+      <div className="zd:flex zd:gap-2 zd:flex-wrap">
         <Badge
           text="Both Icons"
           variant="secondary"

--- a/packages/react-ui/src/components/Badge/index.tsx
+++ b/packages/react-ui/src/components/Badge/index.tsx
@@ -11,8 +11,8 @@ export interface BadgeProps {
 }
 
 const variantStyles = {
-  primary: 'bg-white/40',
-  secondary: 'bg-orange/10',
+  primary: 'zd:bg-white/40',
+  secondary: 'zd:bg-orange/10',
 }
 
 export function Badge({
@@ -25,16 +25,21 @@ export function Badge({
   return (
     <div
       className={cn(
-        'py-1 px-2 gap-1 flex flex-row items-center rounded-lg self-start',
+        'zd:py-1 zd:px-2 zd:gap-1 zd:flex zd:flex-row zd:items-center zd:rounded-lg zd:self-start',
         variantStyles[variant],
         className,
       )}
     >
       {leadingIcon && (
-        <Icon name={leadingIcon} className="w-3 h-3 text-solarOrange" />
+        <Icon
+          name={leadingIcon}
+          className="zd:w-3 zd:h-3 zd:text-solarOrange"
+        />
       )}
-      <Text className="text-body3">{text}</Text>
-      {trailingIcon && <Icon name={trailingIcon} className="w-2.5 h-2.5" />}
+      <Text className="zd:text-body3">{text}</Text>
+      {trailingIcon && (
+        <Icon name={trailingIcon} className="zd:w-2.5 zd:h-2.5" />
+      )}
     </div>
   )
 }

--- a/packages/react-ui/src/components/Button/Button.stories.tsx
+++ b/packages/react-ui/src/components/Button/Button.stories.tsx
@@ -95,7 +95,7 @@ export const SecondaryWithIcon: Story = {
 
 export const AllVariants: Story = {
   render: () => (
-    <div className="flex flex-col gap-4 w-72">
+    <div className="zd:flex zd:flex-col zd:gap-4 zd:w-72">
       <Button text="Primary" action="primary" />
       <Button text="Secondary" action="secondary" />
       <Button text="Disabled" action="primary" disabled />

--- a/packages/react-ui/src/components/Button/index.tsx
+++ b/packages/react-ui/src/components/Button/index.tsx
@@ -10,18 +10,18 @@ import { Wrapper } from '../Wrapper'
 // border (overriding Wrapper's offWhite stroke), and the "blur effect" inset
 // shadows. Per-variant colour + hover/active live on the inner <button>.
 const surfaceClass =
-  'rounded-3xl border-white/0 ' +
-  'shadow-[inset_0_-4px_4px_0_rgba(255,255,255,0.10),inset_0_3px_4px_0_rgba(0,0,0,0.02)]'
+  'zd:rounded-3xl zd:border-white/0 ' +
+  'zd:shadow-[inset_0_-4px_4px_0_rgba(255,255,255,0.10),inset_0_3px_4px_0_rgba(0,0,0,0.02)]'
 
 const innerClass =
-  'flex items-center justify-center gap-2 h-16 w-full px-5 py-3.5 cursor-pointer transition-colors'
+  'zd:flex zd:items-center zd:justify-center zd:gap-2 zd:h-16 zd:w-full zd:px-5 zd:py-3.5 zd:cursor-pointer zd:transition-colors'
 
 // secondary keeps Wrapper's white@0.5 surface; primary overrides it with a dark
 // translucent fill (via inline style, since Wrapper sets its bg inline). Hover/
 // active tints sit on the inner button.
 const bgClasses: Record<NonNullable<ButtonProps['action']>, string> = {
-  primary: 'hover:bg-white/5 active:bg-white/10',
-  secondary: 'hover:bg-white/20 active:bg-white/30',
+  primary: 'zd:hover:bg-white/5 zd:active:bg-white/10',
+  secondary: 'zd:hover:bg-white/20 zd:active:bg-white/30',
 }
 
 const primaryStyle: CSSProperties = {
@@ -29,8 +29,8 @@ const primaryStyle: CSSProperties = {
 }
 
 const textClasses: Record<NonNullable<ButtonProps['action']>, string> = {
-  primary: 'text-white text-body1',
-  secondary: 'text-greyScale text-body1',
+  primary: 'zd:text-white zd:text-body1',
+  secondary: 'zd:text-greyScale zd:text-body1',
 }
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -51,13 +51,13 @@ export function Button({
 }: ButtonProps) {
   return (
     <Wrapper
-      className={cn(surfaceClass, { 'opacity-50': disabled }, className)}
+      className={cn(surfaceClass, { 'zd:opacity-50': disabled }, className)}
       {...(action === 'primary' && { style: primaryStyle })}
     >
       <button
         type={rest.type ?? 'button'}
         className={cn(innerClass, bgClasses[action], {
-          'cursor-not-allowed': disabled,
+          'zd:cursor-not-allowed': disabled,
         })}
         disabled={disabled}
         {...rest}
@@ -65,14 +65,14 @@ export function Button({
         {iconName && !trailIcon && (
           <Icon
             name={iconName}
-            className={cn('w-6 h-6', textClasses[action])}
+            className={cn('zd:w-6 zd:h-6', textClasses[action])}
           />
         )}
         {text && <Text className={textClasses[action]}>{text}</Text>}
         {iconName && trailIcon && (
           <Icon
             name={iconName}
-            className={cn('w-6 h-6', textClasses[action])}
+            className={cn('zd:w-6 zd:h-6', textClasses[action])}
           />
         )}
       </button>

--- a/packages/react-ui/src/components/Callout/index.tsx
+++ b/packages/react-ui/src/components/Callout/index.tsx
@@ -10,14 +10,14 @@ export interface CalloutProps {
 export function Callout({ title, description }: CalloutProps) {
   return (
     <Wrapper
-      className="w-full py-5 px-4 flex flex-col gap-4 rounded-xl"
+      className="zd:w-full zd:py-5 zd:px-4 zd:flex zd:flex-col zd:gap-4 zd:rounded-xl"
       variant="solid"
     >
-      <div className="flex flex-row items-center gap-2">
-        <Icon name="info" className="h-3.5 w-3.5 text-solarOrange" />
-        <Text className="text-body1">{title}</Text>
+      <div className="zd:flex zd:flex-row zd:items-center zd:gap-2">
+        <Icon name="info" className="zd:h-3.5 zd:w-3.5 zd:text-solarOrange" />
+        <Text className="zd:text-body1">{title}</Text>
       </div>
-      <Text className="text-body3 break-all">{description}</Text>
+      <Text className="zd:text-body3 zd:break-all">{description}</Text>
     </Wrapper>
   )
 }

--- a/packages/react-ui/src/components/Icon/Icon.stories.tsx
+++ b/packages/react-ui/src/components/Icon/Icon.stories.tsx
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   args: {
     name: 'check',
-    className: 'w-6 h-6 text-greyScale',
+    className: 'zd:w-6 zd:h-6 zd:text-greyScale',
   },
 }
 
@@ -52,7 +52,7 @@ export const AllIcons: Story = {
             padding: 12,
           }}
         >
-          <Icon name={name} className="w-6 h-6 text-greyScale" />
+          <Icon name={name} className="zd:w-6 zd:h-6 zd:text-greyScale" />
           <span style={{ color: '#999', fontSize: 10, textAlign: 'center' }}>
             {name.replace(/Icon$/, '')}
           </span>

--- a/packages/react-ui/src/components/Icon/index.tsx
+++ b/packages/react-ui/src/components/Icon/index.tsx
@@ -39,5 +39,5 @@ export interface IconProps extends SVGProps<SVGSVGElement> {
 export function Icon({ name, className, ...props }: IconProps) {
   const Component = icons[name]
   if (!Component) return null
-  return <Component className={cn('text-greyScale', className)} {...props} />
+  return <Component className={cn('zd:text-greyScale', className)} {...props} />
 }

--- a/packages/react-ui/src/components/IconButton/index.tsx
+++ b/packages/react-ui/src/components/IconButton/index.tsx
@@ -11,13 +11,13 @@ export interface IconButtonProps
 
 export function IconButton({ iconName, className, ...rest }: IconButtonProps) {
   return (
-    <Wrapper className={cn('h-13 w-13 rounded-2xl', className)}>
+    <Wrapper className={cn('zd:h-13 zd:w-13 zd:rounded-2xl', className)}>
       <button
         type="button"
-        className="flex items-center justify-center flex-1 h-full w-full cursor-pointer hover:bg-white/20 active:bg-white/30 transition-colors"
+        className="zd:flex zd:items-center zd:justify-center zd:flex-1 zd:h-full zd:w-full zd:cursor-pointer zd:hover:bg-white/20 zd:active:bg-white/30 zd:transition-colors"
         {...rest}
       >
-        <Icon name={iconName} className="h-6 w-6 text-greyScale" />
+        <Icon name={iconName} className="zd:h-6 zd:w-6 zd:text-greyScale" />
       </button>
     </Wrapper>
   )

--- a/packages/react-ui/src/components/Input/Input.test.tsx
+++ b/packages/react-ui/src/components/Input/Input.test.tsx
@@ -93,11 +93,11 @@ describe('Input', () => {
       // the focused state is conveyed by a bg-white/20 overlay, not a variant
       // change.
       expect(wrapper.style.backgroundColor).toBe('rgba(255, 255, 255, 0.5)')
-      expect(container.querySelector('.bg-white\\/20')).toBeNull()
+      expect(container.querySelector('.zd\\:bg-white\\/20')).toBeNull()
 
       fireEvent.focus(input)
       expect(wrapper.style.backgroundColor).toBe('rgba(255, 255, 255, 0.5)')
-      expect(container.querySelector('.bg-white\\/20')).not.toBeNull()
+      expect(container.querySelector('.zd\\:bg-white\\/20')).not.toBeNull()
     })
 
     it('removes the tint overlay on blur', () => {
@@ -105,10 +105,10 @@ describe('Input', () => {
       const input = screen.getByPlaceholderText('Blur me')
 
       fireEvent.focus(input)
-      expect(container.querySelector('.bg-white\\/20')).not.toBeNull()
+      expect(container.querySelector('.zd\\:bg-white\\/20')).not.toBeNull()
 
       fireEvent.blur(input)
-      expect(container.querySelector('.bg-white\\/20')).toBeNull()
+      expect(container.querySelector('.zd\\:bg-white\\/20')).toBeNull()
     })
 
     it('calls the original onFocus handler', () => {
@@ -231,7 +231,7 @@ describe('Input', () => {
         <Input variant="listItemStyle" iconName="check" placeholder="List" />,
       )
       // Should have the icon wrapper div
-      const iconWrapper = container.querySelector('.bg-white')
+      const iconWrapper = container.querySelector('.zd\\:bg-white')
       expect(iconWrapper).not.toBeNull()
       expect(iconWrapper?.className).toContain('w-13')
       expect(iconWrapper?.className).toContain('h-13')

--- a/packages/react-ui/src/components/Input/index.tsx
+++ b/packages/react-ui/src/components/Input/index.tsx
@@ -20,9 +20,9 @@ export interface InputProps
 }
 
 function getHeightClass(multiline: boolean | undefined, variant: Variant) {
-  if (multiline) return 'h-32 py-3'
-  if (variant === 'listItemStyle') return 'h-[68px]'
-  return 'h-11'
+  if (multiline) return 'zd:h-32 zd:py-3'
+  if (variant === 'listItemStyle') return 'zd:h-[68px]'
+  return 'zd:h-11'
 }
 
 function InputIcon({
@@ -34,19 +34,24 @@ function InputIcon({
 }) {
   if (variant === 'listItemStyle') {
     return (
-      <div className="w-13 h-13 shrink-0 bg-white rounded-2xl flex items-center justify-center">
-        <Icon name={iconName} className="w-6 h-6 text-greyScale" />
+      <div className="zd:w-13 zd:h-13 zd:shrink-0 zd:bg-white zd:rounded-2xl zd:flex zd:items-center zd:justify-center">
+        <Icon name={iconName} className="zd:w-6 zd:h-6 zd:text-greyScale" />
       </div>
     )
   }
-  return <Icon name={iconName} className="w-5 h-5 shrink-0 text-greyScale/50" />
+  return (
+    <Icon
+      name={iconName}
+      className="zd:w-5 zd:h-5 zd:shrink-0 zd:text-greyScale/50"
+    />
+  )
 }
 
 // `min-w-0` is required so the input doesn't claim its intrinsic content
 // width on mobile browsers (Chrome on Android most visibly), which would
 // squash the leading icon and the trailing chevron-button child.
 const baseInputClass =
-  'flex-1 min-w-0 px-0 text-gray-900 font-medium outline-none bg-transparent min-h-11 placeholder:text-gray-900/50 caret-gray-900'
+  'zd:flex-1 zd:min-w-0 zd:px-0 zd:text-gray-900 zd:font-medium zd:outline-none zd:bg-transparent zd:min-h-11 zd:placeholder:text-gray-900/50 zd:caret-gray-900'
 
 export function Input({
   variant = 'default',
@@ -80,14 +85,14 @@ export function Input({
       {...(inputProps as unknown as TextareaHTMLAttributes<HTMLTextAreaElement>)}
       onFocus={handleFocus}
       onBlur={handleBlur}
-      className={cn(baseInputClass, 'resize-none h-full', className)}
+      className={cn(baseInputClass, 'zd:resize-none zd:h-full', className)}
     />
   ) : (
     <input
       {...inputProps}
       onFocus={handleFocus}
       onBlur={handleBlur}
-      className={cn(baseInputClass, 'h-full', className)}
+      className={cn(baseInputClass, 'zd:h-full', className)}
     />
   )
 
@@ -101,7 +106,7 @@ export function Input({
         onBlur={onBlur as TextareaHTMLAttributes<HTMLTextAreaElement>['onBlur']}
         className={cn(
           baseInputClass,
-          'w-full pl-4 pr-2 resize-none',
+          'zd:w-full zd:pl-4 zd:pr-2 zd:resize-none',
           className,
         )}
       />
@@ -110,19 +115,19 @@ export function Input({
         {...inputProps}
         onFocus={onFocus}
         onBlur={onBlur}
-        className={cn(baseInputClass, 'w-full pl-4 pr-2', className)}
+        className={cn(baseInputClass, 'zd:w-full zd:pl-4 zd:pr-2', className)}
       />
     )
   }
 
   const heightClass = getHeightClass(multiline, variant)
-  const paddingLeft = variant === 'listItemStyle' ? 'pl-2' : 'pl-4'
+  const paddingLeft = variant === 'listItemStyle' ? 'zd:pl-2' : 'zd:pl-4'
 
   return (
     <Wrapper
       data-testid="input-wrapper"
       className={cn(
-        'relative flex w-full rounded-2xl items-center gap-3 pr-2',
+        'zd:relative zd:flex zd:w-full zd:rounded-2xl zd:items-center zd:gap-3 zd:pr-2',
         heightClass,
         paddingLeft,
         containerClassName,
@@ -132,7 +137,7 @@ export function Input({
       {/* On focus, overlay a white/20 tint over the soft (white/0.5) base so the
           field matches the button hover state. */}
       {isFocused && (
-        <div className="absolute inset-0 bg-white/20 pointer-events-none" />
+        <div className="zd:absolute zd:inset-0 zd:bg-white/20 zd:pointer-events-none" />
       )}
       {iconName && <InputIcon variant={variant} iconName={iconName} />}
       {inputElement}

--- a/packages/react-ui/src/components/ListItem/ListItem.test.tsx
+++ b/packages/react-ui/src/components/ListItem/ListItem.test.tsx
@@ -57,7 +57,7 @@ describe('ListItem', () => {
     const { container } = render(
       <ListItem title="Test Title" badgeProps={{ text: 'Badge' }} />,
     )
-    const contentDiv = container.querySelector('.gap-2')
+    const contentDiv = container.querySelector('.zd\\:gap-2')
     expect(contentDiv).not.toBeNull()
   })
 
@@ -90,7 +90,7 @@ describe('ListItem', () => {
 describe('ListItemSkeleton', () => {
   it('renders skeleton loading state', () => {
     const { container } = render(<ListItemSkeleton />)
-    const skeleton = container.querySelector('.animate-pulse')
+    const skeleton = container.querySelector('.zd\\:animate-pulse')
     expect(skeleton).not.toBeNull()
   })
 

--- a/packages/react-ui/src/components/ListItem/index.tsx
+++ b/packages/react-ui/src/components/ListItem/index.tsx
@@ -14,21 +14,21 @@ export function ListItemSkeleton({ className }: ListItemSkeletonProps) {
   return (
     <div
       className={cn(
-        'w-full h-[68px] rounded-2xl border-offWhite border-[0.3px]',
+        'zd:w-full zd:h-[68px] zd:rounded-2xl zd:border-offWhite zd:border-[0.3px]',
         className,
       )}
     >
-      <div className="flex flex-row justify-between items-center p-2">
-        <div className="flex flex-row items-center gap-3">
-          <div className="w-[52px] h-[52px] rounded-2xl bg-offWhite/50 animate-pulse" />
-          <div className="gap-2">
-            <div className="w-14 h-3 rounded-lg bg-offWhite/50 animate-pulse mb-2" />
-            <div className="w-14 h-3 rounded-lg bg-offWhite/50 animate-pulse" />
+      <div className="zd:flex zd:flex-row zd:justify-between zd:items-center zd:p-2">
+        <div className="zd:flex zd:flex-row zd:items-center zd:gap-3">
+          <div className="zd:w-[52px] zd:h-[52px] zd:rounded-2xl zd:bg-offWhite/50 zd:animate-pulse" />
+          <div className="zd:gap-2">
+            <div className="zd:w-14 zd:h-3 zd:rounded-lg zd:bg-offWhite/50 zd:animate-pulse zd:mb-2" />
+            <div className="zd:w-14 zd:h-3 zd:rounded-lg zd:bg-offWhite/50 zd:animate-pulse" />
           </div>
         </div>
-        <div className="gap-2">
-          <div className="w-14 h-3 rounded-lg bg-offWhite/50 animate-pulse mb-2" />
-          <div className="w-14 h-3 rounded-lg bg-offWhite/50 animate-pulse" />
+        <div className="zd:gap-2">
+          <div className="zd:w-14 zd:h-3 zd:rounded-lg zd:bg-offWhite/50 zd:animate-pulse zd:mb-2" />
+          <div className="zd:w-14 zd:h-3 zd:rounded-lg zd:bg-offWhite/50 zd:animate-pulse" />
         </div>
       </div>
     </div>
@@ -61,64 +61,73 @@ export function ListItem({
   return (
     <Wrapper
       className={cn(
-        'w-full h-[68px] rounded-2xl',
-        alert && 'border-0',
+        'zd:w-full zd:h-[68px] zd:rounded-2xl',
+        alert && 'zd:border-0',
         className,
       )}
     >
       <button
         type="button"
         className={cn(
-          'w-full flex flex-row justify-between items-center p-2 transition-colors cursor-pointer',
-          alert ? 'bg-solarOrange/15' : 'hover:bg-white/20 active:bg-white/30',
-          rest.disabled && 'opacity-50 cursor-not-allowed',
+          'zd:w-full zd:flex zd:flex-row zd:justify-between zd:items-center zd:p-2 zd:transition-colors zd:cursor-pointer',
+          alert
+            ? 'zd:bg-solarOrange/15'
+            : 'zd:hover:bg-white/20 zd:active:bg-white/30',
+          rest.disabled && 'zd:opacity-50 zd:cursor-not-allowed',
         )}
         {...rest}
       >
-        <div className="flex flex-row items-center gap-3">
+        <div className="zd:flex zd:flex-row zd:items-center zd:gap-3">
           <div
             className={cn(
-              'w-[52px] h-[52px] rounded-2xl flex items-center justify-center shrink-0',
-              alert ? 'bg-offWhite/50' : 'bg-white',
+              'zd:w-[52px] zd:h-[52px] zd:rounded-2xl zd:flex zd:items-center zd:justify-center zd:shrink-0',
+              alert ? 'zd:bg-offWhite/50' : 'zd:bg-white',
             )}
           >
             {imageUri ? (
-              <img src={imageUri} alt="" className="w-6 h-6" />
+              <img src={imageUri} alt="" className="zd:w-6 zd:h-6" />
             ) : iconName ? (
               <Icon
                 name={iconName}
                 className={cn(
-                  'w-6 h-6',
-                  details || alert ? 'text-solarOrange' : 'text-greyScale',
+                  'zd:w-6 zd:h-6',
+                  details || alert
+                    ? 'zd:text-solarOrange'
+                    : 'zd:text-greyScale',
                 )}
               />
             ) : null}
           </div>
           <div
             className={cn(
-              'flex flex-col justify-center text-left',
-              badgeProps ? 'gap-2' : 'gap-1',
+              'zd:flex zd:flex-col zd:justify-center zd:text-left',
+              badgeProps ? 'zd:gap-2' : 'zd:gap-1',
             )}
           >
-            <Text className="text-body1">{title}</Text>
+            <Text className="zd:text-body1">{title}</Text>
             {subtitle && (
-              <Text className="text-body3 text-greyScale/50">{subtitle}</Text>
+              <Text className="zd:text-body3 zd:text-greyScale/50">
+                {subtitle}
+              </Text>
             )}
             {badgeProps && <Badge {...badgeProps} />}
           </div>
         </div>
         {details ? (
-          <div className="flex flex-col pr-1">
-            <Text className="text-body1">{details.text}</Text>
+          <div className="zd:flex zd:flex-col zd:pr-1">
+            <Text className="zd:text-body1">{details.text}</Text>
             {details.subtext && (
-              <Text className="text-body3 text-greyScale/50 self-end">
+              <Text className="zd:text-body3 zd:text-greyScale/50 zd:self-end">
                 {details.subtext}
               </Text>
             )}
           </div>
         ) : chevron ? (
-          <div className="w-13 h-13 flex items-center justify-center">
-            <Icon name="chevronRight" className="h-6 w-6 text-greyScale" />
+          <div className="zd:w-13 zd:h-13 zd:flex zd:items-center zd:justify-center">
+            <Icon
+              name="chevronRight"
+              className="zd:h-6 zd:w-6 zd:text-greyScale"
+            />
           </div>
         ) : null}
       </button>

--- a/packages/react-ui/src/components/Switch/Switch.test.tsx
+++ b/packages/react-ui/src/components/Switch/Switch.test.tsx
@@ -58,13 +58,13 @@ describe('Switch', () => {
   describe('thumb color', () => {
     it('uses the solarOrange hex color when value is true', () => {
       const { container } = render(<Switch value={true} />)
-      const thumb = container.querySelector('.rounded-full')
+      const thumb = container.querySelector('.zd\\:rounded-full')
       expect(thumb?.className).toContain('bg-solarOrange')
     })
 
     it('uses greyScale/30 when value is false', () => {
       const { container } = render(<Switch value={false} />)
-      const thumb = container.querySelector('.rounded-full')
+      const thumb = container.querySelector('.zd\\:rounded-full')
       expect(thumb?.className).toContain('bg-greyScale/30')
     })
   })

--- a/packages/react-ui/src/components/Switch/index.tsx
+++ b/packages/react-ui/src/components/Switch/index.tsx
@@ -9,22 +9,26 @@ export interface SwitchProps {
 
 export function Switch({ value, onValueChange }: SwitchProps) {
   return (
-    <Wrapper variant="ghost" className="w-14 h-7 rounded-xl p-1">
+    <Wrapper variant="ghost" className="zd:w-14 zd:h-7 zd:rounded-xl zd:p-1">
       <button
         type="button"
         role="switch"
         aria-checked={value ?? false}
         onClick={onValueChange}
-        className="flex items-center justify-center flex-row gap-1.5 w-full h-full rounded-lg bg-white/70 cursor-pointer"
+        className="zd:flex zd:items-center zd:justify-center zd:flex-row zd:gap-1.5 zd:w-full zd:h-full zd:rounded-lg zd:bg-white/70 zd:cursor-pointer"
       >
-        {value && <Text className="text-body3 text-greyScale/90">On</Text>}
+        {value && (
+          <Text className="zd:text-body3 zd:text-greyScale/90">On</Text>
+        )}
         <div
           className={cn(
-            'w-3.5 h-3.5 rounded-full shadow-sm',
-            value ? 'bg-solarOrange' : 'bg-greyScale/30',
+            'zd:w-3.5 zd:h-3.5 zd:rounded-full zd:shadow-sm',
+            value ? 'zd:bg-solarOrange' : 'zd:bg-greyScale/30',
           )}
         />
-        {!value && <Text className="text-body3 text-greyScale/50">Off</Text>}
+        {!value && (
+          <Text className="zd:text-body3 zd:text-greyScale/50">Off</Text>
+        )}
       </button>
     </Wrapper>
   )

--- a/packages/react-ui/src/components/Text/Text.stories.tsx
+++ b/packages/react-ui/src/components/Text/Text.stories.tsx
@@ -44,27 +44,27 @@ export const AsLabel: Story = {
 export const CustomColor: Story = {
   args: {
     children: 'Orange text',
-    className: 'text-orange',
+    className: 'zd:text-orange',
   },
 }
 
 export const LargerSize: Story = {
   args: {
     children: 'Larger body1 text',
-    className: 'text-body1',
+    className: 'zd:text-body1',
   },
 }
 
 export const AllSizes: Story = {
   render: () => (
-    <div className="flex flex-col gap-3">
-      <Text className="text-h1">Heading 1</Text>
-      <Text className="text-h2">Heading 2</Text>
-      <Text className="text-h3">Heading 3</Text>
-      <Text className="text-body1">Body 1</Text>
+    <div className="zd:flex zd:flex-col zd:gap-3">
+      <Text className="zd:text-h1">Heading 1</Text>
+      <Text className="zd:text-h2">Heading 2</Text>
+      <Text className="zd:text-h3">Heading 3</Text>
+      <Text className="zd:text-body1">Body 1</Text>
       <Text>Body 2 (default)</Text>
-      <Text className="text-body3">Body 3</Text>
-      <Text className="text-body4">Body 4</Text>
+      <Text className="zd:text-body3">Body 3</Text>
+      <Text className="zd:text-body4">Body 4</Text>
     </div>
   ),
 }

--- a/packages/react-ui/src/components/Text/Text.test.tsx
+++ b/packages/react-ui/src/components/Text/Text.test.tsx
@@ -69,14 +69,14 @@ describe('Text', () => {
     })
 
     it('allows overriding default classes via tailwind-merge', () => {
-      render(<Text className="font-bold">Bold</Text>)
+      render(<Text className="zd:font-bold">Bold</Text>)
       const el = screen.getByText('Bold')
       expect(el.className).toContain('font-bold')
       expect(el.className).not.toContain('font-medium')
     })
 
     it('allows overriding font family', () => {
-      render(<Text className="font-roboto">Roboto</Text>)
+      render(<Text className="zd:font-roboto">Roboto</Text>)
       const el = screen.getByText('Roboto')
       expect(el.className).toContain('font-roboto')
       expect(el.className).not.toContain('font-sans')

--- a/packages/react-ui/src/components/Text/index.tsx
+++ b/packages/react-ui/src/components/Text/index.tsx
@@ -10,7 +10,7 @@ export function Text({ as: Tag = 'p', className, ...props }: TextProps) {
   return (
     <Tag
       className={cn(
-        'font-medium font-sans text-body2 text-greyScale',
+        'zd:font-medium zd:font-sans zd:text-body2 zd:text-greyScale',
         className,
       )}
       {...(props as HTMLAttributes<HTMLElement> &

--- a/packages/react-ui/src/components/WrappedPressable/WrappedPressable.stories.tsx
+++ b/packages/react-ui/src/components/WrappedPressable/WrappedPressable.stories.tsx
@@ -22,6 +22,6 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
-    className: 'h-12 px-6',
+    className: 'zd:h-12 zd:px-6',
   },
 }

--- a/packages/react-ui/src/components/WrappedPressable/index.tsx
+++ b/packages/react-ui/src/components/WrappedPressable/index.tsx
@@ -20,12 +20,15 @@ export function WrappedPressable({
 
   return (
     <Wrapper
-      className={cn('rounded-xl flex items-center justify-center', className)}
+      className={cn(
+        'zd:rounded-xl zd:flex zd:items-center zd:justify-center',
+        className,
+      )}
       variant={isHovered ? 'soft' : 'ghost'}
     >
       <button
         type="button"
-        className="flex flex-row items-center justify-center gap-2 w-full h-full cursor-pointer"
+        className="zd:flex zd:flex-row zd:items-center zd:justify-center zd:gap-2 zd:w-full zd:h-full zd:cursor-pointer"
         onMouseEnter={(e) => {
           setIsHovered(true)
           onMouseEnter?.(e)

--- a/packages/react-ui/src/components/Wrapper/Wrapper.stories.tsx
+++ b/packages/react-ui/src/components/Wrapper/Wrapper.stories.tsx
@@ -26,9 +26,9 @@ type Story = StoryObj<typeof meta>
 export const Ghost: Story = {
   args: {
     variant: 'ghost',
-    className: 'rounded-2xl p-6',
+    className: 'zd:rounded-2xl zd:p-6',
     children: (
-      <p className="text-gray-900 text-base font-medium">
+      <p className="zd:text-gray-900 zd:text-base zd:font-medium">
         Ghost variant — most transparent (α 0.2)
       </p>
     ),
@@ -38,9 +38,9 @@ export const Ghost: Story = {
 export const Soft: Story = {
   args: {
     variant: 'soft',
-    className: 'rounded-2xl p-6',
+    className: 'zd:rounded-2xl zd:p-6',
     children: (
-      <p className="text-gray-900 text-base font-medium">
+      <p className="zd:text-gray-900 zd:text-base zd:font-medium">
         Soft variant — default (α 0.4)
       </p>
     ),
@@ -50,9 +50,9 @@ export const Soft: Story = {
 export const Solid: Story = {
   args: {
     variant: 'solid',
-    className: 'rounded-2xl p-6',
+    className: 'zd:rounded-2xl zd:p-6',
     children: (
-      <p className="text-gray-900 text-base font-medium">
+      <p className="zd:text-gray-900 zd:text-base zd:font-medium">
         Solid variant — most opaque (α 0.8)
       </p>
     ),
@@ -61,15 +61,21 @@ export const Solid: Story = {
 
 export const AllVariants: Story = {
   render: () => (
-    <div className="flex flex-col gap-4 w-80">
-      <Wrapper variant="ghost" className="rounded-2xl p-6">
-        <p className="text-gray-900 text-base font-medium">Ghost (α 0.2)</p>
+    <div className="zd:flex zd:flex-col zd:gap-4 zd:w-80">
+      <Wrapper variant="ghost" className="zd:rounded-2xl zd:p-6">
+        <p className="zd:text-gray-900 zd:text-base zd:font-medium">
+          Ghost (α 0.2)
+        </p>
       </Wrapper>
-      <Wrapper variant="soft" className="rounded-2xl p-6">
-        <p className="text-gray-900 text-base font-medium">Soft (α 0.4)</p>
+      <Wrapper variant="soft" className="zd:rounded-2xl zd:p-6">
+        <p className="zd:text-gray-900 zd:text-base zd:font-medium">
+          Soft (α 0.4)
+        </p>
       </Wrapper>
-      <Wrapper variant="solid" className="rounded-2xl p-6">
-        <p className="text-gray-900 text-base font-medium">Solid (α 0.8)</p>
+      <Wrapper variant="solid" className="zd:rounded-2xl zd:p-6">
+        <p className="zd:text-gray-900 zd:text-base zd:font-medium">
+          Solid (α 0.8)
+        </p>
       </Wrapper>
     </div>
   ),
@@ -77,13 +83,15 @@ export const AllVariants: Story = {
 
 export const WithRichContent: Story = {
   render: () => (
-    <Wrapper variant="soft" className="rounded-2xl p-6 w-80">
-      <div className="flex flex-col gap-2">
-        <h3 className="text-gray-900 text-lg font-semibold">Wallet Balance</h3>
-        <p className="text-gray-700 text-sm">
+    <Wrapper variant="soft" className="zd:rounded-2xl zd:p-6 zd:w-80">
+      <div className="zd:flex zd:flex-col zd:gap-2">
+        <h3 className="zd:text-gray-900 zd:text-lg zd:font-semibold">
+          Wallet Balance
+        </h3>
+        <p className="zd:text-gray-700 zd:text-sm">
           Your current balance across all chains
         </p>
-        <p className="text-gray-900 text-2xl font-bold">$1,234.56</p>
+        <p className="zd:text-gray-900 zd:text-2xl zd:font-bold">$1,234.56</p>
       </div>
     </Wrapper>
   ),

--- a/packages/react-ui/src/components/Wrapper/index.tsx
+++ b/packages/react-ui/src/components/Wrapper/index.tsx
@@ -31,7 +31,7 @@ export function Wrapper({
   return (
     <div
       className={cn(
-        'overflow-hidden border-offWhite border-[0.3px] backdrop-blur-[15px]',
+        'zd:overflow-hidden zd:border-offWhite zd:border-[0.3px] zd:backdrop-blur-[15px]',
         className,
       )}
       {...rest}

--- a/packages/react-ui/src/styles.css
+++ b/packages/react-ui/src/styles.css
@@ -1,2 +1,2 @@
-@import "tailwindcss";
+@import "tailwindcss" prefix(zd);
 @config "../tailwind.config.ts";

--- a/packages/react-ui/src/utils/common.test.ts
+++ b/packages/react-ui/src/utils/common.test.ts
@@ -14,7 +14,7 @@ describe('cn', () => {
   })
 
   it('merges conflicting tailwind utilities, keeping the last one', () => {
-    expect(cn('p-2', 'p-4')).toBe('p-4')
+    expect(cn('zd:p-2', 'zd:p-4')).toBe('zd:p-4')
   })
 
   it('supports conditional object syntax (clsx)', () => {
@@ -22,6 +22,6 @@ describe('cn', () => {
   })
 
   it('merges custom font-size tokens from the extended config', () => {
-    expect(cn('text-body2', 'text-body1')).toBe('text-body1')
+    expect(cn('zd:text-body2', 'zd:text-body1')).toBe('zd:text-body1')
   })
 })

--- a/packages/react-ui/src/utils/common.ts
+++ b/packages/react-ui/src/utils/common.ts
@@ -2,6 +2,7 @@ import { type ClassValue, clsx } from 'clsx'
 import { extendTailwindMerge } from 'tailwind-merge'
 
 const customTwMerge = extendTailwindMerge({
+  prefix: 'zd',
   extend: {
     classGroups: {
       'font-size': [

--- a/packages/react-wallet-ui/.storybook/preview.tsx
+++ b/packages/react-wallet-ui/.storybook/preview.tsx
@@ -12,8 +12,8 @@ const withScreen: Decorator = (Story, context) => {
   // instead of being clipped.
   return (
     <Screen
-      className="w-125 min-h-75 flex flex-col relative overflow-hidden rounded-[34px]"
-      contentClassName="flex-1 grid place-items-center bg-offWhite/85 m-1.5 px-4 py-6 rounded-[30px] relative"
+      className="zd:w-125 zd:min-h-75 zd:flex zd:flex-col zd:relative zd:overflow-hidden zd:rounded-[34px]"
+      contentClassName="zd:flex-1 zd:grid zd:place-items-center zd:bg-offWhite/85 zd:m-1.5 zd:px-4 zd:py-6 zd:rounded-[30px] zd:relative"
     >
       <div>
         <Story />

--- a/packages/react-wallet-ui/src/auth/components/CodeInput/CodeInput.stories.tsx
+++ b/packages/react-wallet-ui/src/auth/components/CodeInput/CodeInput.stories.tsx
@@ -56,21 +56,29 @@ export const EightDigits: Story = {
 
 export const AllStates: Story = {
   render: () => (
-    <div className="flex flex-col gap-8 items-center">
-      <div className="flex flex-col gap-2 items-center">
-        <span className="text-sm text-gray-500 font-medium">Default (6)</span>
+    <div className="zd:flex zd:flex-col zd:gap-8 zd:items-center">
+      <div className="zd:flex zd:flex-col zd:gap-2 zd:items-center">
+        <span className="zd:text-sm zd:text-gray-500 zd:font-medium">
+          Default (6)
+        </span>
         <CodeInput onComplete={() => window.alert('Completed')} />
       </div>
-      <div className="flex flex-col gap-2 items-center">
-        <span className="text-sm text-gray-500 font-medium">4 digits</span>
+      <div className="zd:flex zd:flex-col zd:gap-2 zd:items-center">
+        <span className="zd:text-sm zd:text-gray-500 zd:font-medium">
+          4 digits
+        </span>
         <CodeInput length={4} />
       </div>
-      <div className="flex flex-col gap-2 items-center">
-        <span className="text-sm text-gray-500 font-medium">8 digits</span>
+      <div className="zd:flex zd:flex-col zd:gap-2 zd:items-center">
+        <span className="zd:text-sm zd:text-gray-500 zd:font-medium">
+          8 digits
+        </span>
         <CodeInput length={8} />
       </div>
-      <div className="flex flex-col gap-2 items-center">
-        <span className="text-sm text-gray-400 font-medium">Disabled</span>
+      <div className="zd:flex zd:flex-col zd:gap-2 zd:items-center">
+        <span className="zd:text-sm zd:text-gray-400 zd:font-medium">
+          Disabled
+        </span>
         <CodeInput disabled />
       </div>
     </div>

--- a/packages/react-wallet-ui/src/auth/components/CodeInput/CodeInput.test.tsx
+++ b/packages/react-wallet-ui/src/auth/components/CodeInput/CodeInput.test.tsx
@@ -16,7 +16,7 @@ describe('CodeInput', () => {
 
     it('renders all boxes as empty initially', () => {
       const { container } = render(<CodeInput />)
-      const textElements = container.querySelectorAll('.text-h2')
+      const textElements = container.querySelectorAll('.zd\\:text-h2')
       Array.from(textElements).forEach((el) => {
         expect(el.textContent).toBe('')
       })
@@ -43,7 +43,7 @@ describe('CodeInput', () => {
         'input[aria-label="Verification code"]',
       ) as HTMLInputElement
       fireEvent.change(hiddenInput, { target: { value: '3' } })
-      const textElements = container.querySelectorAll('.text-h2')
+      const textElements = container.querySelectorAll('.zd\\:text-h2')
       expect(textElements[0].textContent).toBe('3')
     })
 
@@ -217,7 +217,7 @@ describe('CodeInput', () => {
 
       fireEvent.change(hiddenInput, { target: { value: 'ABC' } })
 
-      const textElements = container.querySelectorAll('.text-h2')
+      const textElements = container.querySelectorAll('.zd\\:text-h2')
       expect(textElements[0].textContent).toBe('A')
       expect(textElements[1].textContent).toBe('B')
       expect(textElements[2].textContent).toBe('C')

--- a/packages/react-wallet-ui/src/auth/components/CodeInput/index.tsx
+++ b/packages/react-wallet-ui/src/auth/components/CodeInput/index.tsx
@@ -20,11 +20,11 @@ function CharBox({ char, isFocused }: CharBoxProps) {
       data-testid="code-input-box"
       data-active={isFocused || undefined}
       className={cn(
-        'h-16 w-14 rounded-lg flex items-center justify-center',
-        isFocused && 'border-[1.5px] border-greyScale',
+        'zd:h-16 zd:w-14 zd:rounded-lg zd:flex zd:items-center zd:justify-center',
+        isFocused && 'zd:border-[1.5px] zd:border-greyScale',
       )}
     >
-      <Text className="text-h2">{char}</Text>
+      <Text className="zd:text-h2">{char}</Text>
     </Wrapper>
   )
 }
@@ -89,7 +89,7 @@ export function CodeInput({
   return (
     <button
       type="button"
-      className="flex flex-row items-center justify-between gap-2 w-full cursor-text"
+      className="zd:flex zd:flex-row zd:items-center zd:justify-between zd:gap-2 zd:w-full zd:cursor-text"
       onClick={() => inputRef.current?.focus()}
       disabled={disabled}
       data-testid={testId}
@@ -102,7 +102,7 @@ export function CodeInput({
         onBlur={() => setIsFocused(false)}
         maxLength={codeLength}
         disabled={disabled}
-        className="absolute opacity-0 pointer-events-none"
+        className="zd:absolute zd:opacity-0 zd:pointer-events-none"
         style={{ position: 'absolute', opacity: 0 }}
         aria-label="Verification code"
       />

--- a/packages/react-wallet-ui/src/auth/index.tsx
+++ b/packages/react-wallet-ui/src/auth/index.tsx
@@ -18,7 +18,7 @@ const TITLE_BY_STEP: Partial<Record<AuthStep, string>> = {
 
 function OAuthCallback() {
   return (
-    <div className="flex flex-1 items-center justify-center">
+    <div className="zd:flex zd:flex-1 zd:items-center zd:justify-center">
       <StatusScreen imageName="loading" title="Authenticating...">
         Please wait while we complete the OAuth authentication.
       </StatusScreen>
@@ -28,7 +28,7 @@ function OAuthCallback() {
 
 function PasskeyPrompt() {
   return (
-    <div className="flex flex-1 items-center justify-center">
+    <div className="zd:flex zd:flex-1 zd:items-center zd:justify-center">
       <StatusScreen imageName="loading" title="Passkey authentication">
         Please authenticate with your passkey.
       </StatusScreen>
@@ -86,13 +86,16 @@ export function AuthFlow({
     <Screen
       // Some elements in SignUp need to go from edge to edge.
       // No vertical padding; we set px-0 so we can fully control this padding.
-      contentClassName={step === 'sign-up' ? 'px-0' : undefined}
+      contentClassName={step === 'sign-up' ? 'zd:px-0' : undefined}
       topNav={
         <TopNav
           {...(goBack !== null && { onBack: goBack })}
           onClose={handleClose}
           {...(title && { title })}
-          {...(step === 'sign-up' && { centerLogo: true, className: 'px-4' })}
+          {...(step === 'sign-up' && {
+            centerLogo: true,
+            className: 'zd:px-4',
+          })}
         />
       }
     >

--- a/packages/react-wallet-ui/src/auth/pages/EmailVerification.tsx
+++ b/packages/react-wallet-ui/src/auth/pages/EmailVerification.tsx
@@ -41,26 +41,26 @@ export function EmailVerification() {
 
   return (
     <>
-      <div className="flex-1 flex flex-col gap-8 justify-center">
+      <div className="zd:flex-1 zd:flex zd:flex-col zd:gap-8 zd:justify-center">
         <StatusScreen
           imageName="send"
           title={'Check your email!\n An Email is On Its Way'}
         >
           We've sent a magic link to{' '}
-          <Text as="span" className="text-solarOrange">
+          <Text as="span" className="zd:text-solarOrange">
             {email}
           </Text>
           {'\n'}Please open the email and click the link to log in.
         </StatusScreen>
 
-        <div className="flex flex-col gap-1">
-          <Text className="text-center">
+        <div className="zd:flex zd:flex-col zd:gap-1">
+          <Text className="zd:text-center">
             Did not get an email?{' '}
             <button
               type="button"
               disabled={!canResend}
               onClick={handleResend}
-              className="cursor-pointer underline disabled:opacity-50 disabled:cursor-not-allowed"
+              className="zd:cursor-pointer zd:underline zd:disabled:opacity-50 zd:disabled:cursor-not-allowed"
             >
               {canResend
                 ? 'Resend'
@@ -70,7 +70,7 @@ export function EmailVerification() {
         </div>
       </div>
 
-      <PoweredBy className="self-center pt-4 pb-6" />
+      <PoweredBy className="zd:self-center zd:pt-4 zd:pb-6" />
     </>
   )
 }

--- a/packages/react-wallet-ui/src/auth/pages/ErrorScreen.tsx
+++ b/packages/react-wallet-ui/src/auth/pages/ErrorScreen.tsx
@@ -22,12 +22,12 @@ export function ErrorScreen({
 
   return (
     <>
-      <div className="flex-1 flex flex-col gap-8 items-center justify-center">
+      <div className="zd:flex-1 zd:flex zd:flex-col zd:gap-8 zd:items-center zd:justify-center">
         <StatusScreen imageName="error" title={title}>
           {message}
         </StatusScreen>
 
-        <div className="flex flex-col gap-1">
+        <div className="zd:flex zd:flex-col zd:gap-1">
           {showRetry && (
             <Button action="primary" text="Try again" onClick={handleRetry} />
           )}
@@ -47,7 +47,7 @@ export function ErrorScreen({
         </div>
       </div>
 
-      <PoweredBy className="self-center pt-4 pb-6" />
+      <PoweredBy className="zd:self-center zd:pt-4 zd:pb-6" />
     </>
   )
 }

--- a/packages/react-wallet-ui/src/auth/pages/OtpInput.tsx
+++ b/packages/react-wallet-ui/src/auth/pages/OtpInput.tsx
@@ -76,12 +76,14 @@ export function OtpInput() {
 
   return (
     <>
-      <div className="flex-1 flex flex-col gap-8 justify-center items-center">
-        <div className="flex flex-col gap-4">
-          <Text className="text-h2 text-center">Enter verification code</Text>
-          <Text className="text-center">
+      <div className="zd:flex-1 zd:flex zd:flex-col zd:gap-8 zd:justify-center zd:items-center">
+        <div className="zd:flex zd:flex-col zd:gap-4">
+          <Text className="zd:text-h2 zd:text-center">
+            Enter verification code
+          </Text>
+          <Text className="zd:text-center">
             Enter the code from the email we sent to{' '}
-            <Text className="text-solarOrange">{email}</Text>
+            <Text className="zd:text-solarOrange">{email}</Text>
           </Text>
         </div>
 
@@ -99,14 +101,14 @@ export function OtpInput() {
           disabled={!otp.trim() || isPending}
         />
 
-        <div className="flex flex-col gap-1">
-          <Text className="text-center">
+        <div className="zd:flex zd:flex-col zd:gap-1">
+          <Text className="zd:text-center">
             Did not get an email?{' '}
             <button
               type="button"
               disabled={!canResend}
               onClick={handleResend}
-              className="cursor-pointer underline disabled:opacity-50 disabled:cursor-not-allowed"
+              className="zd:cursor-pointer zd:underline zd:disabled:opacity-50 zd:disabled:cursor-not-allowed"
             >
               {canResend
                 ? 'Resend'
@@ -116,7 +118,7 @@ export function OtpInput() {
         </div>
       </div>
 
-      <PoweredBy className="self-center pt-4 pb-6" />
+      <PoweredBy className="zd:self-center zd:pt-4 zd:pb-6" />
     </>
   )
 }

--- a/packages/react-wallet-ui/src/auth/pages/SignUp.tsx
+++ b/packages/react-wallet-ui/src/auth/pages/SignUp.tsx
@@ -176,10 +176,10 @@ export function SignUp() {
 
   if (error) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <div className="flex flex-col gap-4 max-w-md">
-          <Text className="text-h2 text-center">Error occurred</Text>
-          <Text className="text-center text-red-500">{error}</Text>
+      <div className="zd:flex zd:items-center zd:justify-center zd:h-full">
+        <div className="zd:flex zd:flex-col zd:gap-4 zd:max-w-md">
+          <Text className="zd:text-h2 zd:text-center">Error occurred</Text>
+          <Text className="zd:text-center zd:text-red-500">{error}</Text>
           <Button
             action="primary"
             text="Try again"
@@ -191,21 +191,23 @@ export function SignUp() {
   }
 
   return (
-    <div className="flex-1 flex flex-col justify-between pb-4 overflow-y-auto overflow-x-hidden">
-      <div className="flex-1 flex flex-col justify-center">
-        <div className="px-4 flex flex-col items-center">
-          <div className="w-full px-16 py-4">
-            <BlobAnimation className="w-full pointer-events-none select-none" />
+    <div className="zd:flex-1 zd:flex zd:flex-col zd:justify-between zd:pb-4 zd:overflow-y-auto zd:overflow-x-hidden">
+      <div className="zd:flex-1 zd:flex zd:flex-col zd:justify-center">
+        <div className="zd:px-4 zd:flex zd:flex-col zd:items-center">
+          <div className="zd:w-full zd:px-16 zd:py-4">
+            <BlobAnimation className="zd:w-full zd:pointer-events-none zd:select-none" />
           </div>
-          <Text className="text-h2 text-center">Continue to your wallet</Text>
-          <Text className="mt-2 text-center text-greyScale/50">
+          <Text className="zd:text-h2 zd:text-center">
+            Continue to your wallet
+          </Text>
+          <Text className="zd:mt-2 zd:text-center zd:text-greyScale/50">
             Choose a sign-in method to proceed
           </Text>
         </div>
-        <div className="mt-6 flex flex-col gap-4 mb-4">
+        <div className="zd:mt-6 zd:flex zd:flex-col zd:gap-4 zd:mb-4">
           {enabledMethods.includes('passkey') && (
             <>
-              <div className="px-4 flex flex-col gap-2">
+              <div className="zd:px-4 zd:flex zd:flex-col zd:gap-2">
                 <Button
                   action="secondary"
                   text="Create a passkey"
@@ -223,20 +225,20 @@ export function SignUp() {
                   onClick={handleLoginPasskey}
                 />
               </div>
-              <div className="flex items-center gap-3">
-                <div className="h-px flex-1 bg-greyScale/30" />
-                <Text className="text-body3">or</Text>
-                <div className="h-px flex-1 bg-greyScale/30" />
+              <div className="zd:flex zd:items-center zd:gap-3">
+                <div className="zd:h-px zd:flex-1 zd:bg-greyScale/30" />
+                <Text className="zd:text-body3">or</Text>
+                <div className="zd:h-px zd:flex-1 zd:bg-greyScale/30" />
               </div>
             </>
           )}
-          <div className="px-4 flex flex-col gap-2">
+          <div className="zd:px-4 zd:flex zd:flex-col zd:gap-2">
             {enabledMethods.includes('google') && (
               <ListItem
                 iconName="google"
                 title="Google"
                 chevron
-                className="rounded-3xl"
+                className="zd:rounded-3xl"
                 disabled={anyPending}
                 onClick={handleGoogleAuth}
               />
@@ -252,7 +254,7 @@ export function SignUp() {
                 autoComplete="email"
                 disabled={anyPending}
                 variant="listItemStyle"
-                containerClassName="rounded-3xl"
+                containerClassName="zd:rounded-3xl"
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' && emailInput && !anyPending) {
                     void handleEmailSubmit()
@@ -260,8 +262,8 @@ export function SignUp() {
                 }}
               >
                 {isEmailLoading ? (
-                  <div className="w-13 h-13 flex items-center justify-center">
-                    <div className="w-5 h-5 border-2 border-solarOrange border-t-transparent rounded-full animate-spin" />
+                  <div className="zd:w-13 zd:h-13 zd:flex zd:items-center zd:justify-center">
+                    <div className="zd:w-5 zd:h-5 zd:border-2 zd:border-solarOrange zd:border-t-transparent zd:rounded-full zd:animate-spin" />
                   </div>
                 ) : (
                   <button
@@ -269,14 +271,14 @@ export function SignUp() {
                     disabled={
                       !isValidEmailAddress(emailInput) || needsToAcceptAgreement
                     }
-                    className={`w-13 h-13 rounded-2xl flex items-center justify-center transition-colors ${
+                    className={`zd:w-13 zd:h-13 zd:rounded-2xl zd:flex zd:items-center zd:justify-center zd:transition-colors ${
                       isValidEmailAddress(emailInput) && !needsToAcceptAgreement
-                        ? 'cursor-pointer'
-                        : 'cursor-not-allowed opacity-50'
+                        ? 'zd:cursor-pointer'
+                        : 'zd:cursor-not-allowed zd:opacity-50'
                     }`}
                     onClick={() => handleEmailSubmit()}
                   >
-                    <Icon name="chevronRight" className="text-greyScale" />
+                    <Icon name="chevronRight" className="zd:text-greyScale" />
                   </button>
                 )}
               </Input>
@@ -284,7 +286,7 @@ export function SignUp() {
           </div>
         </div>
       </div>
-      <div className="px-4">
+      <div className="zd:px-4">
         <SignUpFooter
           termsAndConditionsUrl={config?.termsAndConditionsUrl}
           privacyPolicyUrl={config?.privacyPolicyUrl}

--- a/packages/react-wallet-ui/src/auth/pages/Verifying.tsx
+++ b/packages/react-wallet-ui/src/auth/pages/Verifying.tsx
@@ -59,7 +59,7 @@ export function Verifying() {
 
   return (
     <>
-      <div className="flex-1 flex flex-col gap-8 items-center justify-center">
+      <div className="zd:flex-1 zd:flex zd:flex-col zd:gap-8 zd:items-center zd:justify-center">
         {!error && isVerificationLoading && (
           <StatusScreen imageName="loading" title="Verifying Your Email">
             Please wait while we securely connect your wallet.
@@ -102,7 +102,7 @@ export function Verifying() {
         )}
       </div>
 
-      <PoweredBy className="self-center pt-4 pb-6" />
+      <PoweredBy className="zd:self-center zd:pt-4 zd:pb-6" />
     </>
   )
 }

--- a/packages/react-wallet-ui/src/auth/pages/WalletSelection.tsx
+++ b/packages/react-wallet-ui/src/auth/pages/WalletSelection.tsx
@@ -22,12 +22,12 @@ export function WalletSelection() {
 
   return (
     <>
-      <div className="flex-1 flex flex-col gap-8 justify-center">
-        <Text className="text-h2 text-center">Select your wallet</Text>
+      <div className="zd:flex-1 zd:flex zd:flex-col zd:gap-8 zd:justify-center">
+        <Text className="zd:text-h2 zd:text-center">Select your wallet</Text>
 
-        <div className="flex flex-col gap-2">
+        <div className="zd:flex zd:flex-col zd:gap-2">
           {externalConnectors.length === 0 ? (
-            <Text className="text-center">
+            <Text className="zd:text-center">
               No wallets detected. Install a browser wallet extension to
               continue.
             </Text>
@@ -40,14 +40,14 @@ export function WalletSelection() {
                 {...(connector.icon ? { imageUri: connector.icon } : {})}
                 disabled={isPending}
                 onClick={() => handleSelect(connector)}
-                className="rounded-3xl"
+                className="zd:rounded-3xl"
               />
             ))
           )}
         </div>
       </div>
 
-      <PoweredBy className="self-center pt-4 pb-6" />
+      <PoweredBy className="zd:self-center zd:pt-4 zd:pb-6" />
     </>
   )
 }

--- a/packages/react-wallet-ui/src/shared/components/PoweredBy/PoweredBy.stories.tsx
+++ b/packages/react-wallet-ui/src/shared/components/PoweredBy/PoweredBy.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof meta>
 export const MultipleColors: Story = {
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
-      <PoweredBy className="text-gray-900" />
+      <PoweredBy className="zd:text-gray-900" />
     </div>
   ),
 }

--- a/packages/react-wallet-ui/src/shared/components/PoweredBy/index.tsx
+++ b/packages/react-wallet-ui/src/shared/components/PoweredBy/index.tsx
@@ -9,9 +9,18 @@ export function PoweredBy({
   style?: CSSProperties
 }) {
   return (
-    <div className={cn('gap-1.5 flex flex-row items-center', className)}>
+    <div
+      className={cn(
+        'zd:gap-1.5 zd:flex zd:flex-row zd:items-center',
+        className,
+      )}
+    >
       <Text>Powered by</Text>
-      <Icon name="zerodevLogo" className="h-[18px] w-auto" style={style} />
+      <Icon
+        name="zerodevLogo"
+        className="zd:h-[18px] zd:w-auto"
+        style={style}
+      />
     </div>
   )
 }

--- a/packages/react-wallet-ui/src/shared/components/Screen/MultiRadialBackground.tsx
+++ b/packages/react-wallet-ui/src/shared/components/Screen/MultiRadialBackground.tsx
@@ -15,7 +15,7 @@ export function MultiRadialBackground() {
   // just a flat, soft warm-white fill behind it so CardGlow's colors read
   // bright and clean, with no gray muddiers underneath.
   return (
-    <div className="absolute inset-0 z-0 rounded-4xl pointer-events-none">
+    <div className="zd:absolute zd:inset-0 zd:z-0 zd:rounded-4xl zd:pointer-events-none">
       <svg
         width="100%"
         height="100%"
@@ -115,7 +115,7 @@ export function CardGlow() {
   ]
 
   return (
-    <div className="absolute inset-0 z-0 rounded-4xl pointer-events-none overflow-hidden">
+    <div className="zd:absolute zd:inset-0 zd:z-0 zd:rounded-4xl zd:pointer-events-none zd:overflow-hidden">
       <svg
         width="100%"
         height="100%"
@@ -279,7 +279,7 @@ export function WrapperBorder() {
   ]
 
   return (
-    <div className="absolute inset-0 z-0 rounded-4xl pointer-events-none overflow-hidden">
+    <div className="zd:absolute zd:inset-0 zd:z-0 zd:rounded-4xl zd:pointer-events-none zd:overflow-hidden">
       <svg
         width="100%"
         height="100%"

--- a/packages/react-wallet-ui/src/shared/components/Screen/Screen.test.tsx
+++ b/packages/react-wallet-ui/src/shared/components/Screen/Screen.test.tsx
@@ -61,7 +61,7 @@ describe('Screen', () => {
           <div>Content</div>
         </Screen>,
       )
-      const contentWrapper = container.querySelector('.m-1\\.5')
+      const contentWrapper = container.querySelector('.zd\\:m-1\\.5')
       expect(contentWrapper).not.toBeNull()
       expect(contentWrapper?.className).toContain('rounded-4xl')
       expect(contentWrapper?.className).toContain('px-4')

--- a/packages/react-wallet-ui/src/shared/components/Screen/index.tsx
+++ b/packages/react-wallet-ui/src/shared/components/Screen/index.tsx
@@ -25,7 +25,7 @@ export function Screen({
   return (
     <div
       className={cn(
-        'flex flex-col relative overflow-hidden w-100 max-w-full h-[min(810px,100dvh)] rounded-[36px] text-left',
+        'zd:flex zd:flex-col zd:relative zd:overflow-hidden zd:w-100 zd:max-w-full zd:h-[min(810px,100dvh)] zd:rounded-[36px] zd:text-left',
         className,
       )}
       style={style}
@@ -38,7 +38,7 @@ export function Screen({
           vivid and distinct from the border. */}
       <div
         className={cn(
-          'flex flex-1 flex-col m-1.5 px-4 overflow-hidden rounded-4xl relative',
+          'zd:flex zd:flex-1 zd:flex-col zd:m-1.5 zd:px-4 zd:overflow-hidden zd:rounded-4xl zd:relative',
           contentClassName,
         )}
         // clip-path clips backdrop-filter to the rounded corners; plain
@@ -48,10 +48,10 @@ export function Screen({
       >
         <MultiRadialBackground />
         <CardGlow />
-        <div className="relative z-10 flex flex-1 flex-col min-h-0">
+        <div className="zd:relative zd:z-10 zd:flex zd:flex-1 zd:flex-col zd:min-h-0">
           {topNav}
           <div
-            className="flex flex-1 flex-col min-h-0 overflow-y-auto overflow-x-hidden"
+            className="zd:flex zd:flex-1 zd:flex-col zd:min-h-0 zd:overflow-y-auto zd:overflow-x-hidden"
             style={{ paddingTop: `${CONTENT_PADDING_TOP}px` }}
           >
             {children}

--- a/packages/react-wallet-ui/src/shared/components/SignUpFooter/index.tsx
+++ b/packages/react-wallet-ui/src/shared/components/SignUpFooter/index.tsx
@@ -17,20 +17,22 @@ export function SignUpFooter({
   const showAgreement = !!(termsAndConditionsUrl || privacyPolicyUrl)
 
   return (
-    <div className="flex flex-col items-center gap-5">
+    <div className="zd:flex zd:flex-col zd:items-center zd:gap-5">
       {showAgreement && (
         <div
-          className={`flex flex-row items-center gap-2 rounded-md p-2 transition-colors ${
-            highlight ? 'border border-negative' : 'border border-transparent'
+          className={`zd:flex zd:flex-row zd:items-center zd:gap-2 zd:rounded-md zd:p-2 zd:transition-colors ${
+            highlight
+              ? 'zd:border zd:border-negative'
+              : 'zd:border zd:border-transparent'
           }`}
         >
           <input
             type="checkbox"
             checked={agreedToTerms}
             onChange={(e) => setAgreedToTerms(e.target.checked)}
-            className="cursor-pointer [color-scheme:light]"
+            className="zd:cursor-pointer zd:[color-scheme:light]"
           />
-          <Text className="flex-1">
+          <Text className="zd:flex-1">
             I agree to the{' '}
             {termsAndConditionsUrl && (
               <Text
@@ -38,7 +40,7 @@ export function SignUpFooter({
                 href={termsAndConditionsUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="underline"
+                className="zd:underline"
               >
                 Terms & Conditions
               </Text>
@@ -50,7 +52,7 @@ export function SignUpFooter({
                 href={privacyPolicyUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="underline"
+                className="zd:underline"
               >
                 Privacy Policy
               </Text>

--- a/packages/react-wallet-ui/src/shared/components/StatusScreen/index.tsx
+++ b/packages/react-wallet-ui/src/shared/components/StatusScreen/index.tsx
@@ -28,15 +28,21 @@ export function StatusScreen({
   className,
 }: StatusScreenProps) {
   return (
-    <div className={cn('flex flex-col gap-8 items-center', className)}>
+    <div
+      className={cn('zd:flex zd:flex-col zd:gap-8 zd:items-center', className)}
+    >
       <img
         src={STATE_IMAGES[imageName]}
         alt={imageName}
-        className="w-[118px] h-[118px] bg-transparent"
+        className="zd:w-[118px] zd:h-[118px] zd:bg-transparent"
       />
-      <div className="flex flex-col gap-4 items-center">
-        <Text className="text-h2 text-center whitespace-pre-wrap">{title}</Text>
-        <Text className="text-center whitespace-pre-wrap">{children}</Text>
+      <div className="zd:flex zd:flex-col zd:gap-4 zd:items-center">
+        <Text className="zd:text-h2 zd:text-center zd:whitespace-pre-wrap">
+          {title}
+        </Text>
+        <Text className="zd:text-center zd:whitespace-pre-wrap">
+          {children}
+        </Text>
       </div>
     </div>
   )

--- a/packages/react-wallet-ui/src/shared/components/TopNav/index.tsx
+++ b/packages/react-wallet-ui/src/shared/components/TopNav/index.tsx
@@ -18,7 +18,7 @@ export function TopNav({
   return (
     <div
       className={cn(
-        'absolute top-4 left-0 right-0 flex flex-row items-center justify-between',
+        'zd:absolute zd:top-4 zd:left-0 zd:right-0 zd:flex zd:flex-row zd:items-center zd:justify-between',
         className,
       )}
       style={{ height: TOP_NAV_HEIGHT }}
@@ -26,16 +26,16 @@ export function TopNav({
       {onBack ? (
         <IconButton iconName="chevronLeft" onClick={onBack} />
       ) : (
-        <div className="h-13 w-13" />
+        <div className="zd:h-13 zd:w-13" />
       )}
       {centerLogo && (
-        <div className="absolute left-0 right-0 flex items-center justify-center pointer-events-none">
-          <Icon name="zerodevLogo" className="h-8 w-auto" />
+        <div className="zd:absolute zd:left-0 zd:right-0 zd:flex zd:items-center zd:justify-center zd:pointer-events-none">
+          <Icon name="zerodevLogo" className="zd:h-8 zd:w-auto" />
         </div>
       )}
       {title && (
-        <div className="absolute left-0 right-0 flex items-center justify-center pointer-events-none">
-          <Text className="text-body1">{title}</Text>
+        <div className="zd:absolute zd:left-0 zd:right-0 zd:flex zd:items-center zd:justify-center zd:pointer-events-none">
+          <Text className="zd:text-body1">{title}</Text>
         </div>
       )}
       <IconButton iconName="x" onClick={onClose} />

--- a/packages/react-wallet-ui/src/signing/components/AllocationModule/index.tsx
+++ b/packages/react-wallet-ui/src/signing/components/AllocationModule/index.tsx
@@ -26,19 +26,19 @@ export function AllocationModule({
   const checkboxId = useId()
 
   return (
-    <div className="w-full flex flex-col p-2 pb-3 gap-2 border-b border-offWhite/50">
-      <div className="flex flex-row items-center justify-between">
-        <div className="flex flex-row items-center gap-2">
-          <div className="bg-offWhite rounded-xl w-11 h-11 flex items-center justify-center shrink-0">
+    <div className="zd:w-full zd:flex zd:flex-col zd:p-2 zd:pb-3 zd:gap-2 zd:border-b zd:border-offWhite/50">
+      <div className="zd:flex zd:flex-row zd:items-center zd:justify-between">
+        <div className="zd:flex zd:flex-row zd:items-center zd:gap-2">
+          <div className="zd:bg-offWhite zd:rounded-xl zd:w-11 zd:h-11 zd:flex zd:items-center zd:justify-center zd:shrink-0">
             {imageSource && (
-              <img src={imageSource} alt="" className="w-6 h-6" />
+              <img src={imageSource} alt="" className="zd:w-6 zd:h-6" />
             )}
           </div>
-          <div className="flex flex-col">
-            <Text className="text-body1">{symbol}</Text>
-            <div className="flex flex-row gap-1 items-center">
-              <Icon name={network as IconName} className="h-3 w-3" />
-              <Text className="text-body3 text-greyScale/50">
+          <div className="zd:flex zd:flex-col">
+            <Text className="zd:text-body1">{symbol}</Text>
+            <div className="zd:flex zd:flex-row zd:gap-1 zd:items-center">
+              <Icon name={network as IconName} className="zd:h-3 zd:w-3" />
+              <Text className="zd:text-body3 zd:text-greyScale/50">
                 {capitalizeFirst(network)}
               </Text>
             </div>
@@ -46,9 +46,9 @@ export function AllocationModule({
         </div>
         <label
           htmlFor={checkboxId}
-          className="flex flex-row items-center gap-2 cursor-pointer select-none"
+          className="zd:flex zd:flex-row zd:items-center zd:gap-2 zd:cursor-pointer zd:select-none"
         >
-          <Text className="text-body1">
+          <Text className="zd:text-body1">
             {availableAmount} {symbol}
           </Text>
           <input
@@ -56,12 +56,12 @@ export function AllocationModule({
             type="checkbox"
             checked={checked}
             onChange={onCheck}
-            className="h-4 w-4 cursor-pointer accent-solarOrange"
+            className="zd:h-4 zd:w-4 zd:cursor-pointer zd:accent-solarOrange"
           />
         </label>
       </div>
       <Input placeholder="0">
-        <WrappedPressable className="w-14 h-7">
+        <WrappedPressable className="zd:w-14 zd:h-7">
           <Text>Max</Text>
         </WrappedPressable>
       </Input>

--- a/packages/react-wallet-ui/src/signing/components/ArrowCardPair/index.tsx
+++ b/packages/react-wallet-ui/src/signing/components/ArrowCardPair/index.tsx
@@ -86,7 +86,7 @@ function ClippedCard({
     <div
       ref={ref}
       data-testid={`clipped-card-${position}`}
-      className="w-full"
+      className="zd:w-full"
       style={{ clipPath }}
     >
       {children}
@@ -96,9 +96,9 @@ function ClippedCard({
 
 function Arrow({ className }: { className?: string }) {
   return (
-    <div className={cn('p-1 rounded-2xl', className)}>
-      <Wrapper className="w-11 h-11 flex items-center justify-center rounded-xl">
-        <Icon name="chevronDown" className="w-4 h-4" />
+    <div className={cn('zd:p-1 zd:rounded-2xl', className)}>
+      <Wrapper className="zd:w-11 zd:h-11 zd:flex zd:items-center zd:justify-center zd:rounded-xl">
+        <Icon name="chevronDown" className="zd:w-4 zd:h-4" />
       </Wrapper>
     </div>
   )
@@ -115,10 +115,10 @@ export interface ArrowCardPairProps {
 
 export function ArrowCardPair({ topCard, bottomCard }: ArrowCardPairProps) {
   return (
-    <div className="relative flex flex-col gap-1 items-center justify-center w-full">
+    <div className="zd:relative zd:flex zd:flex-col zd:gap-1 zd:items-center zd:justify-center zd:w-full">
       <ClippedCard position="top">{topCard}</ClippedCard>
       <ClippedCard position="bottom">{bottomCard}</ClippedCard>
-      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+      <div className="zd:absolute zd:inset-0 zd:flex zd:items-center zd:justify-center zd:pointer-events-none">
         <Arrow />
       </div>
     </div>

--- a/packages/react-wallet-ui/src/signing/components/DataRow/DataRow.stories.tsx
+++ b/packages/react-wallet-ui/src/signing/components/DataRow/DataRow.stories.tsx
@@ -66,7 +66,7 @@ export const WithTrailingIcon: Story = {
 export const WithCustomValue: Story = {
   args: {
     label: 'status',
-    value: <Text className="text-solarOrange">Pending</Text>,
+    value: <Text className="zd:text-solarOrange">Pending</Text>,
   },
 }
 

--- a/packages/react-wallet-ui/src/signing/components/DataRow/index.tsx
+++ b/packages/react-wallet-ui/src/signing/components/DataRow/index.tsx
@@ -21,20 +21,26 @@ export function DataRow({
 
   return (
     <div
-      className={cn('flex flex-row items-center justify-between', className)}
+      className={cn(
+        'zd:flex zd:flex-row zd:items-center zd:justify-between',
+        className,
+      )}
     >
       <Text>{camelCaseToTitle(label)}</Text>
-      <div className="flex flex-row items-center gap-1">
+      <div className="zd:flex zd:flex-row zd:items-center zd:gap-1">
         {leadingIconName && (
-          <Icon name={leadingIconName} className="h-3 w-3 text-solarOrange" />
+          <Icon
+            name={leadingIconName}
+            className="zd:h-3 zd:w-3 zd:text-solarOrange"
+          />
         )}
         {typeof value === 'string' ? (
-          <Text className="text-body1">{value}</Text>
+          <Text className="zd:text-body1">{value}</Text>
         ) : (
           value
         )}
         {iconName && (
-          <Icon name={iconName} className="w-4 h-4 text-solarOrange" />
+          <Icon name={iconName} className="zd:w-4 zd:h-4 zd:text-solarOrange" />
         )}
       </div>
     </div>
@@ -49,14 +55,17 @@ interface DataRowSkeletonProps {
 export function DataRowSkeleton({ className, label }: DataRowSkeletonProps) {
   return (
     <div
-      className={cn('flex flex-row items-center justify-between', className)}
+      className={cn(
+        'zd:flex zd:flex-row zd:items-center zd:justify-between',
+        className,
+      )}
     >
       {label ? (
         <Text>{camelCaseToTitle(label)}</Text>
       ) : (
-        <div className="w-24 h-3 rounded-lg bg-offWhite/50 animate-pulse" />
+        <div className="zd:w-24 zd:h-3 zd:rounded-lg zd:bg-offWhite/50 zd:animate-pulse" />
       )}
-      <div className="w-24 h-3 rounded-lg bg-offWhite/50 animate-pulse" />
+      <div className="zd:w-24 zd:h-3 zd:rounded-lg zd:bg-offWhite/50 zd:animate-pulse" />
     </div>
   )
 }

--- a/packages/react-wallet-ui/src/signing/components/InfoCard/InfoCard.test.tsx
+++ b/packages/react-wallet-ui/src/signing/components/InfoCard/InfoCard.test.tsx
@@ -30,7 +30,7 @@ describe('InfoCard', () => {
       const { container } = render(
         <InfoCard title="My Title" imageSource="https://example.com/x.png" />,
       )
-      expect(container.querySelector('.bg-white')).not.toBeNull()
+      expect(container.querySelector('.zd\\:bg-white')).not.toBeNull()
       const img = container.querySelector('img') as HTMLImageElement
       expect(img.src).toBe('https://example.com/x.png')
       expect(img.className).toContain('w-8')
@@ -45,7 +45,7 @@ describe('InfoCard', () => {
           imageStyle="filled"
         />,
       )
-      expect(container.querySelector('.bg-white')).toBeNull()
+      expect(container.querySelector('.zd\\:bg-white')).toBeNull()
       const img = container.querySelector('img') as HTMLImageElement
       expect(img.className).toContain('w-11')
       expect(img.className).toContain('h-11')

--- a/packages/react-wallet-ui/src/signing/components/InfoCard/index.tsx
+++ b/packages/react-wallet-ui/src/signing/components/InfoCard/index.tsx
@@ -19,12 +19,12 @@ export function InfoCard({
   rightElement,
 }: InfoCardProps) {
   return (
-    <Wrapper className="h-[84px] px-3 rounded-2xl flex flex-row items-center gap-2 w-full justify-between">
-      <div className="gap-2 flex flex-row items-center h-[52px]">
+    <Wrapper className="zd:h-[84px] zd:px-3 zd:rounded-2xl zd:flex zd:flex-row zd:items-center zd:gap-2 zd:w-full zd:justify-between">
+      <div className="zd:gap-2 zd:flex zd:flex-row zd:items-center zd:h-[52px]">
         {imageStyle === 'contained' ? (
-          <div className="w-11 h-11 rounded-xl bg-white flex items-center justify-center shrink-0">
+          <div className="zd:w-11 zd:h-11 zd:rounded-xl zd:bg-white zd:flex zd:items-center zd:justify-center zd:shrink-0">
             {imageSource && (
-              <img src={imageSource} alt="" className="w-8 h-8" />
+              <img src={imageSource} alt="" className="zd:w-8 zd:h-8" />
             )}
           </div>
         ) : (
@@ -32,13 +32,13 @@ export function InfoCard({
             <img
               src={imageSource}
               alt=""
-              className="w-11 h-11 rounded-xl shrink-0"
+              className="zd:w-11 zd:h-11 zd:rounded-xl zd:shrink-0"
             />
           )
         )}
-        <div className="flex flex-col">
-          <Text className="text-body1">{title}</Text>
-          {subtitle && <Text className="text-greyScale/50">{subtitle}</Text>}
+        <div className="zd:flex zd:flex-col">
+          <Text className="zd:text-body1">{title}</Text>
+          {subtitle && <Text className="zd:text-greyScale/50">{subtitle}</Text>}
         </div>
       </div>
       {rightElement}

--- a/packages/react-wallet-ui/src/signing/components/RouteItem/index.tsx
+++ b/packages/react-wallet-ui/src/signing/components/RouteItem/index.tsx
@@ -9,28 +9,34 @@ export interface GasRoute {
 
 export function RouteItem({ source, destination, gasFee }: GasRoute) {
   return (
-    <div className="w-full flex flex-row items-center justify-between">
-      <div className="flex flex-row items-center gap-1">
-        <div className="relative flex flex-row items-center w-[52px] h-8">
-          <div className="w-8 h-8 flex items-center justify-center bg-offWhite rounded-xl">
-            <Icon name={source as IconName} className="w-[18px] h-[18px]" />
+    <div className="zd:w-full zd:flex zd:flex-row zd:items-center zd:justify-between">
+      <div className="zd:flex zd:flex-row zd:items-center zd:gap-1">
+        <div className="zd:relative zd:flex zd:flex-row zd:items-center zd:w-[52px] zd:h-8">
+          <div className="zd:w-8 zd:h-8 zd:flex zd:items-center zd:justify-center zd:bg-offWhite zd:rounded-xl">
+            <Icon
+              name={source as IconName}
+              className="zd:w-[18px] zd:h-[18px]"
+            />
           </div>
-          <div className="w-8 h-8 flex items-center justify-center bg-offWhite rounded-xl absolute right-0">
+          <div className="zd:w-8 zd:h-8 zd:flex zd:items-center zd:justify-center zd:bg-offWhite zd:rounded-xl zd:absolute zd:right-0">
             <Icon
               name={destination as IconName}
-              className="w-[18px] h-[18px]"
+              className="zd:w-[18px] zd:h-[18px]"
             />
           </div>
         </div>
-        <div className="flex flex-row items-center gap-1">
+        <div className="zd:flex zd:flex-row zd:items-center zd:gap-1">
           <Text>{capitalizeFirst(source)}</Text>
-          <Icon name="arrowRightFill" className="h-3 w-3 text-greyScale/50" />
+          <Icon
+            name="arrowRightFill"
+            className="zd:h-3 zd:w-3 zd:text-greyScale/50"
+          />
           <Text>{capitalizeFirst(destination)}</Text>
         </div>
       </div>
-      <div className="flex flex-row items-center gap-1">
+      <div className="zd:flex zd:flex-row zd:items-center zd:gap-1">
         <Text>{gasFee}</Text>
-        <Icon name="gasStation" className="w-4 h-4 text-solarOrange" />
+        <Icon name="gasStation" className="zd:w-4 zd:h-4 zd:text-solarOrange" />
       </div>
     </div>
   )

--- a/packages/react-wallet-ui/src/signing/components/Section/Section.stories.tsx
+++ b/packages/react-wallet-ui/src/signing/components/Section/Section.stories.tsx
@@ -26,7 +26,7 @@ const meta = {
     title: 'Transaction details',
     iconName: 'wallet',
     children: (
-      <div className="flex flex-col gap-2">
+      <div className="zd:flex zd:flex-col zd:gap-2">
         <Text>Some random text</Text>
       </div>
     ),

--- a/packages/react-wallet-ui/src/signing/components/Section/index.tsx
+++ b/packages/react-wallet-ui/src/signing/components/Section/index.tsx
@@ -17,21 +17,21 @@ export function Section({
   const [collapsed, setCollapsed] = useState(collapsible === true)
 
   return (
-    <Wrapper className="p-4 flex flex-col gap-3 rounded-xl w-full">
-      <div className="flex flex-row justify-between items-center">
-        <div className="flex flex-row items-center gap-2">
-          <Icon name={iconName} className="h-4 w-4 text-solarOrange" />
-          <Text className="text-h3">{title}</Text>
+    <Wrapper className="zd:p-4 zd:flex zd:flex-col zd:gap-3 zd:rounded-xl zd:w-full">
+      <div className="zd:flex zd:flex-row zd:justify-between zd:items-center">
+        <div className="zd:flex zd:flex-row zd:items-center zd:gap-2">
+          <Icon name={iconName} className="zd:h-4 zd:w-4 zd:text-solarOrange" />
+          <Text className="zd:text-h3">{title}</Text>
         </div>
         {collapsible !== undefined && (
           <button
             type="button"
             onClick={() => setCollapsed((c) => !c)}
-            className="flex items-center justify-center cursor-pointer"
+            className="zd:flex zd:items-center zd:justify-center zd:cursor-pointer"
           >
             <Icon
               name={collapsed ? 'chevronDown' : 'chevronUp'}
-              className="w-4 h-4 text-greyScale"
+              className="zd:w-4 zd:h-4 zd:text-greyScale"
             />
           </button>
         )}

--- a/packages/react-wallet-ui/src/signing/components/SigningActions/index.tsx
+++ b/packages/react-wallet-ui/src/signing/components/SigningActions/index.tsx
@@ -18,23 +18,23 @@ export function SigningActions({
   const showAgreement = !!(termsAndConditionsUrl || privacyPolicyUrl)
 
   return (
-    <Wrapper className="p-1 gap-2 mb-1.5 rounded-3xl">
-      <div className="flex flex-row items-center gap-1">
+    <Wrapper className="zd:p-1 zd:gap-2 zd:mb-1.5 zd:rounded-3xl">
+      <div className="zd:flex zd:flex-row zd:items-center zd:gap-1">
         <Button
           text="Reject"
           action="secondary"
-          className="flex-1"
+          className="zd:flex-1"
           onClick={onReject}
         />
         <Button
           text="Confirm"
-          className="flex-1"
+          className="zd:flex-1"
           disabled={disabled}
           onClick={onConfirm}
         />
       </div>
       {showAgreement && (
-        <Text className="text-center text-body3 mt-2">
+        <Text className="zd:text-center zd:text-body3 zd:mt-2">
           By continuing, you accept the{' '}
           {termsAndConditionsUrl && (
             <Text
@@ -42,7 +42,7 @@ export function SigningActions({
               href={termsAndConditionsUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="underline text-body3"
+              className="zd:underline zd:text-body3"
             >
               Terms
             </Text>
@@ -54,7 +54,7 @@ export function SigningActions({
               href={privacyPolicyUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="underline text-body3"
+              className="zd:underline zd:text-body3"
             >
               Privacy Policy
             </Text>

--- a/packages/react-wallet-ui/src/signing/components/SigningLayout/index.tsx
+++ b/packages/react-wallet-ui/src/signing/components/SigningLayout/index.tsx
@@ -19,8 +19,8 @@ export function SigningLayout({
   error,
 }: SigningLayoutProps) {
   return (
-    <div className="flex flex-col h-full">
-      <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-2 pb-2">
+    <div className="zd:flex zd:flex-col zd:h-full">
+      <div className="zd:flex-1 zd:min-h-0 zd:overflow-y-auto zd:flex zd:flex-col zd:gap-2 zd:pb-2">
         {children}
         {!!error && <Callout {...getTxErrorInfo(error)} />}
       </div>

--- a/packages/react-wallet-ui/src/signing/components/SigningPageSkeleton/index.tsx
+++ b/packages/react-wallet-ui/src/signing/components/SigningPageSkeleton/index.tsx
@@ -3,18 +3,23 @@ import { DataRowSkeleton } from '../DataRow'
 
 function SkeletonBar({ className }: { className?: string }) {
   return (
-    <div className={cn('rounded-lg bg-offWhite/50 animate-pulse', className)} />
+    <div
+      className={cn(
+        'zd:rounded-lg zd:bg-offWhite/50 zd:animate-pulse',
+        className,
+      )}
+    />
   )
 }
 
 function SkeletonCard() {
   return (
-    <Wrapper className="rounded-xl p-4 w-full flex flex-col gap-3">
-      <div className="flex flex-row items-center gap-3">
-        <SkeletonBar className="w-12 h-12 rounded-2xl" />
-        <div className="flex flex-col gap-2 flex-1">
-          <SkeletonBar className="w-1/2 h-4" />
-          <SkeletonBar className="w-1/3 h-3" />
+    <Wrapper className="zd:rounded-xl zd:p-4 zd:w-full zd:flex zd:flex-col zd:gap-3">
+      <div className="zd:flex zd:flex-row zd:items-center zd:gap-3">
+        <SkeletonBar className="zd:w-12 zd:h-12 zd:rounded-2xl" />
+        <div className="zd:flex zd:flex-col zd:gap-2 zd:flex-1">
+          <SkeletonBar className="zd:w-1/2 zd:h-4" />
+          <SkeletonBar className="zd:w-1/3 zd:h-3" />
         </div>
       </div>
     </Wrapper>
@@ -23,7 +28,7 @@ function SkeletonCard() {
 
 export function SigningPageSkeleton() {
   return (
-    <div className="flex flex-col gap-2">
+    <div className="zd:flex zd:flex-col zd:gap-2">
       <SkeletonCard />
       <SkeletonCard />
       <DataRowSkeleton />

--- a/packages/react-wallet-ui/src/signing/components/SmartFunding/index.tsx
+++ b/packages/react-wallet-ui/src/signing/components/SmartFunding/index.tsx
@@ -23,16 +23,19 @@ export function SmartFunding({
   totalPooledAmount,
 }: SmartFundingProps) {
   return (
-    <Wrapper className="p-4 flex flex-col gap-3 rounded-xl w-full">
-      <div className="flex flex-row items-center justify-between">
-        <div className="flex flex-row items-center gap-2">
-          <Icon name="stars" className="h-4 w-4 text-solarOrange" />
-          <Text className="text-h3">Smart Funding</Text>
+    <Wrapper className="zd:p-4 zd:flex zd:flex-col zd:gap-3 zd:rounded-xl zd:w-full">
+      <div className="zd:flex zd:flex-row zd:items-center zd:justify-between">
+        <div className="zd:flex zd:flex-row zd:items-center zd:gap-2">
+          <Icon name="stars" className="zd:h-4 zd:w-4 zd:text-solarOrange" />
+          <Text className="zd:text-h3">Smart Funding</Text>
         </div>
-        <div className="flex flex-row items-center gap-1">
+        <div className="zd:flex zd:flex-row zd:items-center zd:gap-1">
           <Switch value={true} />
-          <WrappedPressable className="w-7 h-7">
-            <Icon name="edit" className="h-3.5 w-3.5 text-solarOrange" />
+          <WrappedPressable className="zd:w-7 zd:h-7">
+            <Icon
+              name="edit"
+              className="zd:h-3.5 zd:w-3.5 zd:text-solarOrange"
+            />
           </WrappedPressable>
         </div>
       </div>
@@ -48,9 +51,9 @@ export function SmartFunding({
           availableAmount={pooledToken.availableAmount}
         />
       ))}
-      <div className="flex flex-row items-center justify-between pt-4 px-2 border-t border-offWhite/50">
-        <Text className="text-body1">Pooling outcome</Text>
-        <Text className="text-body1">
+      <div className="zd:flex zd:flex-row zd:items-center zd:justify-between zd:pt-4 zd:px-2 zd:border-t zd:border-offWhite/50">
+        <Text className="zd:text-body1">Pooling outcome</Text>
+        <Text className="zd:text-body1">
           {totalPooledAmount} {inputTokenSymbol}
         </Text>
       </div>

--- a/packages/react-wallet-ui/src/signing/components/SmartFundingGasDetails/index.tsx
+++ b/packages/react-wallet-ui/src/signing/components/SmartFundingGasDetails/index.tsx
@@ -31,11 +31,11 @@ export function SmartFundingGasDetails({
   const { bridge, swapped } = gasRoutes
 
   return (
-    <Wrapper className="p-4 flex flex-col gap-6 rounded-xl w-full">
-      <div className="flex flex-row justify-between items-center">
-        <div className="flex flex-row items-center gap-2">
-          <Icon name="stars" className="h-4 w-4 text-solarOrange" />
-          <Text className="text-h3">Smart Funding Gas Details</Text>
+    <Wrapper className="zd:p-4 zd:flex zd:flex-col zd:gap-6 zd:rounded-xl zd:w-full">
+      <div className="zd:flex zd:flex-row zd:justify-between zd:items-center">
+        <div className="zd:flex zd:flex-row zd:items-center zd:gap-2">
+          <Icon name="stars" className="zd:h-4 zd:w-4 zd:text-solarOrange" />
+          <Text className="zd:text-h3">Smart Funding Gas Details</Text>
         </div>
         <button
           type="button"
@@ -44,17 +44,17 @@ export function SmartFundingGasDetails({
           }}
           aria-label={expanded ? 'Collapse' : 'Expand'}
           aria-expanded={expanded}
-          className="cursor-pointer"
+          className="zd:cursor-pointer"
         >
           <Icon
             name={expanded ? 'chevronUp' : 'chevronDown'}
-            className="w-4 h-4 text-greyScale"
+            className="zd:w-4 zd:h-4 zd:text-greyScale"
           />
         </button>
       </div>
       {expanded && (
         <>
-          <div className="flex flex-col gap-3">
+          <div className="zd:flex zd:flex-col zd:gap-3">
             <DataRow
               label="Total execution time"
               value={formattedExecutionTime}
@@ -68,7 +68,7 @@ export function SmartFundingGasDetails({
           </div>
 
           {bridge && bridge.length > 0 && (
-            <div className="flex flex-col gap-3">
+            <div className="zd:flex zd:flex-col zd:gap-3">
               <Text>{bridge.length} Bridge</Text>
               {bridge.map((gasRoute, key) => (
                 <RouteItem
@@ -82,7 +82,7 @@ export function SmartFundingGasDetails({
           )}
 
           {swapped && swapped.length > 0 && (
-            <div className="flex flex-col gap-3">
+            <div className="zd:flex zd:flex-col zd:gap-3">
               <Text>{swapped.length} Swapped</Text>
               {swapped.map((gasRoute, key) => (
                 <RouteItem
@@ -95,7 +95,7 @@ export function SmartFundingGasDetails({
             </div>
           )}
 
-          <div className="flex flex-col gap-3">
+          <div className="zd:flex zd:flex-col zd:gap-3">
             <Text>Fees:</Text>
             {providerFees.map((item, key) => (
               <DataRow

--- a/packages/react-wallet-ui/src/signing/components/TokenCard/index.tsx
+++ b/packages/react-wallet-ui/src/signing/components/TokenCard/index.tsx
@@ -21,18 +21,18 @@ export function TokenCard({
   const { symbol, imageSource, network } = token
 
   return (
-    <div className="w-full p-2 flex flex-row justify-between items-center">
-      <div className="flex flex-row items-center gap-2">
-        <div className="bg-offWhite rounded-xl w-8 h-8 flex items-center justify-center shrink-0">
+    <div className="zd:w-full zd:p-2 zd:flex zd:flex-row zd:justify-between zd:items-center">
+      <div className="zd:flex zd:flex-row zd:items-center zd:gap-2">
+        <div className="zd:bg-offWhite zd:rounded-xl zd:w-8 zd:h-8 zd:flex zd:items-center zd:justify-center zd:shrink-0">
           {imageSource && (
-            <img src={imageSource} alt="" className="w-[18px] h-[18px]" />
+            <img src={imageSource} alt="" className="zd:w-[18px] zd:h-[18px]" />
           )}
         </div>
-        <div className="flex flex-col">
-          <Text className="text-body1">{symbol}</Text>
-          <div className="flex flex-row gap-1 items-center">
-            <Icon name={network as IconName} className="h-3 w-3" />
-            <Text className="text-body3 text-greyScale/50">
+        <div className="zd:flex zd:flex-col">
+          <Text className="zd:text-body1">{symbol}</Text>
+          <div className="zd:flex zd:flex-row zd:gap-1 zd:items-center">
+            <Icon name={network as IconName} className="zd:h-3 zd:w-3" />
+            <Text className="zd:text-body3 zd:text-greyScale/50">
               {capitalizeFirst(network)}
             </Text>
           </div>
@@ -40,7 +40,7 @@ export function TokenCard({
       </div>
       <Text>
         {pooledAmount}{' '}
-        <Text as="span" className="text-greyScale/50">
+        <Text as="span" className="zd:text-greyScale/50">
           / {availableAmount} {symbol}
         </Text>
       </Text>

--- a/packages/react-wallet-ui/src/signing/components/TxDetailsItem/index.tsx
+++ b/packages/react-wallet-ui/src/signing/components/TxDetailsItem/index.tsx
@@ -12,13 +12,16 @@ export function TxDetailsItem({ title, index, data }: TxDetailsItemProps) {
   const [expanded, setExpanded] = useState(false)
 
   return (
-    <Wrapper className="w-full flex flex-col rounded-xl gap-2" variant="ghost">
-      <Wrapper className="w-full h-[68px] rounded-xl p-4 flex flex-row justify-between items-center">
-        <div className="flex flex-row gap-2 items-center">
-          <div className="w-11 h-11 bg-white flex items-center justify-center rounded-xl">
-            <Text className="text-body1">{index}</Text>
+    <Wrapper
+      className="zd:w-full zd:flex zd:flex-col zd:rounded-xl zd:gap-2"
+      variant="ghost"
+    >
+      <Wrapper className="zd:w-full zd:h-[68px] zd:rounded-xl zd:p-4 zd:flex zd:flex-row zd:justify-between zd:items-center">
+        <div className="zd:flex zd:flex-row zd:gap-2 zd:items-center">
+          <div className="zd:w-11 zd:h-11 zd:bg-white zd:flex zd:items-center zd:justify-center zd:rounded-xl">
+            <Text className="zd:text-body1">{index}</Text>
           </div>
-          <Text className="text-body1">{title}</Text>
+          <Text className="zd:text-body1">{title}</Text>
         </div>
         <button
           type="button"
@@ -27,16 +30,16 @@ export function TxDetailsItem({ title, index, data }: TxDetailsItemProps) {
           }}
           aria-label={expanded ? 'Collapse' : 'Expand'}
           aria-expanded={expanded}
-          className="cursor-pointer"
+          className="zd:cursor-pointer"
         >
           <Icon
             name={expanded ? 'chevronUp' : 'chevronDown'}
-            className="w-4 h-4"
+            className="zd:w-4 zd:h-4"
           />
         </button>
       </Wrapper>
       {expanded && (
-        <div className="flex flex-col px-5 pb-2 gap-2">
+        <div className="zd:flex zd:flex-col zd:px-5 zd:pb-2 zd:gap-2">
           {Object.entries(data).map(([label, value]) => (
             <DataRow key={label} label={label} value={value} />
           ))}

--- a/packages/react-wallet-ui/src/signing/components/TxGasFees/TxGasFees.test.tsx
+++ b/packages/react-wallet-ui/src/signing/components/TxGasFees/TxGasFees.test.tsx
@@ -155,7 +155,7 @@ describe('TxGasFeesSkeleton', () => {
 
   it('renders three ListItem skeletons', () => {
     const { container } = render(<TxGasFeesSkeleton />)
-    const pulses = container.querySelectorAll('.animate-pulse')
+    const pulses = container.querySelectorAll('.zd\\:animate-pulse')
     // 2 bars per ListItemSkeleton * 3 rows + avatar circle per row + 2 inline Fee bars
     expect(pulses.length).toBeGreaterThanOrEqual(3)
   })

--- a/packages/react-wallet-ui/src/signing/components/TxGasFees/index.tsx
+++ b/packages/react-wallet-ui/src/signing/components/TxGasFees/index.tsx
@@ -41,35 +41,43 @@ function getTierIcon(tier: GasTier): IconName {
 
 function SkeletonBar({ className }: { className?: string }) {
   return (
-    <div className={cn('rounded-lg bg-offWhite/50 animate-pulse', className)} />
+    <div
+      className={cn(
+        'zd:rounded-lg zd:bg-offWhite/50 zd:animate-pulse',
+        className,
+      )}
+    />
   )
 }
 
 export function TxGasFeesSkeleton() {
   return (
-    <Wrapper className="rounded-xl p-4 w-full flex flex-col gap-3">
-      <div className="flex flex-row items-center justify-between">
-        <div className="flex flex-row items-center gap-2">
-          <Icon name="lightingFill" className="h-4 w-4 text-solarOrange" />
-          <Text className="text-xl">Estimated Gas Fees</Text>
+    <Wrapper className="zd:rounded-xl zd:p-4 zd:w-full zd:flex zd:flex-col zd:gap-3">
+      <div className="zd:flex zd:flex-row zd:items-center zd:justify-between">
+        <div className="zd:flex zd:flex-row zd:items-center zd:gap-2">
+          <Icon
+            name="lightingFill"
+            className="zd:h-4 zd:w-4 zd:text-solarOrange"
+          />
+          <Text className="zd:text-xl">Estimated Gas Fees</Text>
         </div>
-        <WrappedPressable className="h-7 pl-3 pr-2">
+        <WrappedPressable className="zd:h-7 zd:pl-3 zd:pr-2">
           <Text>Market</Text>
-          <Icon name="chevronDown" className="h-4 w-4" />
+          <Icon name="chevronDown" className="zd:h-4 zd:w-4" />
         </WrappedPressable>
       </div>
-      <div className="flex flex-col gap-4 my-[1.5px]">
+      <div className="zd:flex zd:flex-col zd:gap-4 zd:my-[1.5px]">
         <DataRow
           label="Fee"
           value={
-            <div className="flex flex-row gap-1">
-              <SkeletonBar className="w-[105px] h-3" />
-              <SkeletonBar className="w-14 h-3" />
+            <div className="zd:flex zd:flex-row zd:gap-1">
+              <SkeletonBar className="zd:w-[105px] zd:h-3" />
+              <SkeletonBar className="zd:w-14 zd:h-3" />
             </div>
           }
         />
       </div>
-      <div className="flex flex-col gap-1">
+      <div className="zd:flex zd:flex-col zd:gap-1">
         <ListItemSkeleton />
         <ListItemSkeleton />
         <ListItemSkeleton />
@@ -86,18 +94,21 @@ export function TxGasFees({
   const selectedGasFee = gasFees.find((g) => g.tier === selectedGasTier)
 
   return (
-    <Wrapper className="rounded-xl p-4 w-full flex flex-col gap-3">
-      <div className="flex flex-row items-center justify-between">
-        <div className="flex flex-row items-center gap-2">
-          <Icon name="lightingFill" className="h-4 w-4 text-solarOrange" />
-          <Text className="text-xl">Estimated Gas Fees</Text>
+    <Wrapper className="zd:rounded-xl zd:p-4 zd:w-full zd:flex zd:flex-col zd:gap-3">
+      <div className="zd:flex zd:flex-row zd:items-center zd:justify-between">
+        <div className="zd:flex zd:flex-row zd:items-center zd:gap-2">
+          <Icon
+            name="lightingFill"
+            className="zd:h-4 zd:w-4 zd:text-solarOrange"
+          />
+          <Text className="zd:text-xl">Estimated Gas Fees</Text>
         </div>
-        <WrappedPressable className="h-7 pl-3 pr-2">
+        <WrappedPressable className="zd:h-7 zd:pl-3 zd:pr-2">
           <Text>{capitalizeFirst(selectedGasTier)}</Text>
-          <Icon name="chevronDown" className="h-4 w-4" />
+          <Icon name="chevronDown" className="zd:h-4 zd:w-4" />
         </WrappedPressable>
       </div>
-      <div className="flex flex-col gap-4">
+      <div className="zd:flex zd:flex-col zd:gap-4">
         <DataRow
           label="Fee"
           value={`${selectedGasFee?.fee} (${selectedGasFee?.feeUsd})`}
@@ -112,7 +123,7 @@ export function TxGasFees({
           />
         )}
       </div>
-      <div className="flex flex-col gap-1">
+      <div className="zd:flex zd:flex-col zd:gap-1">
         {gasFees.map((item) => (
           <ListItem
             key={item.tier}

--- a/packages/react-wallet-ui/src/signing/components/TxInformation/index.tsx
+++ b/packages/react-wallet-ui/src/signing/components/TxInformation/index.tsx
@@ -7,17 +7,17 @@ export interface TxInformationProps {
 
 export function TxInformation({ network }: TxInformationProps) {
   return (
-    <Wrapper className="rounded-2xl w-full">
-      <div className="flex flex-col p-4 gap-2">
+    <Wrapper className="zd:rounded-2xl zd:w-full">
+      <div className="zd:flex zd:flex-col zd:p-4 zd:gap-2">
         {network && (
-          <div className="flex flex-row justify-between">
+          <div className="zd:flex zd:flex-row zd:justify-between">
             <Text>Network</Text>
-            <div className="flex flex-row gap-2 items-center">
-              <Text className="text-body1">{capitalizeFirst(network)}</Text>
-              <div className="h-[18px] w-[18px] bg-white flex items-center justify-center rounded-full">
+            <div className="zd:flex zd:flex-row zd:gap-2 zd:items-center">
+              <Text className="zd:text-body1">{capitalizeFirst(network)}</Text>
+              <div className="zd:h-[18px] zd:w-[18px] zd:bg-white zd:flex zd:items-center zd:justify-center zd:rounded-full">
                 <Icon
                   name={network as IconName}
-                  className="h-[18px] w-[18px]"
+                  className="zd:h-[18px] zd:w-[18px]"
                 />
               </div>
             </div>

--- a/packages/react-wallet-ui/src/signing/components/TypedDataMessage/index.tsx
+++ b/packages/react-wallet-ui/src/signing/components/TypedDataMessage/index.tsx
@@ -2,7 +2,7 @@ import { shortenHex } from '../../../shared/utils/common'
 import { DataRow } from '../DataRow'
 import type { TypedDataField, TypedDataV4 } from './types'
 
-const INDENT_CLASS = ['', 'pl-2', 'pl-4', 'pl-6', 'pl-8'] as const
+const INDENT_CLASS = ['', 'zd:pl-2', 'zd:pl-4', 'zd:pl-6', 'zd:pl-8'] as const
 
 function indentClass(level: number): string {
   return INDENT_CLASS[level] ?? INDENT_CLASS.at(-1) ?? ''

--- a/packages/react-wallet-ui/src/signing/index.tsx
+++ b/packages/react-wallet-ui/src/signing/index.tsx
@@ -89,7 +89,7 @@ function UncontrolledSignatureRequest({
     <Screen className={className} style={style}>
       {renderRequestContent(pendingRequest, confirm, reject)}
       {pendingRequests.length > 1 && (
-        <p className="text-xs text-gray-500 mt-3">
+        <p className="zd:text-xs zd:text-gray-500 zd:mt-3">
           +{pendingRequests.length - 1} more pending{' '}
           {pendingRequests.length - 1 === 1 ? 'request' : 'requests'}
         </p>

--- a/packages/react-wallet-ui/src/signing/pages/BatchCalls.tsx
+++ b/packages/react-wallet-ui/src/signing/pages/BatchCalls.tsx
@@ -302,12 +302,12 @@ export function BatchCalls({ calls, confirm, reject }: BatchCallsProps) {
       disabled={confirmDisabled}
       error={gasError}
     >
-      <div className="flex flex-col gap-2 pt-4">
-        <div className="flex flex-col items-center justify-center gap-2 pb-2">
-          <Text className="text-h2">Confirm Transaction</Text>
+      <div className="zd:flex zd:flex-col zd:gap-2 zd:pt-4">
+        <div className="zd:flex zd:flex-col zd:items-center zd:justify-center zd:gap-2 zd:pb-2">
+          <Text className="zd:text-h2">Confirm Transaction</Text>
         </div>
         <Section title="Transaction Details" iconName="arrowSwapHorizontal">
-          <div className="flex flex-col gap-1">
+          <div className="zd:flex zd:flex-col zd:gap-1">
             {calls.map((call, i) => (
               <CallItem
                 key={`${call.to ?? 'unknown'}-${i}`}

--- a/packages/react-wallet-ui/src/signing/pages/CollectionApproval.tsx
+++ b/packages/react-wallet-ui/src/signing/pages/CollectionApproval.tsx
@@ -78,21 +78,21 @@ export function CollectionApproval({
       disabled={confirmDisabled}
       error={gasError}
     >
-      <div className="flex flex-col gap-2 pt-4">
-        <div className="flex flex-col items-center justify-center gap-2 pb-2">
-          <Text className="text-h2">
+      <div className="zd:flex zd:flex-col zd:gap-2 zd:pt-4">
+        <div className="zd:flex zd:flex-col zd:items-center zd:justify-center zd:gap-2 zd:pb-2">
+          <Text className="zd:text-h2">
             {approved
               ? 'Grant Collection Approval'
               : 'Revoke Collection Approval'}
           </Text>
-          <Text className="text-center">
+          <Text className="zd:text-center">
             {approved
               ? `Allow this contract to manage all your ${collectionName} tokens.`
               : `Revoke this contract's permission to manage your ${collectionName} tokens.`}
           </Text>
         </div>
-        <div className="flex flex-col gap-2">
-          <Text className="text-body1 pt-2 px-2">
+        <div className="zd:flex zd:flex-col zd:gap-2">
+          <Text className="zd:text-body1 zd:pt-2 zd:px-2">
             You&#39;re approving permission to
           </Text>
           <ArrowCardPair

--- a/packages/react-wallet-ui/src/signing/pages/Erc20Approval.tsx
+++ b/packages/react-wallet-ui/src/signing/pages/Erc20Approval.tsx
@@ -86,16 +86,16 @@ export function Erc20Approval({
       disabled={confirmDisabled}
       error={gasError}
     >
-      <div className="flex flex-col gap-2 pt-4">
-        <div className="flex flex-col items-center justify-center gap-2 pb-2">
-          <Text className="text-h2">Approve Token Spending</Text>
-          <Text className="text-center">
+      <div className="zd:flex zd:flex-col zd:gap-2 zd:pt-4">
+        <div className="zd:flex zd:flex-col zd:items-center zd:justify-center zd:gap-2 zd:pb-2">
+          <Text className="zd:text-h2">Approve Token Spending</Text>
+          <Text className="zd:text-center">
             This contract is requesting permission to spend your {symbol}. This
             is required for future transactions.
           </Text>
         </div>
-        <div className="flex flex-col gap-2">
-          <Text className="text-body1">You&#39;re approving:</Text>
+        <div className="zd:flex zd:flex-col zd:gap-2">
+          <Text className="zd:text-body1">You&#39;re approving:</Text>
           <ArrowCardPair
             topCard={<InfoCard title={`${formattedAmount} ${symbol}`} />}
             bottomCard={

--- a/packages/react-wallet-ui/src/signing/pages/Erc20Transfer.tsx
+++ b/packages/react-wallet-ui/src/signing/pages/Erc20Transfer.tsx
@@ -83,16 +83,16 @@ export function Erc20Transfer({
       disabled={confirmDisabled}
       error={gasError}
     >
-      <div className="flex flex-col gap-2 pt-4">
-        <div className="flex flex-col items-center justify-center gap-2 pb-2">
-          <Text className="text-h2">Send Token</Text>
-          <Text className="text-center">
+      <div className="zd:flex zd:flex-col zd:gap-2 zd:pt-4">
+        <div className="zd:flex zd:flex-col zd:items-center zd:justify-center zd:gap-2 zd:pb-2">
+          <Text className="zd:text-h2">Send Token</Text>
+          <Text className="zd:text-center">
             You are about to send {formattedAmount} {symbol} to {shortenHex(to)}
             .
           </Text>
         </div>
-        <div className="flex flex-col gap-2">
-          <Text className="text-body1">You&#39;re sending</Text>
+        <div className="zd:flex zd:flex-col zd:gap-2">
+          <Text className="zd:text-body1">You&#39;re sending</Text>
           <ArrowCardPair
             topCard={<InfoCard title={`${formattedAmount} ${symbol}`} />}
             bottomCard={

--- a/packages/react-wallet-ui/src/signing/pages/EthTransfer.tsx
+++ b/packages/react-wallet-ui/src/signing/pages/EthTransfer.tsx
@@ -38,15 +38,15 @@ export function EthTransfer({ to, value, confirm, reject }: EthTransferProps) {
       disabled={confirmDisabled}
       error={gasError}
     >
-      <div className="flex flex-col gap-2 pt-4">
-        <div className="flex flex-col items-center justify-center gap-2 pb-2">
-          <Text className="text-h2">Send Token</Text>
-          <Text className="text-center">
+      <div className="zd:flex zd:flex-col zd:gap-2 zd:pt-4">
+        <div className="zd:flex zd:flex-col zd:items-center zd:justify-center zd:gap-2 zd:pb-2">
+          <Text className="zd:text-h2">Send Token</Text>
+          <Text className="zd:text-center">
             You are about to send {formattedAmount} ETH to {shortenHex(to)}.
           </Text>
         </div>
-        <div className="flex flex-col gap-2">
-          <Text className="text-body1">You&#39;re sending</Text>
+        <div className="zd:flex zd:flex-col zd:gap-2">
+          <Text className="zd:text-body1">You&#39;re sending</Text>
           <ArrowCardPair
             topCard={
               <InfoCard

--- a/packages/react-wallet-ui/src/signing/pages/GenericRequest.tsx
+++ b/packages/react-wallet-ui/src/signing/pages/GenericRequest.tsx
@@ -32,15 +32,15 @@ export function GenericRequest({
   ) {
     return (
       <SigningLayout onConfirm={confirm} onReject={reject}>
-        <div className="flex flex-col gap-2 pt-4">
-          <div className="flex flex-col items-center justify-center gap-2 pb-2">
-            <Text className="text-h2">Confirm Request</Text>
+        <div className="zd:flex zd:flex-col zd:gap-2 zd:pt-4">
+          <div className="zd:flex zd:flex-col zd:items-center zd:justify-center zd:gap-2 zd:pb-2">
+            <Text className="zd:text-h2">Confirm Request</Text>
           </div>
-          <div className="text-sm">
-            <span className="font-medium text-gray-500">Method: </span>
-            <span className="text-gray-900">{request.method}</span>
+          <div className="zd:text-sm">
+            <span className="zd:font-medium zd:text-gray-500">Method: </span>
+            <span className="zd:text-gray-900">{request.method}</span>
           </div>
-          <pre className="rounded-lg bg-gray-50 p-3 text-xs text-gray-700 overflow-auto max-h-48 border border-gray-100">
+          <pre className="zd:rounded-lg zd:bg-gray-50 zd:p-3 zd:text-xs zd:text-gray-700 zd:overflow-auto zd:max-h-48 zd:border zd:border-gray-100">
             {JSON.stringify(request.params, null, 2)}
           </pre>
         </div>
@@ -94,9 +94,9 @@ function GenericSendTransaction({
       disabled={confirmDisabled}
       error={gasError}
     >
-      <div className="flex flex-col gap-2 pt-4">
-        <div className="flex flex-col items-center justify-center gap-2 pb-2">
-          <Text className="text-h2">Confirm Transaction</Text>
+      <div className="zd:flex zd:flex-col zd:gap-2 zd:pt-4">
+        <div className="zd:flex zd:flex-col zd:items-center zd:justify-center zd:gap-2 zd:pb-2">
+          <Text className="zd:text-h2">Confirm Transaction</Text>
         </div>
         <Section title="Transaction Summary" iconName="arrowSwapHorizontal">
           <DataRow label="To" value={shortenHex((to ?? '0x') as string)} />

--- a/packages/react-wallet-ui/src/signing/pages/MintNft.tsx
+++ b/packages/react-wallet-ui/src/signing/pages/MintNft.tsx
@@ -62,15 +62,17 @@ export function MintNft({ contract, data, confirm, reject }: MintNftProps) {
       disabled={confirmDisabled}
       error={gasError}
     >
-      <div className="flex flex-col gap-2 pt-4">
-        <div className="flex flex-col items-center justify-center gap-2 pb-2">
-          <Text className="text-h2">Mint NFT</Text>
-          <Text className="text-center">
+      <div className="zd:flex zd:flex-col zd:gap-2 zd:pt-4">
+        <div className="zd:flex zd:flex-col zd:items-center zd:justify-center zd:gap-2 zd:pb-2">
+          <Text className="zd:text-h2">Mint NFT</Text>
+          <Text className="zd:text-center">
             You are about to mint an NFT from {collectionName}.
           </Text>
         </div>
-        <div className="flex flex-col gap-2">
-          <Text className="text-body1 pt-2 px-2">You&#39;re minting from</Text>
+        <div className="zd:flex zd:flex-col zd:gap-2">
+          <Text className="zd:text-body1 zd:pt-2 zd:px-2">
+            You&#39;re minting from
+          </Text>
           <InfoCard
             title={collectionName}
             imageSource={COLLECTION_IMAGE_SOURCE}

--- a/packages/react-wallet-ui/src/signing/pages/PersonalSign.tsx
+++ b/packages/react-wallet-ui/src/signing/pages/PersonalSign.tsx
@@ -16,15 +16,15 @@ export function PersonalSign({ data, confirm, reject }: PersonalSignProps) {
 
   return (
     <SigningLayout onConfirm={confirm} onReject={reject}>
-      <div className="flex flex-col gap-2 pt-4">
-        <div className="flex flex-col items-center justify-center gap-2 pb-2">
-          <Text className="text-h2">Signature Request</Text>
-          <Text className="text-center">
+      <div className="zd:flex zd:flex-col zd:gap-2 zd:pt-4">
+        <div className="zd:flex zd:flex-col zd:items-center zd:justify-center zd:gap-2 zd:pb-2">
+          <Text className="zd:text-h2">Signature Request</Text>
+          <Text className="zd:text-center">
             Review request details before you confirm.
           </Text>
         </div>
         <Section title="Message Details" iconName="message">
-          <Text className="break-all">{message ?? data}</Text>
+          <Text className="zd:break-all">{message ?? data}</Text>
         </Section>
       </div>
     </SigningLayout>

--- a/packages/react-wallet-ui/src/signing/pages/SignTypedData.tsx
+++ b/packages/react-wallet-ui/src/signing/pages/SignTypedData.tsx
@@ -24,13 +24,13 @@ export function SignTypedData({
   if (!decoded) {
     return (
       <SigningLayout onConfirm={confirm} onReject={reject}>
-        <div className="flex flex-col gap-3">
-          <h3 className="text-lg font-semibold text-gray-900">
+        <div className="zd:flex zd:flex-col zd:gap-3">
+          <h3 className="zd:text-lg zd:font-semibold zd:text-gray-900">
             Sign Typed Data
           </h3>
-          <div className="rounded-lg bg-gray-50 p-4 border border-gray-100">
-            <p className="text-xs text-gray-500 mb-1">Raw data:</p>
-            <pre className="text-sm text-gray-900 whitespace-pre-wrap break-all">
+          <div className="zd:rounded-lg zd:bg-gray-50 zd:p-4 zd:border zd:border-gray-100">
+            <p className="zd:text-xs zd:text-gray-500 zd:mb-1">Raw data:</p>
+            <pre className="zd:text-sm zd:text-gray-900 zd:whitespace-pre-wrap zd:break-all">
               {typedData}
             </pre>
           </div>
@@ -48,10 +48,10 @@ export function SignTypedData({
 
   return (
     <SigningLayout onConfirm={confirm} onReject={reject}>
-      <div className="flex flex-col gap-2 pt-4">
-        <div className="flex flex-col items-center justify-center gap-2 pb-2">
-          <Text className="text-h2">Signature Request</Text>
-          <Text className="text-center">
+      <div className="zd:flex zd:flex-col zd:gap-2 zd:pt-4">
+        <div className="zd:flex zd:flex-col zd:items-center zd:justify-center zd:gap-2 zd:pb-2">
+          <Text className="zd:text-h2">Signature Request</Text>
+          <Text className="zd:text-center">
             Review request details before you confirm.
           </Text>
         </div>

--- a/packages/react-wallet-ui/src/styles.css
+++ b/packages/react-wallet-ui/src/styles.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import "tailwindcss" prefix(zd);
 /* Tokens are single-sourced in @zerodev/react-ui — no token definitions here. */
 @config "../../react-ui/tailwind.config.ts";
 /* Scan both packages' sources so the built CSS serves apps with one stylesheet. */


### PR DESCRIPTION
## Summary
Prefixes all Tailwind utility classes in `react-ui` and `react-wallet-ui` with `zd:` so the packages' prebuilt CSS is namespace-isolated — it can't collide with, or be overridden by, a consumer app's own Tailwind classes (or global CSS). Enables shipping compiled CSS that works for any consumer, Tailwind or not.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
