### PR TITLE
feat(react-ui): rewrite ListItem with composition slots

### DIFF
--- a/.changeset/ripe-tables-think.md
+++ b/.changeset/ripe-tables-think.md
@@ -1,0 +1,26 @@
+---
+"@zerodev/react-ui": patch
+---
+
+feat: rewrite `ListItem` around composition slots — `icon`, `subtitle`, and `trailing` take any ReactNode, so new row variants no longer grow the prop API.
+
+- **`icon`** — leading tile content (an `<img>`, a brand mark, or the new `ListItemIcon` preset, which ships the standard sizing/color and merges `className` overrides).
+- **`subtitle`** — polymorphic secondary line: a plain string keeps the auto-styled text; any node (e.g. `<Badge />`) renders as-is. Replaces the separate `badgeProps`; the title column now uses a uniform `gap-1`.
+- **`trailing`** — right side of the row; the new `ListItemChevron` preset replaces the `chevron` boolean.
+- **`asChild`** — render the row into a child element (e.g. an `<a>`) via Radix Slot; the `asChild`/`children` pairing is enforced at the type level, so `children` without `asChild` is a compile error.
+
+```tsx
+<ListItem
+  title={wallet.name}
+  icon={<ListItemIcon name="wallet" />}
+  subtitle={<Badge text="INSTALLED" />}
+  trailing={<ListItemChevron />}
+  onClick={select}
+/>
+
+<ListItem asChild title="Get MetaMask" trailing={<ListItemChevron />}>
+  <a href={downloadUrl} target="_blank" rel="noopener noreferrer" />
+</ListItem>
+```
+
+BREAKING (`ListItem`): removed `iconName`, `imageUri`, `badgeProps`, `details`, `chevron`, and the unused `alert` variant (no consumers on main or in any open PR). Former `details` content is a one-liner in the `trailing` slot (see `TxGasFees`). `ListItemProps` is now a type alias (base props intersected with the asChild union), no longer an interface — `extends ListItemProps` becomes `& ListItemProps`.

--- a/packages/react-ui/src/components/ListItem/ListItem.stories.tsx
+++ b/packages/react-ui/src/components/ListItem/ListItem.stories.tsx
@@ -80,7 +80,7 @@ export const AsLink: Story = {
     asChild: true,
     children: (
       // biome-ignore lint/a11y/useAnchorContent: the row layout (incl. the title text) is injected into the anchor via Slot
-      <a href="https://metamask.io" target="_blank" rel="noreferrer" />
+      <a href="https://metamask.io" target="_blank" rel="noopener noreferrer" />
     ),
   },
 }

