### PR TITLE
chore(sdk): set prod defaults (kms.zerodev.app, rpc.zerodev.app, prod parent org)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,9 @@ jobs:
         env:
           NEXT_PUBLIC_ZERODEV_PROJECT_ID: ${{ secrets.ZD_PROJECT_ID }}
           NEXT_PUBLIC_KMS_PROXY_BASE_URL: https://kms.staging.zerodev.app/api/v1
+          # Pin the bundler/paymaster to staging so the AA stack matches the
+          # staging KMS above (the SDK default host is prod).
+          NEXT_PUBLIC_ZERODEV_AA_HOST: https://staging-meta-aa-provider.onrender.com
 
       - name: Wait for demo app
         run: |

--- a/apps/zerodev-signer-demo/src/app/wagmi-config.tsx
+++ b/apps/zerodev-signer-demo/src/app/wagmi-config.tsx
@@ -33,6 +33,11 @@ export const config = createConfig({
       projectId: process.env.NEXT_PUBLIC_ZERODEV_PROJECT_ID!,
       proxyBaseUrl: process.env.NEXT_PUBLIC_KMS_PROXY_BASE_URL!,
       chains: [arbitrumSepolia, sepolia],
+      // Bundler/paymaster host override (defaults to the SDK's prod host).
+      // CI/e2e sets this to staging to match NEXT_PUBLIC_KMS_PROXY_BASE_URL.
+      ...(process.env.NEXT_PUBLIC_ZERODEV_AA_HOST && {
+        aaHost: process.env.NEXT_PUBLIC_ZERODEV_AA_HOST,
+      }),
       // Local testing override: our docker backend's Turnkey base org differs
       // from the SDK's hardcoded prod default, so point the connector at it.
       ...(process.env.NEXT_PUBLIC_ORG_ID && {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,8 +1,10 @@
 export const DEFAULT_SESSION_EXPIRATION_IN_SECONDS = '900' // default to 15 minutes
 export const DEFAULT_IFRAME_CONTAINER_ID = 'turnkey-auth-iframe-container-id'
 export const DEFAULT_IFRAME_ELEMENT_ID = 'turnkey-default-iframe-element-id'
-export const DEFAULT_ORGANIZATION_ID = '0d98e826-dd8f-44ca-a585-3afcd27d4002'
-export const KMS_SERVER_URL = 'https://kms.staging.zerodev.app'
+// Prod parent organization id. Only a fallback — the SDK resolves the parent
+// org at runtime from the KMS `server-info/parent-org-id` endpoint.
+export const DEFAULT_ORGANIZATION_ID = '65028f18-01c6-4ed4-beff-2ed1be5d6bad'
+export const KMS_SERVER_URL = 'https://kms.zerodev.app'
 
 // Pinned ECDSA P-256 public key (uncompressed, 65 bytes hex) of Turnkey's
 // TLS Fetcher Sign enclave. Used to verify the signature on the OTP encryption

--- a/packages/react/src/constants.ts
+++ b/packages/react/src/constants.ts
@@ -1,7 +1,6 @@
-// Origin of the ZeroDev AA bundler + paymaster. Staging for now; the prod
-// release flips this to `https://rpc.zerodev.app`. Consumers override the host
-// (not the version/path) via the connector's `aaHost` option.
-export const ZERODEV_AA_HOST = 'https://staging-meta-aa-provider.onrender.com'
+// Origin of the ZeroDev AA bundler + paymaster (prod). Consumers override the
+// host (not the version/path) via the connector's `aaHost` option.
+export const ZERODEV_AA_HOST = 'https://rpc.zerodev.app'
 
 // ZeroDev AA API version the SDK targets. Owned by the SDK (bumped alongside a
 // release that supports a new version) — never set by consumers.


### PR DESCRIPTION
Flips the SDK's built-in defaults from staging to production.

## Changes
- `KMS_SERVER_URL` → `https://kms.zerodev.app`
- `ZERODEV_AA_HOST` → `https://rpc.zerodev.app`
- `DEFAULT_ORGANIZATION_ID` → `65028f18-01c6-4ed4-beff-2ed1be5d6bad` (prod parent org)

## Notes
- The org id is only a **fallback** — the SDK resolves the parent org at runtime from the KMS `server-info/parent-org-id` endpoint, so against prod KMS it fetches this value anyway. Confirmed it straight from prod (`GET https://kms.zerodev.app/api/v1/server-info/parent-org-id`).
- Consumers can still point at staging/self-hosted via the connector's `aaHost` / `proxyBaseUrl` / `organizationId` options.
- No other env-specific hardcodes remain in code (UI packages inherit from core). `TURNKEY_TLS_FETCHER_SIGN_PUBLIC_KEY` is unchanged (Turnkey enclave key, not env-specific).
- Verified: `core` + `react` typecheck and build clean; prod values present in `dist`.

Needs a changeset (behavior-affecting default change) — will add via `pnpm changeset`.
