### PR TITLE
fix(sra): targetTokenSymbol

### DIFF
--- a/apps/sra-demo/src/app/page.tsx
+++ b/apps/sra-demo/src/app/page.tsx
@@ -64,7 +64,8 @@ export default function Home() {
   }
 
   const config = useMemo<SmartRoutingAddressConfig>(
-    () => ({ targetChainId, targetTokenSymbol: 'USDC', slippage }),
+    // targetTokenSymbol defaults to 'USDC' when omitted.
+    () => ({ targetChainId, slippage }),
     [targetChainId, slippage],
   )
 

--- a/packages/smart-routing-address-react-ui/src/components/PendingDeposits/PendingDeposits.stories.tsx
+++ b/packages/smart-routing-address-react-ui/src/components/PendingDeposits/PendingDeposits.stories.tsx
@@ -7,6 +7,7 @@ import { PendingDeposits } from './index'
 
 const config: SmartRoutingAddressConfig = {
   targetChainId: arbitrum.id,
+  targetTokenSymbol: 'USDC',
   slippage: 50,
 }
 

--- a/packages/smart-routing-address-react-ui/src/components/PendingDeposits/PendingDeposits.test.tsx
+++ b/packages/smart-routing-address-react-ui/src/components/PendingDeposits/PendingDeposits.test.tsx
@@ -12,6 +12,7 @@ afterEach(cleanup)
 
 const config: SmartRoutingAddressConfig = {
   targetChainId: arbitrum.id,
+  targetTokenSymbol: 'USDC',
   slippage: 50,
 }
 

--- a/packages/smart-routing-address-react-ui/src/test/fixtures.ts
+++ b/packages/smart-routing-address-react-ui/src/test/fixtures.ts
@@ -18,6 +18,7 @@ export const TEST_PROJECT_ID = 'test-project-id'
 export const TEST_CONFIG: SmartRoutingAddressConfig = {
   projectId: TEST_PROJECT_ID,
   targetChainId: base.id,
+  targetTokenSymbol: 'USDC',
   slippage: 50,
   pollingInterval: 25,
 }

--- a/packages/smart-routing-address-react-ui/src/types.ts
+++ b/packages/smart-routing-address-react-ui/src/types.ts
@@ -35,8 +35,9 @@ export type SmartRoutingAddressConfig = {
   targetChainId: number
   /**
    * Display symbol for the token received on the target chain (e.g. `"USDC"`).
-   * Fixed by the configured actions — when omitted the UI joins every possible
-   * target symbol with a separator.
+   * Fixed by the configured actions — the single asset all deposits swap /
+   * bridge into, regardless of what the user sends. Defaults to `"USDC"`
+   * when omitted.
    */
   targetTokenSymbol?: string
   /** Smart routing address version, defaults to the latest stable */

--- a/packages/smart-routing-address-react-ui/src/utils/config.test.ts
+++ b/packages/smart-routing-address-react-ui/src/utils/config.test.ts
@@ -28,6 +28,7 @@ import {
 /** Minimal config without routes, exercising the defaults */
 const BARE_CONFIG: SmartRoutingAddressConfig = {
   targetChainId: base.id,
+  targetTokenSymbol: 'USDC',
 }
 
 describe('resolveVersion', () => {
@@ -134,7 +135,10 @@ describe('resolveSourceTokens', () => {
 
   it('keeps only stables for a destination chain without native support', () => {
     // bsc only maps USDC/USDT and is not in NATIVE_TOKENS_SUPPORTED
-    const sources = resolveSourceTokens({ targetChainId: bsc.id })
+    const sources = resolveSourceTokens({
+      targetChainId: bsc.id,
+      targetTokenSymbol: 'USDC',
+    })
     const tokenTypes = new Set(sources.map((source) => source.tokenType))
     expect([...tokenTypes].sort()).toEqual(['USDC', 'USDT'])
   })
@@ -186,16 +190,14 @@ describe('token symbols', () => {
     ).toBe('WETH')
   })
 
-  it('uses the configured target token, regardless of source', () => {
+  it('returns the configured target token', () => {
     expect(
-      getDestTokenSymbol({ ...BARE_CONFIG, targetTokenSymbol: 'USDC' }),
-    ).toBe('USDC')
+      getDestTokenSymbol({ ...BARE_CONFIG, targetTokenSymbol: 'ETH' }),
+    ).toBe('ETH')
   })
 
-  it('derives the destination symbol from the defaults', () => {
-    // WBTC is excluded because base has no WBTC token address
-    expect(getDestTokenSymbol(BARE_CONFIG)).toBe(
-      'ETH / USDC / WETH / USDT / DAI / EURC',
-    )
+  it("defaults to 'USDC' when targetTokenSymbol is omitted", () => {
+    const { targetTokenSymbol: _drop, ...withoutSymbol } = BARE_CONFIG
+    expect(getDestTokenSymbol(withoutSymbol)).toBe('USDC')
   })
 })

--- a/packages/smart-routing-address-react-ui/src/utils/config.ts
+++ b/packages/smart-routing-address-react-ui/src/utils/config.ts
@@ -161,23 +161,16 @@ export function getSourceTokenSymbol(source: SourceToken): string {
   return source.tokenType
 }
 
+/** Default destination-token symbol when the consumer doesn't set one — the
+ * most common SRA settlement asset by a wide margin. */
+const DEFAULT_TARGET_TOKEN_SYMBOL = 'USDC'
+
 /**
  * Display symbol for the token received on the target chain. The settlement
  * token is fixed by configuration (`targetTokenSymbol`) — it is the single
  * asset the funds are swapped/bridged into, regardless of what the user sends.
- * Without an explicit setting, every possible target token is joined with a
- * separator (used only before a destination token is configured).
+ * Falls back to `'USDC'` when unset.
  */
 export function getDestTokenSymbol(config: SmartRoutingAddressConfig): string {
-  if (config.targetTokenSymbol) return config.targetTokenSymbol
-
-  const destChain = resolveDestChain(config)
-  const tokenTypes = uniqueTokenTypes(resolveSourceTokens(config))
-  // Distinct token types can share a display symbol (WRAPPED_NATIVE vs WETH)
-  const symbols = new Set(
-    tokenTypes.map((tokenType) =>
-      getSourceTokenSymbol({ tokenType, chain: destChain }),
-    ),
-  )
-  return [...symbols].join(' / ')
+  return config.targetTokenSymbol ?? DEFAULT_TARGET_TOKEN_SYMBOL
 }


### PR DESCRIPTION
Closes [FS-2505](https://linear.app/offchain-labs/issue/FS-2505/empty-targettokensymbol-produces-inconsistent-destination-token)

### Summary

This PR fixes `targetTokenSymbol` in `SmartRoutingAddressConfig`. When omitted it now defaults to `USDC` instead of displaying all tokens

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
