### PR TITLE
fix: register passkeys as discoverable (resident) credentials

### DIFF
--- a/.changeset/perky-gifts-cough.md
+++ b/.changeset/perky-gifts-cough.md
@@ -1,0 +1,5 @@
+---
+"@zerodev/wallet-core": patch
+---
+
+fix: register passkeys as discoverable (resident) credentials so passkey login can find them. register() now sets authenticatorSelection: { residentKey: 'required', userVerification: 'preferred' }, matching the username-less login flow (empty allowCredentials).

--- a/e2e/browser/passkey.spec.ts
+++ b/e2e/browser/passkey.spec.ts
@@ -15,6 +15,7 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 import {
+  getVirtualCredentials,
   setupVirtualAuthenticator,
   teardownVirtualAuthenticator,
   type VirtualAuthenticator,
@@ -85,6 +86,26 @@ async function registerAndWaitForDashboard(
 
 test.describe('Passkey Flow', () => {
   let virtualAuth: VirtualAuthenticator
+
+  test('registers a discoverable (resident) passkey', async ({ page }) => {
+    // The regression guard for the login flow: login resolves credentials with
+    // an empty allowCredentials list, so a passkey the SDK registers must be
+    // resident/discoverable or it can never be used to log in. The virtual
+    // authenticator honors the residentKey hint, so a non-resident credential
+    // here would mean broken login.
+    virtualAuth = await registerAndWaitForDashboard(page)
+
+    try {
+      const credentials = await getVirtualCredentials(virtualAuth)
+      expect(credentials.length).toBeGreaterThan(0)
+      for (const cred of credentials) {
+        expect(cred.isResidentCredential).toBe(true)
+      }
+      console.log('Passkey registered as a discoverable (resident) credential')
+    } finally {
+      await teardownVirtualAuthenticator(virtualAuth)
+    }
+  })
 
   test('should register with passkey and sign a message', async ({ page }) => {
     virtualAuth = await registerAndWaitForDashboard(page)

--- a/e2e/helpers/virtual-authenticator.ts
+++ b/e2e/helpers/virtual-authenticator.ts
@@ -50,3 +50,19 @@ export async function teardownVirtualAuthenticator(
     // Ignore errors during cleanup
   }
 }
+
+/**
+ * Lists the credentials currently stored on the virtual authenticator. Used to
+ * assert a registered passkey is discoverable (resident): login resolves
+ * credentials with an empty allowCredentials list, which can only surface
+ * resident credentials.
+ */
+export async function getVirtualCredentials(auth: VirtualAuthenticator) {
+  const { credentials } = await auth.cdpSession.send(
+    'WebAuthn.getCredentials',
+    {
+      authenticatorId: auth.authenticatorId,
+    },
+  )
+  return credentials
+}

--- a/packages/core/src/stampers/webauthnStamper.test.ts
+++ b/packages/core/src/stampers/webauthnStamper.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getWebAuthnAttestationMock, stampMock, stamperCtorArgs } = vi.hoisted(
+  () => ({
+    getWebAuthnAttestationMock: vi.fn(),
+    stampMock: vi.fn(),
+    stamperCtorArgs: [] as unknown[],
+  }),
+)
+
+vi.mock('@turnkey/http', () => ({
+  getWebAuthnAttestation: getWebAuthnAttestationMock,
+}))
+vi.mock('@turnkey/webauthn-stamper', () => ({
+  WebauthnStamper: class {
+    stamp = stampMock
+    constructor(config: unknown) {
+      stamperCtorArgs.push(config)
+    }
+  },
+}))
+
+import { base64UrlEncode } from '../utils/utils.js'
+import { createWebauthnStamper } from './webauthnStamper.js'
+
+const rp = { id: 'wallet.example.com', name: 'Example Wallet' }
+const registration = { rp, userName: 'alice@example.com' }
+const fakeAttestation = {
+  attestationObject: 'att-obj',
+  clientDataJson: 'cdj',
+  credentialId: 'cred-id',
+}
+
+beforeEach(() => {
+  getWebAuthnAttestationMock.mockReset().mockResolvedValue(fakeAttestation)
+  stampMock.mockReset().mockResolvedValue({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'sig',
+  })
+  stamperCtorArgs.length = 0
+})
+
+// publicKey options handed to getWebAuthnAttestation on the Nth register() call.
+const pkArg = (n = 0) => getWebAuthnAttestationMock.mock.calls[n][0].publicKey
+
+describe('createWebauthnStamper', () => {
+  it('constructs the Turnkey webauthn stamper with the given rpId', async () => {
+    await createWebauthnStamper({ rpId: 'wallet.example.com' })
+    expect(stamperCtorArgs).toEqual([{ rpId: 'wallet.example.com' }])
+  })
+})
+
+describe('register()', () => {
+  // Login resolves credentials with an empty allowCredentials list, which can
+  // only surface discoverable (resident) credentials — so registration must
+  // create a resident credential, otherwise the passkey can never be used to
+  // log in.
+  it('requires a discoverable (resident) credential', async () => {
+    const stamper = await createWebauthnStamper({ rpId: rp.id })
+    await stamper.register(registration)
+    expect(pkArg().authenticatorSelection).toEqual({
+      residentKey: 'required',
+      userVerification: 'preferred',
+    })
+  })
+
+  it('advertises ES256 and RS256 credential params', async () => {
+    const stamper = await createWebauthnStamper({ rpId: rp.id })
+    await stamper.register(registration)
+    expect(pkArg().pubKeyCredParams).toEqual([
+      { type: 'public-key', alg: -7 },
+      { type: 'public-key', alg: -257 },
+    ])
+  })
+
+  it('forwards rp and the user name/displayName from options', async () => {
+    const stamper = await createWebauthnStamper({ rpId: rp.id })
+    await stamper.register(registration)
+    const pk = pkArg()
+    expect(pk.rp).toBe(rp)
+    expect(pk.user.name).toBe('alice@example.com')
+    expect(pk.user.displayName).toBe('alice@example.com')
+  })
+
+  it('generates an ArrayBuffer challenge and user id', async () => {
+    const stamper = await createWebauthnStamper({ rpId: rp.id })
+    await stamper.register(registration)
+    const pk = pkArg()
+    expect(pk.challenge).toBeInstanceOf(ArrayBuffer)
+    expect(pk.user.id).toBeInstanceOf(ArrayBuffer)
+  })
+
+  it('returns the attestation and an encodedChallenge matching the challenge sent', async () => {
+    const stamper = await createWebauthnStamper({ rpId: rp.id })
+    const result = await stamper.register(registration)
+    expect(result.attestation).toBe(fakeAttestation)
+    expect(result.encodedChallenge).toBe(base64UrlEncode(pkArg().challenge))
+  })
+
+  it('uses a fresh challenge and user id on each registration', async () => {
+    const stamper = await createWebauthnStamper({ rpId: rp.id })
+    await stamper.register(registration)
+    await stamper.register(registration)
+    expect(base64UrlEncode(pkArg(0).challenge)).not.toBe(
+      base64UrlEncode(pkArg(1).challenge),
+    )
+    expect(base64UrlEncode(pkArg(0).user.id)).not.toBe(
+      base64UrlEncode(pkArg(1).user.id),
+    )
+  })
+})
+
+describe('stamp() and clear()', () => {
+  it('delegates stamp() to the Turnkey stamper and returns its Stamp', async () => {
+    const stamper = await createWebauthnStamper({ rpId: rp.id })
+    const out = await stamper.stamp('request-body')
+    expect(stampMock).toHaveBeenCalledWith('request-body')
+    expect(out).toEqual({ stampHeaderName: 'X-Stamp', stampHeaderValue: 'sig' })
+  })
+
+  it('clear() resolves as a no-op', async () => {
+    const stamper = await createWebauthnStamper({ rpId: rp.id })
+    await expect(stamper.clear()).resolves.toBeUndefined()
+  })
+})

--- a/packages/core/src/stampers/webauthnStamper.ts
+++ b/packages/core/src/stampers/webauthnStamper.ts
@@ -33,6 +33,13 @@ export async function createWebauthnStamper({
             name: options.userName,
             displayName: options.userName,
           },
+          // Login resolves the credential with an empty allowCredentials list,
+          // which can only surface discoverable (resident) credentials — so the
+          // credential must be created as resident.
+          authenticatorSelection: {
+            residentKey: 'required',
+            userVerification: 'preferred',
+          },
         },
       })
 


### PR DESCRIPTION
## Problem
Passkeys registered via the SDK were created **non-discoverable**. `register()` (`webauthnStamper.ts`) called `getWebAuthnAttestation` without `authenticatorSelection`, so the browser applied the default `residentKey: "discouraged"`. Login (`stamp()` → Turnkey webauthn stamper) resolves credentials with an **empty `allowCredentials`** list, which can only surface **discoverable (resident)** credentials — so a registered passkey could never be used to log in (`NotAllowedError` → "login does nothing").

Masked by iCloud Keychain / Google Password Manager (they always create discoverable passkeys); reproduces on Chromium's platform authenticator and several third-party password managers.

## Fix
`register()` now sets `authenticatorSelection: { residentKey: 'required', userVerification: 'preferred' }`, matching the username-less login flow. `userVerification: 'preferred'` aligns with the login stamper's default.

## Tests
- **Unit** (`webauthnStamper.test.ts`): asserts `residentKey: 'required'`, credential params, rp/user forwarding, challenge/user-id, return shape, freshness, and stamp/clear delegation.
- **E2E** (`passkey.spec.ts`): registers on a CDP virtual authenticator (which honors the `residentKey` hint), then asserts `isResidentCredential === true` via `WebAuthn.getCredentials`.

Closes #333