### PR TITLE
fix: add repository field to wallet-core and wallet-react (npm provenance)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,11 @@
   "name": "@zerodev/wallet-core",
   "version": "0.0.1",
   "description": "ZeroDev Wallet SDK built on Turnkey",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zerodevapp/zerodev-wallet-sdk.git",
+    "directory": "packages/core"
+  },
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,6 +2,11 @@
   "name": "@zerodev/wallet-react",
   "version": "0.0.2",
   "description": "React hooks for ZeroDev Wallet SDK",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zerodevapp/zerodev-wallet-sdk.git",
+    "directory": "packages/react"
+  },
   "sideEffects": false,
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",


### PR DESCRIPTION
## What
Add the `repository` field (with `directory`) to `@zerodev/wallet-core` and `@zerodev/wallet-react` package.json, matching `react-ui` / `wallet-react-ui`.

## Why
The first OIDC publish of `@zerodev/wallet-react@0.0.2` failed:

> `E422 … Error verifying sigstore provenance bundle: package.json: "repository.url" is "", expected to match "https://github.com/zerodevapp/zerodev-wallet-sdk"`

npm provenance requires `repository.url` to match the source repo from the OIDC claim. `core` and `react` were missing it. `wallet-react-ui@0.0.3` published fine (it had the field).

## Effect on release
**No changeset / no version bump.** `wallet-react` stays at 0.0.2 (already bumped on main, but never published). On merge, the release run finds no changesets and runs `changeset publish`, which will publish `@zerodev/wallet-react@0.0.2` now that the field is present. `wallet-react-ui@0.0.3` is already on npm and will be skipped. Also unblocks the next `wallet-core` release.