### PR TITLE
ci: guard publishable packages before release (repository + packaging)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Run Biome CI
         run: pnpm run ci
 
+      # Fail fast if a publishable package lacks a repository field — npm's
+      # provenance check would otherwise reject the publish with E422.
+      - name: Check publishable packages
+        run: node scripts/check-publishable.mjs
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest
@@ -75,6 +80,16 @@ jobs:
 
       - name: Build packages
         run: pnpm build
+
+      # Packaging smoke test: confirm each publishable package can be packed
+      # (catches missing dist / bad `files` / `exports` before release).
+      - name: Verify packaging (npm pack --dry-run)
+        run: |
+          for d in $(node scripts/check-publishable.mjs --list); do
+            echo "::group::npm pack $d"
+            ( cd "$d" && npm pack --dry-run --ignore-scripts )
+            echo "::endgroup::"
+          done
 
   test:
     name: Test

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:integration": "vitest run --config e2e/vitest.integration.config.ts",
     "test:e2e": "playwright test --config e2e/playwright.config.ts",
     "test:e2e:headed": "playwright test --config e2e/playwright.config.ts --headed",
+    "check:publishable": "node scripts/check-publishable.mjs",
     "prepare": "husky",
     "changeset": "changeset",
     "changeset:version": "changeset version && pnpm install --lockfile-only",

--- a/scripts/check-publishable.mjs
+++ b/scripts/check-publishable.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Guards npm Trusted Publishing (OIDC): every publishable package — any
+// packages/* that isn't `"private": true` — must carry a `repository` field
+// whose url matches this repo and whose `directory` matches its folder. npm's
+// provenance check rejects a publish otherwise with E422 (this bit us once:
+// wallet-react@0.0.2 failed to publish while a dependent already had).
+//
+// Runs on every PR (in the Lint job), so the failure is caught before the
+// "Version Packages" PR is ever created — no post-merge rollback.
+//
+//   node scripts/check-publishable.mjs          # validate, exit 1 on problems
+//   node scripts/check-publishable.mjs --list    # print publishable dirs, one per line
+import { readdirSync, readFileSync, existsSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const pkgsDir = join(root, 'packages')
+const EXPECTED_URL = 'git+https://github.com/zerodevapp/zerodev-wallet-sdk.git'
+const listOnly = process.argv.includes('--list')
+
+const publishable = []
+for (const name of readdirSync(pkgsDir).sort()) {
+  const pkgPath = join(pkgsDir, name, 'package.json')
+  if (!existsSync(pkgPath)) continue
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+  if (pkg.private === true) continue // intentionally never published
+  publishable.push({ name, pkg })
+}
+
+if (listOnly) {
+  for (const { name } of publishable) console.log(`packages/${name}`)
+  process.exit(0)
+}
+
+if (!publishable.length) {
+  console.error('check-publishable: no publishable packages found — did the packages/ layout change?')
+  process.exit(1)
+}
+
+const errors = []
+for (const { name, pkg } of publishable) {
+  const dir = `packages/${name}`
+  const repo = pkg.repository
+  if (!repo || typeof repo !== 'object') {
+    errors.push(`${pkg.name}: missing "repository" object`)
+    continue
+  }
+  if (!repo.url || !repo.url.trim()) {
+    errors.push(`${pkg.name}: "repository.url" is empty`)
+  } else if (repo.url !== EXPECTED_URL) {
+    errors.push(`${pkg.name}: "repository.url" is "${repo.url}", expected "${EXPECTED_URL}"`)
+  }
+  if (repo.directory !== dir) {
+    errors.push(`${pkg.name}: "repository.directory" is "${repo.directory ?? '(unset)'}", expected "${dir}"`)
+  }
+}
+
+if (errors.length) {
+  console.error('Publishable package checks failed:\n')
+  for (const e of errors) console.error(`  ✗ ${e}`)
+  console.error('\nnpm Trusted Publishing rejects a publish whose package.json "repository"')
+  console.error('does not match the source repo (E422). Fix these before merging.')
+  process.exit(1)
+}
+
+console.log(`check-publishable: OK — ${publishable.length} publishable packages have a valid repository field`)
+for (const { pkg } of publishable) console.log(`  ✓ ${pkg.name}`)


### PR DESCRIPTION
Adds two pre-release safety checks so we catch publish-blocking problems on the PR, not after the "Version Packages" PR is merged (the ask from #release-thread).

## What
- **`scripts/check-publishable.mjs`** — every non-private `packages/*` must have a `repository` field whose `url` matches this repo and whose `directory` matches its folder. Auto-discovers packages (new ones are covered automatically). Runs in the **Lint** job (`node scripts/check-publishable.mjs`), so it rides the existing required check — no branch-protection changes needed.
- **`npm pack --dry-run`** per publishable package in the **Build** job — packaging smoke test for missing `dist` / bad `files` / `exports`.

## Why this shape
The failure we actually hit (`wallet-react@0.0.2` → `E422 … "repository.url" is ""`) is npm's **server-side** provenance validation. A plain `npm publish --dry-run` never contacts the registry for that check, so it wouldn't have caught it. The deterministic guard for that class is the static `repository` check — hence leading with it. The pack dry-run covers the separate packaging class.

Both are fast and deterministic (no registry auth, no flakiness).