### PR TITLE
chore: changeset for wallet-react wagmi v3 support

### DIFF
--- a/.changeset/twenty-pans-stick.md
+++ b/.changeset/twenty-pans-stick.md
@@ -1,0 +1,5 @@
+---
+"@zerodev/wallet-react": patch
+---
+
+feat: support wagmi v3 (@wagmi/core/wagmi peers widened to ^2.22.0 || ^3.0.0) and move ox from a peer to a direct dependency so consumers no longer need to install it.


### PR DESCRIPTION
Adds the missing changeset for #292 (merged without one), so `@zerodev/wallet-react` gets a patch release for wagmi v3 support + `ox` moved to a direct dependency.

This is also the first real end-to-end exercise of the CI release pipeline (#301): on merge, the release workflow should open a "Version Packages" PR; merging that publishes to npm via Trusted Publishing (OIDC).