### PR TITLE
fix(release): pin npm to 11.x so OIDC publish works on Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # npm Trusted Publishing (OIDC) needs npm >= 11.5.1; node 20 ships npm 10.
+      # Pin to the 11.x line — `npm@latest` (12.x) dropped Node 20 and broke this.
       - name: Upgrade npm for OIDC publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Create Version PR or publish
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0


### PR DESCRIPTION
## Why the Version Packages PR stopped opening
`npm@latest` rolled to **12.x**, which requires Node `>=22.22.2`. The release workflow pins Node 20, so the `Upgrade npm for OIDC publishing` step (`npm install -g npm@latest`) now fails with `EBADENGINE`:

```
npm error EBADENGINE Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"} Actual: node v20.20.2
```

That step failing **skips** `Create Version PR or publish` — so since ~07-09 every merge to main has silently failed to open/update the Version PR. Changesets from #299/#300/#304/#305/#306 piled up on main, unreleased.

## Fix
Pin to `npm@11` (≥ 11.5.1, which is all OIDC Trusted Publishing needs, and still supports Node 20). Stops chasing `latest` into engine breaks.

## After merge
The (fixed) release run will process the pending changesets and open a Version Packages PR bumping `@zerodev/react-ui` and `@zerodev/wallet-react-ui`. Merging that publishes them.

Follow-up (separate): Node 20 is deprecated on GH runners — worth bumping the workflows to Node 22 later, but that's not needed to unblock this.