### PR TITLE
fix(sra): update transaction progress live

### DIFF
--- a/apps/sra-demo/src/app/components/MockPanel.tsx
+++ b/apps/sra-demo/src/app/components/MockPanel.tsx
@@ -79,9 +79,8 @@ export function MockPanel({
   const address =
     addressState.status === 'success' ? addressState.address : undefined
   const pastedOk =
-    // `strict: false` — the mock deliberately flips the returned address's
-    // EIP-55 checksum so real wallets refuse to send to it (see `mock.ts`
-    // `toFakeAddress`). Validate the format only and compare case-insensitively.
+    // Compare case-insensitively so pastes from mixed-case sources still
+    // match. `strict: false` accepts either form.
     isAddress(pasted.trim(), { strict: false }) &&
     !!address &&
     pasted.trim().toLowerCase() === address.toLowerCase()
@@ -155,13 +154,13 @@ export function MockPanel({
           </span>
 
           {/* Demo-only warning — matches the reference's `pg__warn` banner.
-              Reads as a red-tinted callout so users understand the address
-              can't accept real funds. */}
+              Red-tinted callout: the simulated demo returns a real SRA
+              address (server passthrough), so real funds sent to it would
+              route. Only status updates below are mocked. */}
           <p className="mt-2 rounded-lg border border-danger/35 bg-danger/10 px-3 py-2.5 text-xs leading-[1.5] text-ink">
-            <b className="text-danger">Demo only.</b> The generated address has
-            an intentionally invalid checksum, so real wallets refuse it — it
-            can't receive real funds. Never send real assets to it; use the
-            simulated wallet below.
+            <b className="text-danger">Demo only.</b> This is a real deposit
+            address — the demo only mocks the status updates below. Never send
+            real assets to it; use the simulated wallet to preview the flow.
           </p>
 
           {/* Warm gradient + peach border + orange-tinted shadow — matches

--- a/apps/sra-demo/src/app/page.tsx
+++ b/apps/sra-demo/src/app/page.tsx
@@ -52,7 +52,10 @@ export default function Home() {
     SIMULATED_DEFAULT_RECIPIENT,
   )
   const [targetChainId, setTargetChainId] = useState<number>(arbitrum.id)
-  const [slippage, setSlippage] = useState<number>(50)
+  // `undefined` = don't send `slippage` to the widget/SDK, so the SRA server
+  // uses its own default. Tight client-set values (e.g. 50 bps) massively
+  // inflate `minDeposit` since the server computes it as ~fee / slippage.
+  const [slippage, setSlippage] = useState<number | undefined>(undefined)
   // Bumped by `MockControls` after inserting/clearing mock deposits or
   // toggling error/sponsored modes — re-mounts the widget so freshly-added
   // deposits re-baseline as past and new mock state takes effect.
@@ -70,7 +73,9 @@ export default function Home() {
     SIMULATED_DEFAULT_RECIPIENT,
   )
   const [draftChain, setDraftChain] = useState<number>(targetChainId)
-  const [draftSlippage, setDraftSlippage] = useState<number>(slippage)
+  const [draftSlippage, setDraftSlippage] = useState<number | undefined>(
+    slippage,
+  )
 
   // Mock lifecycle owned at page level so the toggle can flip it cleanly.
   // Simulated → install the fetch interceptor + seed past-deposits from
@@ -117,8 +122,12 @@ export default function Home() {
   }
 
   const config = useMemo<SmartRoutingAddressConfig>(
-    // targetTokenSymbol defaults to 'USDC' when omitted.
-    () => ({ targetChainId, slippage }),
+    // Omit `slippage` when unset so the server picks its default — sending
+    // a tight value (e.g. 50 bps) blows up `minDeposit`.
+    () => ({
+      targetChainId,
+      ...(slippage !== undefined && { slippage }),
+    }),
     [targetChainId, slippage],
   )
 
@@ -135,13 +144,12 @@ export default function Home() {
         </div>
       )}
 
-      {/* Key on recipient+chain+slippage+mode so the whole SRA subtree resets
-          (including provider state) when the user regenerates or flips modes —
-          otherwise stale addresses can persist across config changes. */}
-      <SmartRoutingAddressProvider
-        key={`${mode}-${recipient}-${targetChainId}-${slippage}-${mockNonce}`}
-        config={config}
-      >
+      {/* Remount only on the two axes where re-instantiating the widget is
+          the goal: switching mock lifecycle (`mode`) and the mock-controls
+          reset (`mockNonce`). Recipient / chain / slippage flow through as
+          `config` prop updates — the provider refetches internally, so the
+          picker's token/chain selection survives "Save & regenerate". */}
+      <SmartRoutingAddressProvider key={`${mode}-${mockNonce}`} config={config}>
         {/* Grid uses an arbitrary breakpoint of 900px — Tailwind's default
             `md` (768) is too eager and `lg` (1024) too late for this
             two-column ↔ stacked flip. */}
@@ -308,21 +316,39 @@ export default function Home() {
                   <span className="flex items-baseline justify-between text-sm font-semibold">
                     Max slippage
                     <span className="text-muted tabular-nums">
-                      {(draftSlippage / 100).toFixed(2)}%
+                      {draftSlippage === undefined
+                        ? 'Server default'
+                        : `${(draftSlippage / 100).toFixed(2)}%`}
                     </span>
                   </span>
-                  <input
-                    type="range"
-                    min={10}
-                    max={300}
-                    step={10}
-                    value={draftSlippage}
-                    onChange={(e) => setDraftSlippage(Number(e.target.value))}
-                    className="w-full accent-ink"
-                  />
+                  <span className="flex items-center gap-2 text-[13px] text-muted">
+                    <input
+                      type="checkbox"
+                      checked={draftSlippage !== undefined}
+                      onChange={(e) =>
+                        setDraftSlippage(e.target.checked ? 100 : undefined)
+                      }
+                      className="accent-ink"
+                    />
+                    Override server default
+                  </span>
+                  {draftSlippage !== undefined && (
+                    <input
+                      type="range"
+                      min={50}
+                      max={500}
+                      step={10}
+                      value={draftSlippage}
+                      onChange={(e) => setDraftSlippage(Number(e.target.value))}
+                      className="w-full accent-ink"
+                    />
+                  )}
                   <span className="text-[13px] text-muted">
-                    Max price movement tolerated while swapping. Lower protects
-                    the price but raises the minimum deposit; higher lowers it.
+                    Max price movement tolerated while swapping. A tighter value
+                    protects the price but raises the minimum deposit, and can
+                    make it fluctuate significantly with gas. Leaving it on{' '}
+                    <b>Server default</b> keeps the minimum deposit at the
+                    lowest.
                   </span>
                 </label>
 

--- a/packages/smart-routing-address-react-ui/src/components/PendingDeposits/index.tsx
+++ b/packages/smart-routing-address-react-ui/src/components/PendingDeposits/index.tsx
@@ -87,7 +87,13 @@ export function PendingDeposits({
             : undefined
           const sourceChainLogo = CHAIN_ICONS[chainId]
 
-          const destSymbol = getDestTokenSymbol(config)
+          // Dest symbol mirrors this row's source (widget's default actions
+          // forward the deposited token). Consumer overrides via
+          // `config.targetTokenSymbol` still win.
+          const destSymbol = getDestTokenSymbol(
+            config,
+            sourceSymbol || undefined,
+          )
           const destTokenLogo = destSymbol
             ? TOKEN_ICONS[destSymbol.toUpperCase()]
             : undefined

--- a/packages/smart-routing-address-react-ui/src/constants.ts
+++ b/packages/smart-routing-address-react-ui/src/constants.ts
@@ -67,11 +67,25 @@ export const CHAINS_BY_ID: ReadonlyMap<number, Chain> = new Map(
 )
 
 /**
- * Source tokens offered for deposits: every
- * supported mainnet token the SDK exposes (NATIVE plus each ERC-20, with
- * wrapped native surfaced as WETH), mapped to its viem chain object. Testnets
- * are excluded from the default; chains this package cannot resolve to a viem
- * chain are skipped.
+ * Token types the SDK ships in `SUPPORTED_TOKENS` but the SRA server does not
+ * yet recognize. Sending one of these as a source token makes the server
+ * reject the whole `createSmartRoutingAddress` request with
+ * `Invalid params: Token address … is not supported on chain N`, which breaks
+ * the entire destination (e.g. Base). Remove entries here as the server
+ * registry catches up.
+ *
+ * TODO: file/track ZeroDev SRA server bug for EURC on Base
+ * (chain 8453, address 0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42) — once the
+ * server accepts it, drop this filter.
+ */
+const UNSUPPORTED_TOKEN_TYPES: ReadonlySet<TOKEN_TYPE> = new Set(['EURC'])
+
+/**
+ * Source tokens offered for deposits: every supported mainnet token the SDK
+ * exposes (NATIVE plus each ERC-20, with wrapped native surfaced as WETH),
+ * mapped to its viem chain object. Testnets are excluded from the default;
+ * chains this package cannot resolve to a viem chain are skipped, and token
+ * types the server can't route yet are filtered via `UNSUPPORTED_TOKEN_TYPES`.
  */
 export const DEFAULT_SOURCE_TOKENS: SourceToken[] = Object.entries(
   SUPPORTED_TOKENS,
@@ -79,8 +93,10 @@ export const DEFAULT_SOURCE_TOKENS: SourceToken[] = Object.entries(
   // Skip chains this package cannot resolve to a viem chain object
   const chain = CHAINS_BY_ID.get(Number(chainId))
   if (!chain) return []
-  return Object.keys(tokens).map((tokenType) => ({
-    chain,
-    tokenType: tokenType as TOKEN_TYPE,
-  }))
+  return Object.keys(tokens)
+    .filter((t) => !UNSUPPORTED_TOKEN_TYPES.has(t as TOKEN_TYPE))
+    .map((tokenType) => ({
+      chain,
+      tokenType: tokenType as TOKEN_TYPE,
+    }))
 })

--- a/packages/smart-routing-address-react-ui/src/pages/Deposit.tsx
+++ b/packages/smart-routing-address-react-ui/src/pages/Deposit.tsx
@@ -144,8 +144,8 @@ export function Deposit({
   const pastDepositsCount = deposits.length - newDeposits.length
 
   const destChain = resolveDestChain(config)
-  const destSymbol = getDestTokenSymbol(config)
   const sourceSymbol = source ? getSourceTokenSymbol(source) : undefined
+  const destSymbol = getDestTokenSymbol(config, sourceSymbol)
   const sourceTokenLogo = sourceSymbol
     ? TOKEN_ICONS[sourceSymbol.toUpperCase()]
     : undefined

--- a/packages/smart-routing-address-react-ui/src/pages/PastDeposits.tsx
+++ b/packages/smart-routing-address-react-ui/src/pages/PastDeposits.tsx
@@ -98,10 +98,6 @@ export function PastDeposits({ onSelectDeposit }: PastDepositsProps) {
 
   const destChain = resolveDestChain(config)
   const destChainLogo = CHAIN_ICONS[destChain.id]
-  const destSymbol = getDestTokenSymbol(config)
-  const destTokenLogo = destSymbol
-    ? TOKEN_ICONS[destSymbol.toUpperCase()]
-    : undefined
 
   const groups = useMemo(
     () => groupByDay(deposits as DepositWithTimestamp[]),
@@ -168,6 +164,16 @@ export function PastDeposits({ onSelectDeposit }: PastDepositsProps) {
                       ? TOKEN_ICONS[sourceSymbol.toUpperCase()]
                       : undefined
                     const sourceChainLogo = CHAIN_ICONS[chainId]
+                    // Dest symbol mirrors this row's source (widget's default
+                    // actions forward the deposited token). Consumer overrides
+                    // via `config.targetTokenSymbol` still win.
+                    const destSymbol = getDestTokenSymbol(
+                      config,
+                      sourceSymbol || undefined,
+                    )
+                    const destTokenLogo = destSymbol
+                      ? TOKEN_ICONS[destSymbol.toUpperCase()]
+                      : undefined
                     const amountLabel = feeData
                       ? `${formatDisplayAmount(amount, feeData.decimal, 'down')} ${sourceSymbol}`
                       : String(amount)

--- a/packages/smart-routing-address-react-ui/src/pages/TransactionDetails.tsx
+++ b/packages/smart-routing-address-react-ui/src/pages/TransactionDetails.tsx
@@ -12,6 +12,7 @@ import { type ReactNode, useState } from 'react'
 import { FeeBreakdownRows, FeeSummary } from '../components/FeeBreakdown'
 import { FEE_INFO } from '../components/FeeBreakdown/feeInfo'
 import { useSmartRoutingAddressContext } from '../context/SmartRoutingAddressContext'
+import { useDepositStatus } from '../hooks/useDepositStatus'
 import { useProviderFees } from '../hooks/useProviderFees'
 import { CHAIN_ICONS, PROVIDER_ICONS, TOKEN_ICONS } from '../iconAssets'
 import type { DepositWithTimestamp } from '../types'
@@ -19,7 +20,9 @@ import { getTxUrl } from '../utils/chains'
 import {
   getDestTokenSymbol,
   getSourceTokenSymbol,
+  resolveBaseUrl,
   resolveDestChain,
+  resolvePollingInterval,
   sourceTokensFromFees,
 } from '../utils/config'
 import { getDepositStage } from '../utils/deposits'
@@ -29,6 +32,29 @@ import { buildFeeBreakdown } from '../utils/providerFees'
 
 export interface TransactionDetailsProps {
   deposit: DepositWithTimestamp
+}
+
+/**
+ * Poll the deposits list and return the latest snapshot of the deposit
+ * matching `initial.deposit.transactionHash`, falling back to `initial` until
+ * the first response lands (or if the deposit falls out of the list). Keeps
+ * the details view live while the same interval is already running in
+ * `Deposit` / `PastDeposits`.
+ */
+function useLiveDeposit(initial: DepositWithTimestamp): DepositWithTimestamp {
+  const { config, addressState } = useSmartRoutingAddressContext()
+  const address =
+    addressState.status === 'success' ? addressState.address : undefined
+  const { deposits } = useDepositStatus({
+    address,
+    pollingInterval: resolvePollingInterval(config),
+    baseUrl: resolveBaseUrl(config),
+  })
+  const targetHash = initial.deposit.transactionHash
+  const live = deposits.find((d) => d.deposit.transactionHash === targetHash) as
+    | DepositWithTimestamp
+    | undefined
+  return live ?? initial
 }
 
 /** DOM id shared by the fee-toggle button's `aria-controls` and the panel it
@@ -53,7 +79,13 @@ function formatDate(iso?: string): string | null {
  * `ArrowCardPair` + `InfoCard`, a "Transaction details" `Section` with the
  * route metadata, and a "Transaction Progress" `Section` with the step trail.
  */
-export function TransactionDetails({ deposit }: TransactionDetailsProps) {
+export function TransactionDetails({
+  deposit: initialDeposit,
+}: TransactionDetailsProps) {
+  // Re-poll and pick the latest snapshot for this deposit so the details view
+  // — Transaction Progress in particular — updates live rather than staying
+  // frozen at click-time state.
+  const deposit = useLiveDeposit(initialDeposit)
   const { config, addressState, recipient } = useSmartRoutingAddressContext()
   const estimatedFees =
     addressState.status === 'success' ? addressState.estimatedFees : []

--- a/packages/smart-routing-address-react-ui/src/pages/TransactionDetails.tsx
+++ b/packages/smart-routing-address-react-ui/src/pages/TransactionDetails.tsx
@@ -110,7 +110,7 @@ export function TransactionDetails({
   const sourceChainLogo = CHAIN_ICONS[chainId]
 
   const destChain = resolveDestChain(config)
-  const destSymbol = getDestTokenSymbol(config)
+  const destSymbol = getDestTokenSymbol(config, sourceSymbol || undefined)
   const destTokenLogo = destSymbol
     ? TOKEN_ICONS[destSymbol.toUpperCase()]
     : undefined

--- a/packages/smart-routing-address-react-ui/src/utils/config.test.ts
+++ b/packages/smart-routing-address-react-ui/src/utils/config.test.ts
@@ -147,7 +147,8 @@ describe('resolveSourceTokens', () => {
 describe('resolveActions', () => {
   it('builds an action per default token type', () => {
     // WBTC is excluded because base has no WBTC token address; wrapped
-    // native is surfaced as WETH
+    // native is surfaced as WETH. EURC is excluded via
+    // `UNSUPPORTED_TOKEN_TYPES` because the SRA server rejects it.
     const actions = resolveActions(BARE_CONFIG, OWNER)
     expect(Object.keys(actions ?? {})).toEqual([
       'NATIVE',
@@ -155,7 +156,6 @@ describe('resolveActions', () => {
       'WETH',
       'USDT',
       'DAI',
-      'EURC',
     ])
   })
 
@@ -190,14 +190,19 @@ describe('token symbols', () => {
     ).toBe('WETH')
   })
 
-  it('returns the configured target token', () => {
+  it('prefers the explicit target token when configured', () => {
     expect(
-      getDestTokenSymbol({ ...BARE_CONFIG, targetTokenSymbol: 'ETH' }),
-    ).toBe('ETH')
+      getDestTokenSymbol({ ...BARE_CONFIG, targetTokenSymbol: 'USDC' }, 'ETH'),
+    ).toBe('USDC')
   })
 
-  it("defaults to 'USDC' when targetTokenSymbol is omitted", () => {
+  it('falls back to the source symbol when targetTokenSymbol is unset', () => {
     const { targetTokenSymbol: _drop, ...withoutSymbol } = BARE_CONFIG
-    expect(getDestTokenSymbol(withoutSymbol)).toBe('USDC')
+    expect(getDestTokenSymbol(withoutSymbol, 'ETH')).toBe('ETH')
+  })
+
+  it('returns undefined when neither target nor source is provided', () => {
+    const { targetTokenSymbol: _drop, ...withoutSymbol } = BARE_CONFIG
+    expect(getDestTokenSymbol(withoutSymbol)).toBeUndefined()
   })
 })

--- a/packages/smart-routing-address-react-ui/src/utils/config.ts
+++ b/packages/smart-routing-address-react-ui/src/utils/config.ts
@@ -161,16 +161,19 @@ export function getSourceTokenSymbol(source: SourceToken): string {
   return source.tokenType
 }
 
-/** Default destination-token symbol when the consumer doesn't set one — the
- * most common SRA settlement asset by a wide margin. */
-const DEFAULT_TARGET_TOKEN_SYMBOL = 'USDC'
-
 /**
- * Display symbol for the token received on the target chain. The settlement
- * token is fixed by configuration (`targetTokenSymbol`) — it is the single
- * asset the funds are swapped/bridged into, regardless of what the user sends.
- * Falls back to `'USDC'` when unset.
+ * Display symbol for the token received on the target chain.
+ *
+ * Priority: (1) explicit `config.targetTokenSymbol` — a consumer that swaps
+ * to a fixed settlement asset in their `actions` config should set this so
+ * the label reflects what actually lands. (2) `sourceSymbol` — the widget's
+ * default `resolveActions` forwards the deposited token, so when no override
+ * is set the destination symbol mirrors the source. (3) `undefined` — no
+ * lie, no fallback; callers already handle a missing symbol gracefully.
  */
-export function getDestTokenSymbol(config: SmartRoutingAddressConfig): string {
-  return config.targetTokenSymbol ?? DEFAULT_TARGET_TOKEN_SYMBOL
+export function getDestTokenSymbol(
+  config: SmartRoutingAddressConfig,
+  sourceSymbol?: string,
+): string | undefined {
+  return config.targetTokenSymbol ?? sourceSymbol
 }


### PR DESCRIPTION
Closes [FS-2522](https://linear.app/offchain-labs/issue/FS-2522/live-transaction-progress-on-transactiondetails-page)

### Summary

- This PR updates transaction progress live, instead of having to re-navigate to the screen
- Lets destination token match the source token when `targetTokenSymbol` is not set

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
