### PR TITLE
feat(react-ui): reusable animated Modal

### DIFF
--- a/.changeset/gentle-mice-drift.md
+++ b/.changeset/gentle-mice-drift.md
@@ -1,0 +1,5 @@
+---
+"@zerodev/react-ui": patch
+---
+
+feat: add `Modal` — a reusable animated bottom-sheet primitive. Slides up on open, back down on close; dim backdrop fades in/out; ESC and backdrop-click dismiss. Refactor `QrModal` to compose it. `QrModal` now takes an `open` prop (controlled) so the exit animation plays before unmount.

--- a/packages/react-ui/src/components/Modal/Modal.test.tsx
+++ b/packages/react-ui/src/components/Modal/Modal.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Modal } from './index'
+
+afterEach(cleanup)
+
+describe('Modal', () => {
+  it('renders children when open', () => {
+    render(
+      <Modal open onClose={() => {}}>
+        <div data-testid="content">hello</div>
+      </Modal>,
+    )
+    expect(screen.getByTestId('content')).toBeDefined()
+  })
+
+  it('does not mount when open starts false', () => {
+    const { container } = render(
+      <Modal open={false} onClose={() => {}}>
+        <div data-testid="content">hello</div>
+      </Modal>,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('fires onClose when the dim backdrop is clicked', () => {
+    const onClose = vi.fn()
+    render(
+      <Modal open onClose={onClose}>
+        <div>content</div>
+      </Modal>,
+    )
+    const backdrop = screen.getByRole('button', { name: 'Close' })
+    fireEvent.click(backdrop)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onClose when Escape is pressed', () => {
+    const onClose = vi.fn()
+    render(
+      <Modal open onClose={onClose}>
+        <div>content</div>
+      </Modal>,
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire onClose on Escape when closed', () => {
+    const onClose = vi.fn()
+    render(
+      <Modal open={false} onClose={onClose}>
+        <div>content</div>
+      </Modal>,
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('merges caller className onto the sheet', () => {
+    const { container } = render(
+      <Modal open onClose={() => {}} className="custom-sheet">
+        <div>content</div>
+      </Modal>,
+    )
+    expect(container.querySelector('.custom-sheet')).not.toBeNull()
+  })
+})

--- a/packages/react-ui/src/components/Modal/index.tsx
+++ b/packages/react-ui/src/components/Modal/index.tsx
@@ -1,0 +1,93 @@
+import { type ReactNode, useEffect, useState } from 'react'
+
+import { cn } from '../../utils/common'
+
+// Keep in sync with the `--animate-modal-out` duration in styles.css. Used to
+// schedule unmount so the sheet finishes sliding down before it disappears.
+const EXIT_DURATION_MS = 250
+
+export interface ModalProps {
+  /** Whether the modal is open. Toggling this drives the slide-in/out
+   * animation; the caller flips it via `onClose` (backdrop / ESC / a close
+   * button inside `children`). */
+  open: boolean
+  /** Fires when the user dismisses the modal (dim backdrop click or ESC).
+   * The caller is responsible for setting `open` back to false. */
+  onClose: () => void
+  children: ReactNode
+  /** Classes applied to the sheet — override colour/padding/etc. Positioning
+   * (`absolute bottom-1.5 left-1.5 right-1.5`), radius, and the slide
+   * animation are owned by Modal and not overridable via this prop. */
+  className?: string
+}
+
+/**
+ * Animated bottom-sheet modal. Passed to `<Screen overlay={…}>` so it renders
+ * at the outer card level — the dim backdrop covers the entire Screen
+ * (including the TopNav band) and the sheet is anchored to the bottom of the
+ * outer frame, respecting the 6px gradient border ring.
+ *
+ * Animation: CSS keyframe animations (not transitions). Switching the
+ * animation-name between `modal-in` and `modal-out` forces the browser to
+ * restart the animation from its `from` keyframe every time — so a rapid
+ * open → close → open still plays the full slide-up, instead of a tiny
+ * interpolation from a barely-moved position (which is what CSS transitions
+ * do when interrupted mid-way).
+ */
+export function Modal({ open, onClose, children, className }: ModalProps) {
+  const [mounted, setMounted] = useState(open)
+  // `null` = haven't picked a phase yet; used only for the initial mount
+  // when open starts false (nothing rendered) so we don't play `modal-out`
+  // by default.
+  const [phase, setPhase] = useState<'in' | 'out' | null>(open ? 'in' : null)
+
+  useEffect(() => {
+    if (open) {
+      setMounted(true)
+      setPhase('in')
+      return
+    }
+    // Only run the exit animation if we've been shown at least once — no
+    // pointless `modal-out` on the very first render with open=false.
+    setPhase((prev) => (prev === null ? null : 'out'))
+    const timeout = window.setTimeout(() => setMounted(false), EXIT_DURATION_MS)
+    return () => window.clearTimeout(timeout)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleEscape)
+    return () => document.removeEventListener('keydown', handleEscape)
+  }, [open, onClose])
+
+  if (!mounted) return null
+
+  const isIn = phase === 'in'
+
+  return (
+    <div className="zd:absolute zd:inset-0 zd:z-10">
+      <button
+        type="button"
+        aria-label="Close"
+        onClick={onClose}
+        className={cn(
+          'zd:absolute zd:inset-0 zd:bg-greyScale/20 zd:cursor-default',
+          isIn ? 'zd:animate-backdrop-in' : 'zd:animate-backdrop-out',
+        )}
+      />
+      <div
+        className={cn(
+          'zd:absolute zd:bottom-1.5 zd:left-1.5 zd:right-1.5',
+          'zd:bg-white zd:rounded-[32px] zd:overflow-hidden',
+          isIn ? 'zd:animate-modal-in' : 'zd:animate-modal-out',
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/packages/react-ui/src/components/QrModal/index.tsx
+++ b/packages/react-ui/src/components/QrModal/index.tsx
@@ -1,77 +1,73 @@
 import { Button } from '../Button'
-import { SheetShell } from '../SheetShell'
+import { Modal } from '../Modal'
 import { Text } from '../Text'
 import { QrCode } from './QrCode'
 
 export interface QrModalProps {
-  /** Whether the modal is open. Controlled. */
+  /** Whether the modal is open. */
   open: boolean
-  /** Called when the modal requests to close (backdrop click, ESC,
-   * Cancel button). */
-  onOpenChange: (open: boolean) => void
   /** Address to encode in the QR code and display below it. */
   address: string
   /** Called when the user taps "Copy address". */
   onCopy: () => void
+  /** Called when the user taps "Cancel" or the dim backdrop. */
+  onClose: () => void
 }
 
 /**
- * Bottom-anchored modal showing the deposit address as a QR code. Composes
- * `<SheetShell>` for the animated bottom-sheet chrome; this file owns the
- * QR / address / copy-cancel layout inside it.
+ * Bottom-anchored sheet showing the deposit address as a QR code. Composes
+ * `<Modal>` for the animated bottom-sheet chrome; this file owns the QR /
+ * address / copy-cancel layout inside it.
  */
-export function QrModal({ open, onOpenChange, address, onCopy }: QrModalProps) {
+export function QrModal({ open, address, onCopy, onClose }: QrModalProps) {
   return (
-    <SheetShell
-      open={open}
-      onOpenChange={onOpenChange}
-      title="Your deposit address"
-    >
-      {/* Bottom-half gradient — light blue at bottom-left fading into
-          peach/orange at bottom-right — mirrors the "amorphic" image used
-          in the Figma design. Colors echo `MultiRadialBackground`. */}
-      <div
-        aria-hidden
-        className="zd:absolute zd:inset-0 zd:pointer-events-none"
-        style={{
-          background:
-            'radial-gradient(ellipse 78% 65% at 5% 105%, rgba(69,171,251,0.35) 0%, rgba(69,171,251,0) 72%), radial-gradient(ellipse 82% 65% at 100% 105%, rgba(250,200,172,0.65) 0%, rgba(250,200,172,0) 72%), radial-gradient(ellipse 58% 52% at 100% 100%, rgba(242,123,62,0.35) 0%, rgba(242,123,62,0) 72%)',
-        }}
-      />
-      <div className="zd:relative zd:flex zd:flex-col zd:gap-6 zd:items-center zd:pt-6 zd:px-4 zd:pb-3">
-        <div className="zd:flex zd:flex-col zd:gap-3 zd:items-center">
-          <Text className="zd:text-h2 zd:text-center">
-            Your deposit address
+    <Modal open={open} onClose={onClose}>
+      {/* Relative wrapper so the ambient gradient can absolute-position behind
+          the content. Modal itself sets the sheet's white bg + rounded frame;
+          this gradient sits on top of the bg but under the content. */}
+      <div className="zd:relative">
+        {/* Bottom-half gradient — light blue at bottom-left fading into
+            peach/orange at bottom-right — mirrors the "amorphic" image used
+            in the Figma design. Colours echo `MultiRadialBackground`. */}
+        <div
+          aria-hidden
+          className="zd:absolute zd:inset-0 zd:pointer-events-none"
+          style={{
+            background:
+              'radial-gradient(ellipse 78% 65% at 5% 105%, rgba(69,171,251,0.35) 0%, rgba(69,171,251,0) 72%), radial-gradient(ellipse 82% 65% at 100% 105%, rgba(250,200,172,0.65) 0%, rgba(250,200,172,0) 72%), radial-gradient(ellipse 58% 52% at 100% 100%, rgba(242,123,62,0.35) 0%, rgba(242,123,62,0) 72%)',
+          }}
+        />
+        <div className="zd:relative zd:flex zd:flex-col zd:gap-6 zd:items-center zd:pt-6 zd:px-4 zd:pb-3">
+          <div className="zd:flex zd:flex-col zd:gap-3 zd:items-center">
+            <Text className="zd:text-h2 zd:text-center">
+              Your deposit address
+            </Text>
+            <Text className="zd:text-body2 zd:text-center zd:max-w-[300px]">
+              Send funds to this address to automatically bridge and swap
+              desired assets.
+            </Text>
+          </div>
+
+          <div className="zd:relative zd:bg-white zd:w-[200px] zd:h-[200px] zd:p-3 zd:flex zd:items-center zd:justify-center">
+            <QrCode value={address} size={176} eyeRadius={2} />
+            {/* Corner brackets — viewfinder-style framing. Color/thickness
+                match the Figma's `rgba(19,14,11,0.1)` 1px outline. */}
+            <div className="zd:absolute zd:top-0 zd:left-0 zd:w-5 zd:h-5 zd:border-t zd:border-l zd:border-greyScale/10 zd:rounded-tl-lg zd:pointer-events-none" />
+            <div className="zd:absolute zd:top-0 zd:right-0 zd:w-5 zd:h-5 zd:border-t zd:border-r zd:border-greyScale/10 zd:rounded-tr-lg zd:pointer-events-none" />
+            <div className="zd:absolute zd:bottom-0 zd:left-0 zd:w-5 zd:h-5 zd:border-b zd:border-l zd:border-greyScale/10 zd:rounded-bl-lg zd:pointer-events-none" />
+            <div className="zd:absolute zd:bottom-0 zd:right-0 zd:w-5 zd:h-5 zd:border-b zd:border-r zd:border-greyScale/10 zd:rounded-br-lg zd:pointer-events-none" />
+          </div>
+
+          <Text className="zd:text-body2 zd:text-center zd:break-all zd:max-w-[230px]">
+            {address}
           </Text>
-          <Text className="zd:text-body2 zd:text-center zd:max-w-[300px]">
-            Send funds to this address to automatically bridge and swap desired
-            assets.
-          </Text>
-        </div>
 
-        <div className="zd:relative zd:bg-white zd:w-[200px] zd:h-[200px] zd:p-3 zd:flex zd:items-center zd:justify-center">
-          <QrCode value={address} size={176} eyeRadius={2} />
-          {/* Corner brackets — viewfinder-style framing. Color/thickness
-              match the Figma's `rgba(19,14,11,0.1)` 1px outline. */}
-          <div className="zd:absolute zd:top-0 zd:left-0 zd:w-5 zd:h-5 zd:border-t zd:border-l zd:border-greyScale/10 zd:rounded-tl-lg zd:pointer-events-none" />
-          <div className="zd:absolute zd:top-0 zd:right-0 zd:w-5 zd:h-5 zd:border-t zd:border-r zd:border-greyScale/10 zd:rounded-tr-lg zd:pointer-events-none" />
-          <div className="zd:absolute zd:bottom-0 zd:left-0 zd:w-5 zd:h-5 zd:border-b zd:border-l zd:border-greyScale/10 zd:rounded-bl-lg zd:pointer-events-none" />
-          <div className="zd:absolute zd:bottom-0 zd:right-0 zd:w-5 zd:h-5 zd:border-b zd:border-r zd:border-greyScale/10 zd:rounded-br-lg zd:pointer-events-none" />
-        </div>
-
-        <Text className="zd:text-body2 zd:text-center zd:break-all zd:max-w-[230px]">
-          {address}
-        </Text>
-
-        <div className="zd:flex zd:flex-col zd:gap-1 zd:w-full">
-          <Button action="primary" text="Copy address" onClick={onCopy} />
-          <Button
-            action="secondary"
-            text="Cancel"
-            onClick={() => onOpenChange(false)}
-          />
+          <div className="zd:flex zd:flex-col zd:gap-1 zd:w-full">
+            <Button action="primary" text="Copy address" onClick={onCopy} />
+            <Button action="secondary" text="Cancel" onClick={onClose} />
+          </div>
         </div>
       </div>
-    </SheetShell>
+    </Modal>
   )
 }

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -30,6 +30,7 @@ export {
   type ListItemProps,
   ListItemSkeleton,
 } from './components/ListItem'
+export { Modal, type ModalProps } from './components/Modal'
 export {
   PillItem,
   type PillItemProps,

--- a/packages/react-ui/tailwind.config.ts
+++ b/packages/react-ui/tailwind.config.ts
@@ -57,15 +57,17 @@ const config: Config = {
         mono: undefined,
         roboto: ['Roboto', 'sans-serif'],
       },
-      // Sheet / overlay animations bound to Radix's `data-state=open|closed`
-      // attributes. Defined here (not in the CSS) so downstream packages that
-      // `@config` this file inherit them without duplication.
+      // Modal slide-up / slide-down animations. Defined in the config (not
+      // the CSS) so consumers who @config this file (e.g.
+      // smart-routing-address-react-ui) inherit them automatically. CSS
+      // animations restart deterministically when animation-name changes,
+      // which is what Modal relies on for open→close→open interrupts.
       keyframes: {
-        'sheet-in': {
+        'modal-in': {
           from: { transform: 'translateY(100%)' },
           to: { transform: 'translateY(0)' },
         },
-        'sheet-out': {
+        'modal-out': {
           from: { transform: 'translateY(0)' },
           to: { transform: 'translateY(100%)' },
         },
@@ -79,8 +81,8 @@ const config: Config = {
         },
       },
       animation: {
-        'sheet-in': 'sheet-in 300ms cubic-bezier(0.32, 0.72, 0, 1) forwards',
-        'sheet-out': 'sheet-out 250ms cubic-bezier(0.32, 0.72, 0, 1) forwards',
+        'modal-in': 'modal-in 300ms cubic-bezier(0.32, 0.72, 0, 1) forwards',
+        'modal-out': 'modal-out 250ms cubic-bezier(0.32, 0.72, 0, 1) forwards',
         'backdrop-in': 'backdrop-in 200ms ease-out forwards',
         'backdrop-out': 'backdrop-out 200ms ease-out forwards',
       },

--- a/packages/smart-routing-address-react-ui/src/pages/index.tsx
+++ b/packages/smart-routing-address-react-ui/src/pages/index.tsx
@@ -86,6 +86,19 @@ export function SmartRoutingAddress({
     setQrOpen(false)
   }
 
+  // Mount the QrModal whenever an address is available; the modal itself
+  // handles its open/close animation from the `open` prop and keeps its DOM
+  // mounted through the exit transition — that way toggling `qrOpen`
+  // false triggers the slide-down animation instead of an abrupt unmount.
+  const overlay = address ? (
+    <QrModal
+      open={qrOpen}
+      address={address}
+      onCopy={handleCopy}
+      onClose={() => setQrOpen(false)}
+    />
+  ) : undefined
+
   return (
     <Screen
       className={className}
@@ -100,20 +113,9 @@ export function SmartRoutingAddress({
           onRightButtonClick={onClose}
         />
       }
+      {...(overlay && { overlay })}
     >
       {renderStep(step, { onQrClick: handleQrClick })}
-      {/* QrModal renders itself via `useScreenOverlayContainer()` + portal, so
-        it stays inside the card frame while composing at this level rather
-        than being hoisted into `Screen`'s API. Mounted whenever an address
-        exists so Radix Dialog owns the open/close animation lifecycle. */}
-      {address && (
-        <QrModal
-          open={qrOpen}
-          onOpenChange={setQrOpen}
-          address={address}
-          onCopy={handleCopy}
-        />
-      )}
     </Screen>
   )
 }


### PR DESCRIPTION
Closes [FS-2404](https://linear.app/offchain-labs/issue/FS-2404/reusable-animated-modal-component)

### Summary

This PR adds a reusable animated Modal component to `react-ui`

### Demo



https://github.com/user-attachments/assets/177dd652-9a19-4765-aca2-b6b2d4fe10d6

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"omar/sra-qr","parentHead":"07dd96c581a832340390cc01d13044664f4ef0e0","parentPull":322,"trunk":"main"}
```
-->
