### PR TITLE
refactor(react)!: replace aaUrl with aaHost (multichain-safe)

### DIFF
--- a/packages/react/src/constants.ts
+++ b/packages/react/src/constants.ts
@@ -1,2 +1,8 @@
-export const ZERODEV_AA_URL =
-  'https://staging-meta-aa-provider.onrender.com/api/v3/'
+// Origin of the ZeroDev AA bundler + paymaster. Staging for now; the prod
+// release flips this to `https://rpc.zerodev.app`. Consumers override the host
+// (not the version/path) via the connector's `aaHost` option.
+export const ZERODEV_AA_HOST = 'https://staging-meta-aa-provider.onrender.com'
+
+// ZeroDev AA API version the SDK targets. Owned by the SDK (bumped alongside a
+// release that supports a new version) — never set by consumers.
+export const ZERODEV_AA_VERSION = 'v3'

--- a/packages/react/src/core/connector.ts
+++ b/packages/react/src/core/connector.ts
@@ -38,7 +38,7 @@ export type ConnectorCoreParams = {
   projectId: string
   organizationId?: string
   proxyBaseUrl?: string
-  aaUrl?: string // Bundler/paymaster URL
+  aaHost?: string // Bundler/paymaster host origin (default: ZERODEV_AA_HOST)
   chains: readonly Chain[]
   rpId?: string
   sessionStorage?: StorageAdapter
@@ -161,7 +161,7 @@ export function zeroDevWalletCore(
       const kernelClient = createKernelAccountClient({
         account: kernelAccount,
         bundlerTransport: http(
-          getAAUrl(params.projectId, chainId, params.aaUrl),
+          getAAUrl(params.projectId, chainId, params.aaHost),
           httpOpts,
         ),
         chain,
@@ -169,7 +169,7 @@ export function zeroDevWalletCore(
         paymaster: createZeroDevPaymasterClient({
           chain,
           transport: http(
-            getAAUrl(params.projectId, chainId, params.aaUrl),
+            getAAUrl(params.projectId, chainId, params.aaHost),
             httpOpts,
           ),
         }),

--- a/packages/react/src/utils/aaUtils.test.ts
+++ b/packages/react/src/utils/aaUtils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { ZERODEV_AA_HOST, ZERODEV_AA_VERSION } from '../constants.js'
+import { getAAUrl } from './aaUtils.js'
+
+describe('getAAUrl', () => {
+  it('builds the default per-chain URL (SDK-owned host + version)', () => {
+    expect(getAAUrl('proj', 421614)).toBe(
+      `${ZERODEV_AA_HOST}/api/${ZERODEV_AA_VERSION}/proj/chain/421614`,
+    )
+  })
+
+  it('appends the chainId per chain (multichain-safe)', () => {
+    expect(getAAUrl('proj', 11155111)).toContain('/chain/11155111')
+    expect(getAAUrl('proj', 8453)).toContain('/chain/8453')
+  })
+
+  it('overrides only the host via aaHost; version + path stay SDK-owned', () => {
+    expect(getAAUrl('proj', 1, 'https://rpc.zerodev.app')).toBe(
+      `https://rpc.zerodev.app/api/${ZERODEV_AA_VERSION}/proj/chain/1`,
+    )
+  })
+
+  it('trims a trailing slash on aaHost', () => {
+    expect(getAAUrl('proj', 1, 'https://rpc.zerodev.app/')).toBe(
+      `https://rpc.zerodev.app/api/${ZERODEV_AA_VERSION}/proj/chain/1`,
+    )
+  })
+})

--- a/packages/react/src/utils/aaUtils.ts
+++ b/packages/react/src/utils/aaUtils.ts
@@ -1,5 +1,13 @@
-import { ZERODEV_AA_URL } from '../constants.js'
+import { ZERODEV_AA_HOST, ZERODEV_AA_VERSION } from '../constants.js'
 
-export function getAAUrl(projectId: string, chainId: number, aaUrl?: string) {
-  return aaUrl || `${ZERODEV_AA_URL}${projectId}/chain/${chainId}`
+/**
+ * Builds the ZeroDev AA bundler/paymaster URL for a project + chain.
+ *
+ * The chainId is always appended, so this is multichain-safe. Consumers may
+ * override only the host (`aaHost`, e.g. a staging/self-hosted origin); the
+ * API version and path shape are owned by the SDK.
+ */
+export function getAAUrl(projectId: string, chainId: number, aaHost?: string) {
+  const host = (aaHost ?? ZERODEV_AA_HOST).replace(/\/+$/, '')
+  return `${host}/api/${ZERODEV_AA_VERSION}/${projectId}/chain/${chainId}`
 }


### PR DESCRIPTION
Replaces the `aaUrl` connector option with `aaHost`.

## Why
`aaUrl` was passed **verbatim** to both the bundler and paymaster transports for every chain (the `chainId` was only substituted in the default path). So a single override like `.../chain/421614` pinned *all* chains to that one chain's endpoint — broken the moment you go multichain. It also forced consumers to hardcode the API version (`/api/v3/`).

## What
- **`aaHost`** (origin only) replaces `aaUrl`. `getAAUrl` always builds `${host}/api/${VERSION}/${projectId}/chain/${chainId}` → **per-chain by construction** (multichain-safe), and the **API version is SDK-owned** (`ZERODEV_AA_VERSION`), never in consumer config.
- `ZERODEV_AA_URL` → split into `ZERODEV_AA_HOST` + `ZERODEV_AA_VERSION`.
- Trailing-slash trim on `aaHost`; unit tests for `getAAUrl` (default, per-chain, host override, slash trim).

## Consumer guidance
- **Prod multichain:** set nothing — once `ZERODEV_AA_HOST` flips to prod at release, per-chain URLs are derived automatically.
- **Staging / self-hosted:** set only `aaHost` (e.g. `https://staging-meta-aa-provider.onrender.com`).

## Notes
- **Default host stays staging** here — the prod release flips `ZERODEV_AA_HOST` to `https://rpc.zerodev.app` (one-liner), keeping this PR independent of that toggle.
- **BREAKING:** the `aaUrl` option is removed. No published consumer uses it; add to the changeset.
- Verified: `getAAUrl` + connector tests pass, react typechecks.
