### PR TITLE
fix(demo): responsive Screen layout — fixed on mobile, relative on desktop

### DIFF
--- a/apps/zerodev-signer-demo/src/app/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/page.tsx
@@ -138,7 +138,7 @@ function EmailMethodSettings() {
   if (step === null || step === 'authenticated') return null
 
   return (
-    <div className="flex justify-end pb-2">
+    <div className="absolute top-[22px] left-[22px] z-60 sm:static sm:z-auto flex justify-start sm:justify-end pb-2">
       <button
         type="button"
         onClick={handleOpen}

--- a/packages/react-wallet-ui/src/shared/components/Screen/Screen.test.tsx
+++ b/packages/react-wallet-ui/src/shared/components/Screen/Screen.test.tsx
@@ -39,10 +39,17 @@ describe('Screen', () => {
         </Screen>,
       )
       const wrapper = container.firstChild as HTMLElement
-      // w-100 = 400px width; height is 800px clamped to the viewport on short
-      // screens (self-contained, no dependency on a definite-height ancestor)
-      expect(wrapper.className).toContain('w-100')
-      expect(wrapper.className).toContain('h-[min(810px,100dvh)]')
+      // Mobile: pinned full-screen (fixed inset-0, h-[100dvh]) so the wallet
+      // fills the viewport from top-0 regardless of sibling chrome. sm+: normal
+      // in-flow 810px block (w-100 = 400px) capped at the viewport height.
+      // Self-contained — no dependency on a definite-height ancestor.
+      expect(wrapper.className).toContain('zd:fixed')
+      expect(wrapper.className).toContain('zd:inset-0')
+      expect(wrapper.className).toContain('zd:h-[100dvh]')
+      expect(wrapper.className).toContain('zd:sm:relative')
+      expect(wrapper.className).toContain('zd:sm:w-100')
+      expect(wrapper.className).toContain('zd:sm:h-[810px]')
+      expect(wrapper.className).toContain('zd:sm:max-h-[100dvh]')
     })
 
     it('renders MultiRadialBackground', () => {

--- a/packages/react-wallet-ui/src/shared/components/Screen/index.tsx
+++ b/packages/react-wallet-ui/src/shared/components/Screen/index.tsx
@@ -25,7 +25,9 @@ export function Screen({
   return (
     <div
       className={cn(
-        'zd:flex zd:flex-col zd:relative zd:overflow-hidden zd:w-100 zd:max-w-full zd:h-[min(810px,100dvh)] zd:rounded-[36px] zd:text-left',
+        'zd:flex zd:flex-col zd:overflow-hidden zd:text-left',
+        'zd:fixed zd:inset-0 zd:z-50 zd:w-screen zd:h-[100dvh] zd:rounded-[36px]',
+        'zd:sm:relative zd:sm:z-auto zd:sm:w-100 zd:sm:max-w-full zd:sm:h-[810px] zd:sm:max-h-[100dvh]',
         className,
       )}
       style={style}


### PR DESCRIPTION
## Summary
Makes the auth `Screen` fill the entire viewport on mobile (fixed, from top-0) while keeping a normal in-flow centered card on desktop — and repositions the demo's settings cogwheel so it stays reachable under the full-screen mobile card.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
