### PR TITLE
feat(react-ui): add size variants (sm/md/lg) via a density-scaled spacing system

### DIFF
--- a/apps/zerodev-signer-demo/next.config.ts
+++ b/apps/zerodev-signer-demo/next.config.ts
@@ -3,7 +3,11 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
-  transpilePackages: ['@zerodev/wallet-react', '@zerodev/wallet-core'],
+  transpilePackages: [
+    '@zerodev/wallet-react',
+    '@zerodev/wallet-react-ui',
+    '@zerodev/wallet-core',
+  ],
   // Force a single wagmi / @wagmi/core instance in the bundle. wagmi exposes
   // its config through React Context; if two physical copies end up loaded,
   // `WagmiProvider` and `useConfig` reference different Contexts and hooks

--- a/apps/zerodev-signer-demo/src/app/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/page.tsx
@@ -84,7 +84,7 @@ function LandingPageInner() {
     <div className="min-h-screen">
       <AppHeader/>
       <main
-        className="mx-auto grid min-h-[calc(100vh-88px)] w-full max-w-[1040px] items-center gap-x-10 gap-y-4 px-4 py-8 sm:px-6 lg:grid-cols-[1fr_360px] lg:px-0 lg:py-12">
+        className="mx-auto grid min-h-[calc(100vh-88px)] w-full max-w-[1080px] items-center gap-x-10 gap-y-4 px-4 py-8 sm:px-6 lg:grid-cols-[1fr_400px] lg:px-0 lg:py-12">
         <section className="mx-auto max-w-xl text-center lg:mx-0 lg:text-left">
           <h1 className="font-[var(--font-dm-sans)] text-4xl font-bold leading-[1.06] text-[var(--ink)] sm:text-5xl">
             Embedded Smart Wallets
@@ -112,7 +112,7 @@ function LandingPageInner() {
           </div>
         </section>
 
-        <div className="mx-auto flex w-full max-w-[360px] flex-col items-center lg:mx-0">
+        <div className="mx-auto flex w-full flex-col items-center lg:mx-0">
           {showReconnect ? (
             <div className="flex h-[729px] w-[360px] items-center justify-center">
               <button
@@ -124,13 +124,9 @@ function LandingPageInner() {
               </button>
             </div>
           ) : (
-            <div className="h-[729px] w-[360px] overflow-hidden">
-              <div className="origin-top-left scale-[0.9]">
-                <div className="w-[400px]">
-                  <AuthFlow/>
-                </div>
-              </div>
-            </div>
+
+              <AuthFlow size="md" />
+
           )}
 
           <p className="mt-3 max-w-[360px] text-center text-xs leading-5 text-[var(--muted)]">

--- a/apps/zerodev-signer-demo/src/app/verify/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/verify/page.tsx
@@ -28,7 +28,7 @@ function VerifyPageInner() {
   return (
     <div className="mx-auto w-full max-w-[500px] min-h-screen flex flex-col sm:max-w-none sm:h-screen sm:min-h-0 sm:flex-row sm:items-center sm:justify-center">
       <div className="flex-1 w-full flex flex-col sm:flex-none sm:w-[500px] sm:h-[800px]">
-        <AuthFlow />
+        <AuthFlow size="md" />
       </div>
     </div>
   )

--- a/packages/react-ui/src/components/Input/Input.test.tsx
+++ b/packages/react-ui/src/components/Input/Input.test.tsx
@@ -75,11 +75,9 @@ describe('Input', () => {
       expect(screen.getByTestId('input-wrapper').className).toContain('h-32')
     })
 
-    it('applies h-[68px] for listItemStyle', () => {
+    it('applies h-17 for listItemStyle', () => {
       render(<Input variant="listItemStyle" placeholder="List" />)
-      expect(screen.getByTestId('input-wrapper').className).toContain(
-        'h-[68px]',
-      )
+      expect(screen.getByTestId('input-wrapper').className).toContain('h-17')
     })
   })
 

--- a/packages/react-ui/src/components/Input/index.tsx
+++ b/packages/react-ui/src/components/Input/index.tsx
@@ -21,7 +21,7 @@ export interface InputProps
 
 function getHeightClass(multiline: boolean | undefined, variant: Variant) {
   if (multiline) return 'zd:h-32 zd:py-3'
-  if (variant === 'listItemStyle') return 'zd:h-[68px]'
+  if (variant === 'listItemStyle') return 'zd:h-17'
   return 'zd:h-11'
 }
 
@@ -51,7 +51,7 @@ function InputIcon({
 // width on mobile browsers (Chrome on Android most visibly), which would
 // squash the leading icon and the trailing chevron-button child.
 const baseInputClass =
-  'zd:flex-1 zd:min-w-0 zd:px-0 zd:text-gray-900 zd:font-medium zd:outline-none zd:bg-transparent zd:min-h-11 zd:placeholder:text-gray-900/50 zd:caret-gray-900'
+  'zd:flex-1 zd:min-w-0 zd:px-0 zd:text-body1 zd:text-gray-900 zd:font-medium zd:outline-none zd:bg-transparent zd:min-h-11 zd:placeholder:text-gray-900/50 zd:caret-gray-900'
 
 export function Input({
   variant = 'default',

--- a/packages/react-ui/src/components/ListItem/index.tsx
+++ b/packages/react-ui/src/components/ListItem/index.tsx
@@ -14,13 +14,13 @@ export function ListItemSkeleton({ className }: ListItemSkeletonProps) {
   return (
     <div
       className={cn(
-        'zd:w-full zd:h-[68px] zd:rounded-2xl zd:border-offWhite zd:border-[0.3px]',
+        'zd:w-full zd:h-17 zd:rounded-2xl zd:border-offWhite zd:border-[0.3px]',
         className,
       )}
     >
       <div className="zd:flex zd:flex-row zd:justify-between zd:items-center zd:p-2">
         <div className="zd:flex zd:flex-row zd:items-center zd:gap-3">
-          <div className="zd:w-[52px] zd:h-[52px] zd:rounded-2xl zd:bg-offWhite/50 zd:animate-pulse" />
+          <div className="zd:w-13 zd:h-13 zd:rounded-2xl zd:bg-offWhite/50 zd:animate-pulse" />
           <div className="zd:gap-2">
             <div className="zd:w-14 zd:h-3 zd:rounded-lg zd:bg-offWhite/50 zd:animate-pulse zd:mb-2" />
             <div className="zd:w-14 zd:h-3 zd:rounded-lg zd:bg-offWhite/50 zd:animate-pulse" />
@@ -61,7 +61,7 @@ export function ListItem({
   return (
     <Wrapper
       className={cn(
-        'zd:w-full zd:h-[68px] zd:rounded-2xl',
+        'zd:w-full zd:h-17 zd:rounded-2xl',
         alert && 'zd:border-0',
         className,
       )}
@@ -80,7 +80,7 @@ export function ListItem({
         <div className="zd:flex zd:flex-row zd:items-center zd:gap-3">
           <div
             className={cn(
-              'zd:w-[52px] zd:h-[52px] zd:rounded-2xl zd:flex zd:items-center zd:justify-center zd:shrink-0',
+              'zd:w-13 zd:h-13 zd:rounded-2xl zd:flex zd:items-center zd:justify-center zd:shrink-0',
               alert ? 'zd:bg-offWhite/50' : 'zd:bg-white',
             )}
           >

--- a/packages/react-ui/tailwind.config.ts
+++ b/packages/react-ui/tailwind.config.ts
@@ -4,9 +4,13 @@ const config: Config = {
   content: ['./src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
+      // Custom steps derive from the spacing base (var(--zd-spacing), default
+      // 0.25rem) so density variants rescale them like every other spacing
+      // utility. 13 = 52px, 17 = 68px, 4.5 = 18px at the default base.
       spacing: {
-        13: '52px',
-        4.5: '18px',
+        13: 'calc(var(--zd-spacing) * 13)',
+        17: 'calc(var(--zd-spacing) * 17)',
+        4.5: 'calc(var(--zd-spacing) * 4.5)',
       },
       colors: {
         // Design color palette START
@@ -23,24 +27,27 @@ const config: Config = {
         negative: '#FF4221',
       },
       fontSize: {
-        xs: '10px',
-        sm: '12px',
-        base: '14px',
-        lg: '16px',
-        xl: '18px',
-        '2xl': '20px',
-        '3xl': '24px',
-        '4xl': '30px',
-        '5xl': '36px',
-        '6xl': '48px',
+        // Font sizes multiply by --zd-density (default 1) so text scales with
+        // the density variants like spacing does. Line-heights are percentages,
+        // which already track the scaled font-size.
+        xs: 'calc(10px * var(--zd-density))',
+        sm: 'calc(12px * var(--zd-density))',
+        base: 'calc(14px * var(--zd-density))',
+        lg: 'calc(16px * var(--zd-density))',
+        xl: 'calc(18px * var(--zd-density))',
+        '2xl': 'calc(20px * var(--zd-density))',
+        '3xl': 'calc(24px * var(--zd-density))',
+        '4xl': 'calc(30px * var(--zd-density))',
+        '5xl': 'calc(36px * var(--zd-density))',
+        '6xl': 'calc(48px * var(--zd-density))',
         // Design typography START
-        h1: ['42px', '110%'],
-        h2: ['28px', '110%'],
-        h3: ['18px', '130%'],
-        body1: ['16px', '130%'],
-        body2: ['14px', '130%'],
-        body3: ['12px', '130%'],
-        body4: ['10px', '130%'],
+        h1: ['calc(42px * var(--zd-density))', '110%'],
+        h2: ['calc(28px * var(--zd-density))', '110%'],
+        h3: ['calc(18px * var(--zd-density))', '130%'],
+        body1: ['calc(16px * var(--zd-density))', '130%'],
+        body2: ['calc(14px * var(--zd-density))', '130%'],
+        body3: ['calc(12px * var(--zd-density))', '130%'],
+        body4: ['calc(10px * var(--zd-density))', '130%'],
         // Design typography END
       },
       fontFamily: {

--- a/packages/wallet-react-ui/src/auth/index.tsx
+++ b/packages/wallet-react-ui/src/auth/index.tsx
@@ -63,8 +63,10 @@ function renderStep(step: AuthStep | null): ReactNode {
 
 export function AuthFlow({
   onClose: userOnClose,
+  size,
 }: {
   onClose?: (() => void) | undefined
+  size?: 'sm' | 'md' | 'lg' | undefined
 } = {}) {
   const { step, goToStep, goBack, reset } = useAuth()
   const logo = useStore(useKitStore(), (s) => s.logo)
@@ -87,6 +89,7 @@ export function AuthFlow({
 
   return (
     <Screen
+      {...(size && { size })}
       // Some elements in SignUp need to go from edge to edge.
       // No vertical padding; we set px-0 so we can fully control this padding.
       contentClassName={step === 'sign-up' ? 'zd:px-0' : undefined}

--- a/packages/wallet-react-ui/src/shared/components/PoweredBy/PoweredBy.test.tsx
+++ b/packages/wallet-react-ui/src/shared/components/PoweredBy/PoweredBy.test.tsx
@@ -37,7 +37,7 @@ describe('PoweredBy', () => {
     it('renders with default dimensions', () => {
       render(<PoweredBy />)
       const icon = screen.getByTestId('icon-zerodevLogo')
-      expect(icon.className).toContain('h-[18px]')
+      expect(icon.className).toContain('h-4.5')
       expect(icon.className).toContain('w-auto')
     })
   })

--- a/packages/wallet-react-ui/src/shared/components/PoweredBy/index.tsx
+++ b/packages/wallet-react-ui/src/shared/components/PoweredBy/index.tsx
@@ -16,11 +16,7 @@ export function PoweredBy({
       )}
     >
       <Text>Powered by</Text>
-      <Icon
-        name="zerodevLogo"
-        className="zd:h-[18px] zd:w-auto"
-        style={style}
-      />
+      <Icon name="zerodevLogo" className="zd:h-4.5 zd:w-auto" style={style} />
     </div>
   )
 }

--- a/packages/wallet-react-ui/src/shared/components/Screen/Screen.test.tsx
+++ b/packages/wallet-react-ui/src/shared/components/Screen/Screen.test.tsx
@@ -39,17 +39,30 @@ describe('Screen', () => {
         </Screen>,
       )
       const wrapper = container.firstChild as HTMLElement
-      // Mobile: pinned full-screen (fixed inset-0, h-[100dvh]) so the wallet
-      // fills the viewport from top-0 regardless of sibling chrome. sm+: normal
-      // in-flow 810px block (w-100 = 400px) capped at the viewport height.
-      // Self-contained — no dependency on a definite-height ancestor.
-      expect(wrapper.className).toContain('zd:fixed')
-      expect(wrapper.className).toContain('zd:inset-0')
-      expect(wrapper.className).toContain('zd:h-[100dvh]')
-      expect(wrapper.className).toContain('zd:sm:relative')
-      expect(wrapper.className).toContain('zd:sm:w-100')
-      expect(wrapper.className).toContain('zd:sm:h-[810px]')
-      expect(wrapper.className).toContain('zd:sm:max-h-[100dvh]')
+      // One parent-relative box at every breakpoint: 400×810 at density 1
+      // (w-100 / h-202.5), capped to the parent (max-w/h-full), never viewport-
+      // pinned — a consumer wrapper controls the final size.
+      expect(wrapper.className).toContain('zd:w-100')
+      expect(wrapper.className).toContain('zd:h-202.5')
+      expect(wrapper.className).toContain('zd:max-w-full')
+      expect(wrapper.className).toContain('zd:max-h-full')
+    })
+
+    it('defaults to the lg size, and honors the size prop', () => {
+      const { container, rerender } = render(
+        <Screen>
+          <div>Content</div>
+        </Screen>,
+      )
+      // size drives the density scale via the data attribute (see styles.css).
+      expect((container.firstChild as HTMLElement).dataset.zdSize).toBe('lg')
+
+      rerender(
+        <Screen size="sm">
+          <div>Content</div>
+        </Screen>,
+      )
+      expect((container.firstChild as HTMLElement).dataset.zdSize).toBe('sm')
     })
 
     it('renders MultiRadialBackground', () => {

--- a/packages/wallet-react-ui/src/shared/components/Screen/index.tsx
+++ b/packages/wallet-react-ui/src/shared/components/Screen/index.tsx
@@ -13,21 +13,32 @@ export function Screen({
   children,
   className,
   contentClassName,
+  size = 'lg',
   style,
   topNav,
 }: {
   children: ReactNode
   className?: string | undefined
   contentClassName?: string | undefined
+  size?: 'sm' | 'md' | 'lg' | undefined
   style?: CSSProperties | undefined
   topNav?: ReactNode
 }) {
   return (
     <div
+      data-zd-size={size}
       className={cn(
-        'zd:flex zd:flex-col zd:overflow-hidden zd:text-left',
-        'zd:fixed zd:inset-0 zd:z-50 zd:w-screen zd:h-[100dvh] zd:rounded-[36px]',
-        'zd:sm:relative zd:sm:z-auto zd:sm:w-100 zd:sm:max-w-full zd:sm:h-[810px] zd:sm:max-h-[100dvh]',
+        // 400×810 by default, but never taller/wider than the parent — a
+        // consumer wrapper with its own size caps the Screen (max-w/h-full =
+        // 100% of the parent). overflow-hidden clips the frame to its rounded
+        // border ring; content scrolls in the inner div below.
+        'zd:relative zd:flex zd:flex-col zd:text-left',
+        // w-100 = 400px, h-202.5 = 810px at density 1; both compile to
+        // calc(var(--zd-spacing) * N), so they scale with the size variants.
+        // rounded-[38px] = inner card radius (32px) + the 6px border-ring gap,
+        // so the ring has a uniform width — equal inner/outer radii would make
+        // the corners read thicker than the sides.
+        'zd:w-100 zd:h-202.5 zd:max-w-full zd:max-h-full zd:overflow-hidden zd:rounded-[38px]',
         className,
       )}
       style={style}
@@ -40,6 +51,9 @@ export function Screen({
           vivid and distinct from the border. */}
       <div
         className={cn(
+          // m-1.5 = calc(var(--zd-spacing) * 1.5) = 6px at density 1, so the
+          // gradient border ring thins with the size variants — matching the
+          // now-scaling corner radius, keeping the whole frame proportional.
           'zd:flex zd:flex-1 zd:flex-col zd:m-1.5 zd:px-4 zd:overflow-hidden zd:rounded-4xl zd:relative',
           contentClassName,
         )}
@@ -54,7 +68,12 @@ export function Screen({
           {topNav}
           <div
             className="zd:flex zd:flex-1 zd:flex-col zd:min-h-0 zd:overflow-y-auto zd:overflow-x-hidden"
-            style={{ paddingTop: `${CONTENT_PADDING_TOP}px` }}
+            // Scale via --zd-spacing (matches TopNav's scaled height) so the
+            // top padding shrinks with the frame — otherwise the fixed 68px
+            // eats a disproportionate share at smaller sizes and overflows.
+            style={{
+              paddingTop: `calc(${CONTENT_PADDING_TOP / 4} * var(--zd-spacing))`,
+            }}
           >
             {children}
           </div>

--- a/packages/wallet-react-ui/src/shared/components/TopNav/index.tsx
+++ b/packages/wallet-react-ui/src/shared/components/TopNav/index.tsx
@@ -22,7 +22,10 @@ export function TopNav({
         'zd:absolute zd:top-4 zd:left-0 zd:right-0 zd:flex zd:flex-row zd:items-center zd:justify-between',
         className,
       )}
-      style={{ height: TOP_NAV_HEIGHT }}
+      // Scale via --zd-spacing (the 4px base) like every spacing utility, so
+      // the nav height tracks the density variants and doesn't eat a
+      // disproportionate share of the shrunken frame at smaller sizes.
+      style={{ height: `calc(${TOP_NAV_HEIGHT / 4} * var(--zd-spacing))` }}
     >
       {onBack ? (
         <IconButton iconName="chevronLeft" onClick={onBack} />

--- a/packages/wallet-react-ui/src/styles.css
+++ b/packages/wallet-react-ui/src/styles.css
@@ -4,3 +4,41 @@
 /* Scan both packages' sources so the built CSS serves apps with one stylesheet. */
 @source "./";
 @source "../../react-ui/src";
+
+/* ---------------------------------------------------------------------------
+   Density system
+   ---------------------------------------------------------------------------
+   `--zd-density` is the public knob: a unitless multiplier (1 = default). The
+   spacing base derives from it, and every spacing/size utility in the SDK
+   compiles to calc(var(--zd-spacing) * N) — including the custom 13/17/4.5
+   steps (see react-ui/tailwind.config.ts) — so one variable rescales spacing,
+   padding, gaps, control heights, and the frame width together. Font sizes also
+   multiply by --zd-density (see the fontSize tokens), so type scales too — a
+   true proportional zoom. Corner radii, borders, and icon sizes stay fixed.
+
+   Consumers set the density via the Screen/AuthFlow `size` prop, which writes
+   `data-zd-size` on the Screen root; the scale below maps size → density.
+
+   Other libraries scale a whole UI from one variable the same way:
+   - Tailwind v4 --spacing (the mechanism this builds on):
+     https://tailwindcss.com/docs/margin
+   - Radix Themes `scaling` prop (90%–110%) via a --scaling var:
+     https://www.radix-ui.com/themes/docs/theme/spacing
+   - shadcn/ui --radius (calc(var(--radius) * N)):
+     https://ui.shadcn.com/docs/theming
+   - Material UI theme.spacing factor (build-time variant):
+     https://mui.com/material-ui/customization/spacing/ */
+:root { --zd-density: 1; }
+
+/* --zd-spacing must be (re)declared on the SAME selector that sets the density,
+   not on :root. A custom property resolves where it's declared: on :root it
+   would compute once against the root density and every descendant would
+   inherit that fixed value, so setting --zd-density deeper would do nothing.
+   Declaring it on [data-zd-size] recomputes it there against the local density,
+   and the result inherits into the subtree. */
+[data-zd-size] {
+  --zd-spacing: calc(0.25rem * var(--zd-density));
+}
+[data-zd-size="sm"] { --zd-density: 0.8; }  /* compact */
+[data-zd-size="md"] { --zd-density: 0.9; }  /* in between */
+[data-zd-size="lg"] { --zd-density: 1; }    /* default / comfortable */


### PR DESCRIPTION
## Summary

Adds `sm`/`md`/`lg` size variants to the wallet UI. A single `--zd-density` variable proportionally scales the whole `AuthFlow`/`Screen` card — spacing, control heights, frame dimensions, and type — exposed via a `size` prop.

## Examples from other libraries

Other libraries scale a whole UI from one variable the same way:
   - Tailwind v4 --spacing (the mechanism this builds on):
     https://tailwindcss.com/docs/margin
   - Radix Themes `scaling` prop (90%–110%) via a --scaling var:
     https://www.radix-ui.com/themes/docs/theme/spacing
   - shadcn/ui --radius (calc(var(--radius) * N)):
     https://ui.shadcn.com/docs/theming
   - Material UI theme.spacing factor (build-time variant):
     https://mui.com/material-ui/customization/spacing/

## Changes

**Density system** (`packages/wallet-react-ui/src/styles.css`)
- `--zd-density` (unitless, default 1) drives `--zd-spacing`; scoped per `[data-zd-size]` so each Screen instance recomputes locally and cascades to its subtree. Maps `sm`→0.8, `md`→0.9, `lg`→1.
- Reference links to equivalent single-variable scaling in Tailwind v4, Radix, shadcn, MUI.

**Token wiring** (`packages/react-ui/tailwind.config.ts`)
- Custom spacing steps (`13`/`4.5`, new `17`) now derive from `--zd-spacing` instead of literal px, so `h-13`/`h-17`/etc. scale.
- Font-size tokens multiply by `--zd-density`, so text scales with the variants.

**`size` prop** (`Screen`, `auth/AuthFlow`)
- New `size?: 'sm' | 'md' | 'lg'` (default `lg`), written as `data-zd-size` on the Screen root.
- Screen frame: `w-100`/`h-202.5` (400×810 at density 1) now density-scaled; `rounded-[38px]` outer radius = inner 32px + 6px ring so the gradient border has uniform width.
- `TopNav` height and content top-padding switched from fixed px to `--zd-spacing` multiples so they scale with the frame (fixed px would overflow at smaller sizes).

**Component sizing** (`react-ui`)
- `Input`/`ListItem` row + icon boxes moved from arbitrary px (`h-[68px]`, `w-[52px]`) to spacing steps (`h-17`, `h-13`/`w-13`).
- Input text bumped to `text-body1` (was unset → native fallback); `PoweredBy` logo `h-[18px]`→`h-4.5`.

**Demo** (`apps/zerodev-signer-demo`)
- Landing renders `<AuthFlow size="md" />` directly; drops the manual scale/fixed-width wrapper and widens the grid column 360→400px.
- `next.config.ts`: add `@zerodev/wallet-react-ui` to `transpilePackages` (single wagmi instance in the bundle).

## Breaking changes

- `Screen` default is `size="lg"`. Bare `<Screen>`/`<AuthFlow>` render at density 1 (unchanged visual), but the pre-existing mobile full-screen behavior (`fixed inset-0 h-[100dvh]`) is removed — Screen is now a parent-relative box at all breakpoints (`max-w/h-full`). Consumers relying on viewport-pinning must wrap it.

## Notes

- Corner radii, hairline borders, and icon sizes are intentionally fixed (don't scale with density).
- Arbitrary-value sizes in signing components (`h-[84px]`, etc.) are outside the auth surface and untouched — they won't scale.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