--- a/packages/react-ui/src/components/ListItem/ListItem.stories.tsx
+++ b/packages/react-ui/src/components/ListItem/ListItem.stories.tsx
@@ -1,6 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { ListItem, ListItemSkeleton } from './index'
+import { Badge } from '../Badge'
+import { Text } from '../Text'
+import {
+  ListItem,
+  ListItemChevron,
+  ListItemIcon,
+  ListItemSkeleton,
+} from './index'
 
 const meta = {
   title: 'Shared/ListItem',
@@ -10,14 +17,6 @@ const meta = {
   },
   tags: ['autodocs'],
   argTypes: {
-    iconName: {
-      control: 'text',
-      description: 'Icon name to display',
-    },
-    imageUri: {
-      control: 'text',
-      description: 'Image URI to display',
-    },
     title: {
       control: 'text',
       description: 'Main title text',
@@ -25,14 +24,6 @@ const meta = {
     subtitle: {
       control: 'text',
       description: 'Subtitle text',
-    },
-    chevron: {
-      control: 'boolean',
-      description: 'Show chevron icon',
-    },
-    alert: {
-      control: 'boolean',
-      description: 'Alert styling',
     },
   },
   decorators: [
@@ -49,45 +40,48 @@ type Story = StoryObj<typeof meta>
 
 export const WithIcon: Story = {
   args: {
-    iconName: 'wallet',
+    icon: <ListItemIcon name="wallet" />,
     title: 'Wallet',
     subtitle: 'Connected',
-    chevron: true,
+    trailing: <ListItemChevron />,
   },
 }
 
 export const WithDetails: Story = {
   args: {
-    iconName: 'wallet',
+    icon: <ListItemIcon name="wallet" className="zd:text-solarOrange" />,
     title: 'Transaction',
     subtitle: 'Pending',
-    details: {
-      text: '$100.00',
-      subtext: 'USD',
-    },
+    trailing: (
+      <div className="zd:flex zd:flex-col zd:pr-1">
+        <Text className="zd:text-body1">$100.00</Text>
+        <Text className="zd:text-body3 zd:text-greyScale/50 zd:self-end">
+          USD
+        </Text>
+      </div>
+    ),
   },
 }
 
 export const WithBadge: Story = {
   args: {
-    iconName: 'wallet',
+    icon: <ListItemIcon name="wallet" />,
     title: 'Verified Wallet',
-    badgeProps: {
-      text: 'Verified',
-      variant: 'secondary',
-      leadingIcon: 'check',
-    },
-    chevron: true,
+    subtitle: <Badge text="Verified" variant="secondary" leadingIcon="check" />,
+    trailing: <ListItemChevron />,
   },
 }
 
-export const AlertState: Story = {
+export const AsLink: Story = {
   args: {
-    iconName: 'warning',
-    title: 'Action Required',
-    subtitle: 'Review transaction',
-    alert: true,
-    chevron: true,
+    icon: <ListItemIcon name="wallet" />,
+    title: 'Get MetaMask',
+    trailing: <ListItemChevron />,
+    asChild: true,
+    children: (
+      // biome-ignore lint/a11y/useAnchorContent: the row layout (incl. the title text) is injected into the anchor via Slot
+      <a href="https://metamask.io" target="_blank" rel="noreferrer" />
+    ),
   },
 }
 

--- a/packages/react-ui/src/components/ListItem/ListItem.test.tsx
+++ b/packages/react-ui/src/components/ListItem/ListItem.test.tsx
@@ -16,7 +16,7 @@ vi.mock('../Icon', async () => {
   }
 })
 
-import { ListItem, ListItemSkeleton } from './index'
+import { ListItem, ListItemChevron, ListItemSkeleton } from './index'
 
 afterEach(() => {
   cleanup()
@@ -28,62 +28,52 @@ describe('ListItem', () => {
     expect(screen.getByText('Test Title')).toBeDefined()
   })
 
-  it('renders subtitle when provided', () => {
+  it('renders a string subtitle with the standard styling', () => {
     render(<ListItem title="Test Title" subtitle="Test Subtitle" />)
     expect(screen.getByText('Test Subtitle')).toBeDefined()
   })
 
-  it('renders icon when iconName is provided', () => {
-    render(<ListItem title="Test Title" iconName="wallet" />)
-    expect(screen.getByTestId('icon-wallet')).toBeDefined()
+  it('renders a node subtitle as-is', () => {
+    render(
+      <ListItem title="Test Title" subtitle={<span data-testid="badge" />} />,
+    )
+    expect(screen.getByTestId('badge')).toBeDefined()
   })
 
-  it('renders chevron when chevron prop is true', () => {
-    render(<ListItem title="Test Title" chevron />)
-    expect(screen.getByTestId('icon-chevronRight')).toBeDefined()
+  it('renders the icon slot inside the leading tile', () => {
+    render(
+      <ListItem title="Test Title" icon={<span data-testid="custom-icon" />} />,
+    )
+    expect(screen.getByTestId('custom-icon')).toBeDefined()
   })
 
-  it('renders badge when badgeProps is provided', () => {
+  it('renders the trailing slot', () => {
     render(
       <ListItem
         title="Test Title"
-        badgeProps={{ text: 'New', variant: 'secondary' }}
+        trailing={<span data-testid="trailing" />}
       />,
     )
-    expect(screen.getByText('New')).toBeDefined()
+    expect(screen.getByTestId('trailing')).toBeDefined()
   })
 
-  it('applies correct gap when badge is present', () => {
-    const { container } = render(
-      <ListItem title="Test Title" badgeProps={{ text: 'Badge' }} />,
-    )
-    const contentDiv = container.querySelector('.zd\\:gap-2')
-    expect(contentDiv).not.toBeNull()
-  })
-
-  it('renders details when provided', () => {
-    render(
-      <ListItem
-        title="Test Title"
-        details={{
-          text: 'Detail Text',
-          subtext: 'Detail Subtext',
-        }}
-      />,
-    )
-    expect(screen.getByText('Detail Text')).toBeDefined()
-    expect(screen.getByText('Detail Subtext')).toBeDefined()
-  })
-
-  it('applies alert styling when alert prop is true', () => {
-    const { container } = render(<ListItem title="Test Title" alert />)
-    const button = container.querySelector('button')
-    expect(button?.className).toContain('bg-solarOrange/15')
-  })
-
-  it('renders as a button element', () => {
+  it('renders as a button element by default', () => {
     render(<ListItem title="Test Title" />)
     expect(screen.getByRole('button')).toBeDefined()
+  })
+
+  it('renders into the child element with asChild', () => {
+    render(
+      <ListItem title="Link Row" asChild trailing={<ListItemChevron />}>
+        {/* biome-ignore lint/a11y/useAnchorContent: the row layout (incl. the title text) is injected into the anchor via Slot */}
+        <a href="https://example.com" />
+      </ListItem>,
+    )
+    const link = screen.getByRole('link')
+    expect(link.getAttribute('href')).toBe('https://example.com')
+    // row layout is injected into the anchor
+    expect(link.textContent).toContain('Link Row')
+    expect(screen.queryByRole('button')).toBeNull()
   })
 })
 

--- a/packages/react-ui/src/components/ListItem/index.tsx
+++ b/packages/react-ui/src/components/ListItem/index.tsx
@@ -1,7 +1,7 @@
-import type { ButtonHTMLAttributes } from 'react'
+import { Slot } from 'radix-ui'
+import type { ButtonHTMLAttributes, ReactElement, ReactNode } from 'react'
 
 import { cn } from '../../utils/common'
-import { Badge, type BadgeProps } from '../Badge'
 import { Icon, type IconName } from '../Icon'
 import { Text } from '../Text'
 import { Wrapper } from '../Wrapper'
@@ -35,102 +35,97 @@ export function ListItemSkeleton({ className }: ListItemSkeletonProps) {
   )
 }
 
-export interface ListItemProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  iconName?: IconName
-  imageUri?: string
+interface ListItemBaseProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
   title: string
-  subtitle?: string
-  badgeProps?: BadgeProps
-  details?: { text: string; subtext?: string }
-  chevron?: boolean
-  alert?: boolean
+  /** Secondary line under the title — plain text (auto-styled) or any node,
+   * e.g. a `<Badge />`. */
+  subtitle?: ReactNode
+  /** Leading tile content — any node (`ListItemIcon`, `<img>`, a brand mark).
+   * Size the node itself (e.g. `zd:w-6 zd:h-6`); the tile keeps its frame. */
+  icon?: ReactNode
+  /** Right side of the row — `<ListItemChevron />` or any custom node. */
+  trailing?: ReactNode
 }
 
+// `children` is only meaningful as the asChild target — the union makes the
+// pairing a compile-time contract.
+type ListItemAsChildProps =
+  | {
+      /** Render the row into the child element (e.g. an `<a>`) instead of a
+       * `<button>`. Pass a single childless element; the row layout is
+       * injected into it. */
+      asChild: true
+      children: ReactElement
+    }
+  | { asChild?: false; children?: never }
+
+export type ListItemProps = ListItemBaseProps & ListItemAsChildProps
+
 export function ListItem({
-  iconName,
-  imageUri,
+  icon,
   title,
   subtitle,
-  badgeProps,
-  details,
-  chevron,
-  alert,
+  trailing,
+  asChild,
+  children,
   className,
   ...rest
 }: ListItemProps) {
+  const Comp = asChild ? Slot.Root : 'button'
   return (
-    <Wrapper
-      className={cn(
-        'zd:w-full zd:h-17 zd:rounded-2xl',
-        alert && 'zd:border-0',
-        className,
-      )}
-    >
-      <button
-        type="button"
+    <Wrapper className={cn('zd:w-full zd:h-17 zd:rounded-2xl', className)}>
+      <Comp
+        {...(!asChild && { type: 'button' as const })}
         className={cn(
-          'zd:w-full zd:flex zd:flex-row zd:justify-between zd:items-center zd:p-2 zd:transition-colors zd:cursor-pointer',
-          alert
-            ? 'zd:bg-solarOrange/15'
-            : 'zd:hover:bg-white/20 zd:active:bg-white/30',
+          'zd:w-full zd:flex zd:flex-row zd:justify-between zd:items-center zd:p-2 zd:transition-colors zd:cursor-pointer zd:hover:bg-white/20 zd:active:bg-white/30',
           rest.disabled && 'zd:opacity-50 zd:cursor-not-allowed',
         )}
         {...rest}
       >
+        {asChild && <Slot.Slottable>{children}</Slot.Slottable>}
         <div className="zd:flex zd:flex-row zd:items-center zd:gap-3">
-          <div
-            className={cn(
-              'zd:w-13 zd:h-13 zd:rounded-2xl zd:flex zd:items-center zd:justify-center zd:shrink-0',
-              alert ? 'zd:bg-offWhite/50' : 'zd:bg-white',
-            )}
-          >
-            {imageUri ? (
-              <img src={imageUri} alt="" className="zd:w-6 zd:h-6" />
-            ) : iconName ? (
-              <Icon
-                name={iconName}
-                className={cn(
-                  'zd:w-6 zd:h-6',
-                  details || alert
-                    ? 'zd:text-solarOrange'
-                    : 'zd:text-greyScale',
-                )}
-              />
-            ) : null}
+          <div className="zd:w-13 zd:h-13 zd:rounded-2xl zd:bg-white zd:flex zd:items-center zd:justify-center zd:shrink-0">
+            {icon}
           </div>
-          <div
-            className={cn(
-              'zd:flex zd:flex-col zd:justify-center zd:text-left',
-              badgeProps ? 'zd:gap-2' : 'zd:gap-1',
-            )}
-          >
+          <div className="zd:flex zd:flex-col zd:justify-center zd:text-left zd:gap-1">
             <Text className="zd:text-body1">{title}</Text>
-            {subtitle && (
+            {typeof subtitle === 'string' ? (
               <Text className="zd:text-body3 zd:text-greyScale/50">
                 {subtitle}
               </Text>
+            ) : (
+              subtitle
             )}
-            {badgeProps && <Badge {...badgeProps} />}
           </div>
         </div>
-        {details ? (
-          <div className="zd:flex zd:flex-col zd:pr-1">
-            <Text className="zd:text-body1">{details.text}</Text>
-            {details.subtext && (
-              <Text className="zd:text-body3 zd:text-greyScale/50 zd:self-end">
-                {details.subtext}
-              </Text>
-            )}
-          </div>
-        ) : chevron ? (
-          <div className="zd:w-13 zd:h-13 zd:flex zd:items-center zd:justify-center">
-            <Icon
-              name="chevronRight"
-              className="zd:h-6 zd:w-6 zd:text-greyScale"
-            />
-          </div>
-        ) : null}
-      </button>
+        {trailing}
+      </Comp>
     </Wrapper>
+  )
+}
+
+export interface ListItemIconProps {
+  name: IconName
+  className?: string
+}
+
+/** Standard leading icon for the tile — pre-sized and colored for the slot;
+ * override via `className` (e.g. `zd:text-solarOrange`). */
+export function ListItemIcon({ name, className }: ListItemIconProps) {
+  return (
+    <Icon
+      name={name}
+      className={cn('zd:w-6 zd:h-6 zd:text-greyScale', className)}
+    />
+  )
+}
+
+/** Standard trailing chevron for navigation rows. */
+export function ListItemChevron() {
+  return (
+    <div className="zd:w-13 zd:h-13 zd:flex zd:items-center zd:justify-center">
+      <Icon name="chevronRight" className="zd:h-6 zd:w-6 zd:text-greyScale" />
+    </div>
   )
 }

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -33,6 +33,9 @@ export { IconButton, type IconButtonProps } from './components/IconButton'
 export { Input, type InputProps } from './components/Input'
 export {
   ListItem,
+  ListItemChevron,
+  ListItemIcon,
+  type ListItemIconProps,
   type ListItemProps,
   ListItemSkeleton,
 } from './components/ListItem'

--- a/packages/wallet-react-ui/src/auth/pages/SignUp.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp.tsx
@@ -1,4 +1,12 @@
-import { Button, Icon, Input, ListItem, Text } from '@zerodev/react-ui'
+import {
+  Button,
+  Icon,
+  Input,
+  ListItem,
+  ListItemChevron,
+  ListItemIcon,
+  Text,
+} from '@zerodev/react-ui'
 import {
   useAuthenticateOAuth,
   useLoginPasskey,
@@ -235,9 +243,9 @@ export function SignUp() {
           <div className="zd:px-4 zd:flex zd:flex-col zd:gap-2">
             {enabledMethods.includes('google') && (
               <ListItem
-                iconName="google"
+                icon={<ListItemIcon name="google" />}
                 title="Google"
-                chevron
+                trailing={<ListItemChevron />}
                 className="zd:rounded-3xl"
                 disabled={anyPending}
                 onClick={handleGoogleAuth}

--- a/packages/wallet-react-ui/src/auth/pages/WalletSelection.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/WalletSelection.tsx
@@ -1,4 +1,4 @@
-import { ListItem, PoweredBy, Text } from '@zerodev/react-ui'
+import { ListItem, ListItemIcon, PoweredBy, Text } from '@zerodev/react-ui'
 import { useConnect } from 'wagmi'
 import { useAuth } from '../hooks/useAuth'
 
@@ -35,8 +35,17 @@ export function WalletSelection() {
               <ListItem
                 key={connector.uid}
                 title={connector.name}
-                iconName="walletOutline"
-                {...(connector.icon ? { imageUri: connector.icon } : {})}
+                icon={
+                  connector.icon ? (
+                    <img
+                      src={connector.icon}
+                      alt=""
+                      className="zd:w-6 zd:h-6"
+                    />
+                  ) : (
+                    <ListItemIcon name="walletOutline" />
+                  )
+                }
                 disabled={isPending}
                 onClick={() => handleSelect(connector)}
                 className="zd:rounded-3xl"

--- a/packages/wallet-react-ui/src/signing/components/TxGasFees/TxGasFees.test.tsx
+++ b/packages/wallet-react-ui/src/signing/components/TxGasFees/TxGasFees.test.tsx
@@ -11,31 +11,13 @@ vi.mock('@zerodev/react-ui', async (importOriginal) => {
   }: { name: string } & React.SVGProps<SVGSVGElement>) =>
     React.createElement('svg', { 'data-testid': `icon-${name}`, ...props })
 
-  // ListItem renders its icon internally via the package-private Icon, which
-  // the barrel mock cannot intercept — stub it to expose the same testids.
-  const MockListItem = ({
-    title,
-    iconName,
-    details,
-  }: {
-    title?: string
-    iconName?: string
-    details?: { text?: string; subtext?: string }
-  }) =>
-    React.createElement(
-      'div',
-      null,
-      iconName ? React.createElement(MockIcon, { name: iconName }) : null,
-      title ? React.createElement('p', null, title) : null,
-      details?.text ? React.createElement('p', null, details.text) : null,
-      details?.subtext ? React.createElement('p', null, details.subtext) : null,
-    )
-
   return {
     ...actual,
     Icon: MockIcon,
+    // ListItemIcon wraps the package-private Icon, which this barrel mock
+    // can't reach — stub it to expose the same testids.
+    ListItemIcon: MockIcon,
     icons: {},
-    ListItem: MockListItem,
   }
 })
 

--- a/packages/wallet-react-ui/src/signing/components/TxGasFees/index.tsx
+++ b/packages/wallet-react-ui/src/signing/components/TxGasFees/index.tsx
@@ -4,6 +4,7 @@ import {
   Icon,
   type IconName,
   ListItem,
+  ListItemIcon,
   ListItemSkeleton,
   Text,
   WrappedPressable,
@@ -143,11 +144,22 @@ export function TxGasFees({
           <ListItem
             key={item.tier}
             title={capitalizeFirst(item.tier)}
-            iconName={getTierIcon(item.tier)}
-            details={{
-              text: item.fee,
-              ...(item.feeUsd && { subtext: item.feeUsd }),
-            }}
+            icon={
+              <ListItemIcon
+                name={getTierIcon(item.tier)}
+                className="zd:text-solarOrange"
+              />
+            }
+            trailing={
+              <div className="zd:flex zd:flex-col zd:pr-1">
+                <Text className="zd:text-body1">{item.fee}</Text>
+                {item.feeUsd && (
+                  <Text className="zd:text-body3 zd:text-greyScale/50 zd:self-end">
+                    {item.feeUsd}
+                  </Text>
+                )}
+              </div>
+            }
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary

Rewrites `ListItem` from config props to slots (`icon` / `subtitle` / `trailing`) + `asChild`. Groundwork for the external-wallets flow, which adds ~a dozen wallet rows the old API couldn't express.

## Why

- Every new row variant needed a new prop (`iconName`/`imageUri`, `badgeProps`, `details`, `chevron`, `alert` — several mutually exclusive). Slots take any node, so variants stop growing the API.
- Wallet rows mix icon sources — runtime strings (announced connectors), the icon set, brand components. One `icon` slot fits all three.
- Download rows are links, not buttons — `asChild` (Radix Slot) renders the row into a consumer `<a>`.

## Changes

- `ListItem`: three ReactNode slots; the row layout (tile, title column, gaps) stays enforced by the component. `subtitle` takes a string (auto-styled) or a node (e.g. `<Badge />`).
- `asChild` via Radix Slot; `children` without `asChild` is a compile error (discriminated union).
- New exported presets: `ListItemIcon` (standard size/color, `className` merges) and `ListItemChevron`.
- Consumers migrated: `SignUp`, `WalletSelection`, `TxGasFees` (details column inlined into `trailing`; its test now stubs only `ListItemIcon` instead of all of `ListItem`).
- Stories/tests rewritten for the slot API, incl. an `AsLink` story and an `asChild` anchor test. Changeset included.

## Breaking

- Removed `ListItem` props: `iconName`, `imageUri`, `badgeProps`, `details`, `chevron`, `alert` (no consumers on main or in any open PR).
- `ListItemProps` is now a type alias — `extends ListItemProps` becomes `& ListItemProps`.

Closes FS-2485

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
