### PR TITLE
feat(react): default AA URL to ?provider=ULTRA_RELAY

### DIFF
--- a/.changeset/frank-pianos-stop.md
+++ b/.changeset/frank-pianos-stop.md
@@ -1,0 +1,5 @@
+---
+"@zerodev/wallet-react": patch
+---
+
+feat: default the AA bundler/paymaster URL to ?provider=ULTRA_RELAY

--- a/packages/react/src/constants.ts
+++ b/packages/react/src/constants.ts
@@ -5,3 +5,7 @@ export const ZERODEV_AA_HOST = 'https://rpc.zerodev.app'
 // ZeroDev AA API version the SDK targets. Owned by the SDK (bumped alongside a
 // release that supports a new version) — never set by consumers.
 export const ZERODEV_AA_VERSION = 'v3'
+
+// Bundler/paymaster provider the SDK requests by default (appended as
+// `?provider=` to the AA URL). Owned by the SDK.
+export const ZERODEV_AA_PROVIDER = 'ULTRA_RELAY'

--- a/packages/react/src/utils/aaUtils.test.ts
+++ b/packages/react/src/utils/aaUtils.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest'
-import { ZERODEV_AA_HOST, ZERODEV_AA_VERSION } from '../constants.js'
+import {
+  ZERODEV_AA_HOST,
+  ZERODEV_AA_PROVIDER,
+  ZERODEV_AA_VERSION,
+} from '../constants.js'
 import { getAAUrl } from './aaUtils.js'
 
 describe('getAAUrl', () => {
-  it('builds the default per-chain URL (SDK-owned host + version)', () => {
+  it('builds the default per-chain URL (SDK-owned host + version + provider)', () => {
     expect(getAAUrl('proj', 421614)).toBe(
-      `${ZERODEV_AA_HOST}/api/${ZERODEV_AA_VERSION}/proj/chain/421614`,
+      `${ZERODEV_AA_HOST}/api/${ZERODEV_AA_VERSION}/proj/chain/421614?provider=${ZERODEV_AA_PROVIDER}`,
     )
   })
 
@@ -14,15 +18,19 @@ describe('getAAUrl', () => {
     expect(getAAUrl('proj', 8453)).toContain('/chain/8453')
   })
 
-  it('overrides only the host via aaHost; version + path stay SDK-owned', () => {
+  it('requests the default provider', () => {
+    expect(getAAUrl('proj', 1)).toContain('?provider=ULTRA_RELAY')
+  })
+
+  it('overrides only the host via aaHost; version + path + provider stay SDK-owned', () => {
     expect(getAAUrl('proj', 1, 'https://rpc.zerodev.app')).toBe(
-      `https://rpc.zerodev.app/api/${ZERODEV_AA_VERSION}/proj/chain/1`,
+      `https://rpc.zerodev.app/api/${ZERODEV_AA_VERSION}/proj/chain/1?provider=${ZERODEV_AA_PROVIDER}`,
     )
   })
 
   it('trims a trailing slash on aaHost', () => {
     expect(getAAUrl('proj', 1, 'https://rpc.zerodev.app/')).toBe(
-      `https://rpc.zerodev.app/api/${ZERODEV_AA_VERSION}/proj/chain/1`,
+      `https://rpc.zerodev.app/api/${ZERODEV_AA_VERSION}/proj/chain/1?provider=${ZERODEV_AA_PROVIDER}`,
     )
   })
 })

--- a/packages/react/src/utils/aaUtils.ts
+++ b/packages/react/src/utils/aaUtils.ts
@@ -1,13 +1,17 @@
-import { ZERODEV_AA_HOST, ZERODEV_AA_VERSION } from '../constants.js'
+import {
+  ZERODEV_AA_HOST,
+  ZERODEV_AA_PROVIDER,
+  ZERODEV_AA_VERSION,
+} from '../constants.js'
 
 /**
  * Builds the ZeroDev AA bundler/paymaster URL for a project + chain.
  *
  * The chainId is always appended, so this is multichain-safe. Consumers may
  * override only the host (`aaHost`, e.g. a staging/self-hosted origin); the
- * API version and path shape are owned by the SDK.
+ * API version, path shape, and default provider are owned by the SDK.
  */
 export function getAAUrl(projectId: string, chainId: number, aaHost?: string) {
   const host = (aaHost ?? ZERODEV_AA_HOST).replace(/\/+$/, '')
-  return `${host}/api/${ZERODEV_AA_VERSION}/${projectId}/chain/${chainId}`
+  return `${host}/api/${ZERODEV_AA_VERSION}/${projectId}/chain/${chainId}?provider=${ZERODEV_AA_PROVIDER}`
 }


### PR DESCRIPTION
Appends `?provider=ULTRA_RELAY` to the AA bundler/paymaster URL by default.

Done in one place — `getAAUrl` in `packages/react/src/utils/aaUtils.ts`, the single chokepoint both the bundler and paymaster clients route through (connector.ts:164, :172), so both pick it up. The value is an SDK-owned constant (`ZERODEV_AA_PROVIDER`) alongside host/version. The `aaHost` override still only swaps the origin; version/path/provider stay SDK-owned.

Tests updated (`aaUtils.test.ts`) — 5 passing.

_Needs a changeset (`@zerodev/wallet-react`, patch) — adding next._