### PR TITLE
demo(sra): UX enhancements

### DIFF
--- a/apps/sra-demo/src/app/components/MockControls.tsx
+++ b/apps/sra-demo/src/app/components/MockControls.tsx
@@ -88,17 +88,14 @@ export function MockControls({
   // `pg__dev` panel; visually distinguishes the developer controls from the
   // wallet card above without being obtrusive.
   return (
-    <details
-      className="group mt-2 overflow-hidden rounded-xl border border-[rgba(242,108,26,0.28)] bg-[rgba(255,250,245,0.6)]"
-      open
-    >
+    <details className="group mt-2 overflow-hidden rounded-xl border border-[rgba(242,108,26,0.28)] bg-[rgba(255,250,245,0.6)]">
       <summary className="flex cursor-pointer items-center gap-2 px-4 py-[13px] text-sm font-semibold text-ink group-open:border-b group-open:border-border-warm">
         Mock controls
         <span className="rounded-full bg-[rgba(242,108,26,0.15)] px-2 py-[3px] text-[11px] font-bold uppercase tracking-[0.04em] text-primary">
           Active
         </span>
-        <span className="ml-auto text-lg text-muted transition-transform duration-150 group-open:rotate-180">
-          ▾
+        <span className="ml-auto text-lg text-muted transition-transform duration-150 group-open:rotate-90">
+          ›
         </span>
       </summary>
 

--- a/apps/sra-demo/src/app/components/MockPanel.tsx
+++ b/apps/sra-demo/src/app/components/MockPanel.tsx
@@ -247,9 +247,9 @@ export function MockPanel({
             Try modifying the experience
           </span>
           <span className="text-sm leading-[1.5] text-muted">
-            Open <b>Advanced settings</b> below to change the max slippage or
-            destination chain, then use the mock controls to preview how the
-            widget handles errors, sponsored fees and past deposits.
+            Adjust the max slippage or destination chain in <b>Settings</b>{' '}
+            below, then open <b>Mock controls</b> to preview how the widget
+            handles errors, sponsored fees and past deposits.
           </span>
           <MockControls
             destChainId={destChainId}

--- a/apps/sra-demo/src/app/page.tsx
+++ b/apps/sra-demo/src/app/page.tsx
@@ -4,6 +4,7 @@ import {
   SmartRoutingAddress,
   type SmartRoutingAddressConfig,
   SmartRoutingAddressProvider,
+  useSmartRoutingAddress,
 } from '@zerodev/smart-routing-address-react-ui'
 import { useEffect, useMemo, useState } from 'react'
 import type { Chain } from 'viem'
@@ -25,7 +26,7 @@ import {
 const SIMULATED_DEFAULT_RECIPIENT: Address =
   '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
 
-// Destination chains offered in the "Advanced settings" configurator.
+// Destination chains offered in the "Settings" configurator.
 const CHAINS: Chain[] = [arbitrum, base, optimism, polygon, mainnet]
 
 /** Demo run mode. In `simulated` the mock fetch layer intercepts every SRA
@@ -42,6 +43,10 @@ export default function Home() {
   // Run mode drives every safety-relevant behaviour below (mock fetch
   // install, default recipient, whether the widget renders at all).
   const [mode, setMode] = useState<DemoMode>('simulated')
+  // Whether the SRA widget is mounted. TopNav's `X` sets this to false;
+  // the "+ Fund" button reopens it. Mirrors the auth demo's pattern of
+  // dismissable card + explicit re-open trigger.
+  const [sraOpen, setSraOpen] = useState(true)
 
   // Applied config drives the widget. Draft state below is edited freely and
   // only applied (regenerating the routing address) when "Save & regenerate"
@@ -51,6 +56,11 @@ export default function Home() {
   const [recipient, setRecipient] = useState<Address | ''>(
     SIMULATED_DEFAULT_RECIPIENT,
   )
+  // Remembers the last address the user typed in mainnet mode so switching
+  // simulated → mainnet doesn't force them to re-enter it. Reset only on
+  // page refresh. `null` until the user commits a mainnet recipient.
+  const [lastMainnetRecipient, setLastMainnetRecipient] =
+    useState<Address | null>(null)
   const [targetChainId, setTargetChainId] = useState<number>(arbitrum.id)
   // `undefined` = don't send `slippage` to the widget/SDK, so the SRA server
   // uses its own default. Tight client-set values (e.g. 50 bps) massively
@@ -90,6 +100,23 @@ export default function Home() {
     }
   }, [mode])
 
+  // Persist the mode across page refreshes so a mainnet session stays on
+  // mainnet after reload. Restored on mount via `switchMode` (not a raw
+  // setMode) so the recipient / draft resets happen too — that keeps the
+  // mainnet safety default (empty recipient) intact after refresh.
+  useEffect(() => {
+    const stored = localStorage.getItem('sra-demo-mode')
+    if (stored === 'mainnet' || stored === 'simulated') {
+      switchMode(stored)
+    }
+    // Intentionally mount-only: further mode changes are persisted by the
+    // effect below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+  useEffect(() => {
+    localStorage.setItem('sra-demo-mode', mode)
+  }, [mode])
+
   // Reset recipient defaults when the run mode changes. Simulated re-seeds
   // Vitalik's address so the widget works without input; mainnet clears the
   // recipient so the user MUST enter their own address before a real deposit
@@ -97,12 +124,17 @@ export default function Home() {
   const switchMode = (next: DemoMode) => {
     if (next === mode) return
     setMode(next)
+    // Fresh mode = fresh session, so the widget always re-opens.
+    setSraOpen(true)
     if (next === 'simulated') {
       setRecipient(SIMULATED_DEFAULT_RECIPIENT)
       setDraftRecipient(SIMULATED_DEFAULT_RECIPIENT)
     } else {
-      setRecipient('')
-      setDraftRecipient('')
+      // Restore the last mainnet address the user committed this session
+      // so they don't have to re-enter it after visiting simulated mode.
+      const restored = lastMainnetRecipient ?? ''
+      setRecipient(restored)
+      setDraftRecipient(restored)
     }
   }
 
@@ -116,7 +148,10 @@ export default function Home() {
 
   const save = () => {
     if (!draftValid) return
-    setRecipient(draftRecipient as Address)
+    const next = draftRecipient as Address
+    setRecipient(next)
+    // Snapshot the mainnet recipient so it survives a simulated round trip.
+    if (mode === 'mainnet') setLastMainnetRecipient(next)
     setTargetChainId(draftChain)
     setSlippage(draftSlippage)
   }
@@ -150,6 +185,7 @@ export default function Home() {
           `config` prop updates — the provider refetches internally, so the
           picker's token/chain selection survives "Save & regenerate". */}
       <SmartRoutingAddressProvider key={`${mode}-${mockNonce}`} config={config}>
+        {mode === 'simulated' && <SimulatedCopyGuard />}
         {/* Grid uses an arbitrary breakpoint of 900px — Tailwind's default
             `md` (768) is too eager and `lg` (1024) too late for this
             two-column ↔ stacked flip. */}
@@ -242,8 +278,8 @@ export default function Home() {
                 </p>
                 <ol className="m-0 ml-4 flex list-decimal flex-col gap-1 text-sm leading-[1.5] text-ink">
                   <li>
-                    Open <b>Advanced settings</b> below and set{' '}
-                    <b>Delivery address</b> to your own address.
+                    Open <b>Settings</b> below and set <b>Delivery address</b>{' '}
+                    to your own address.
                   </li>
                   <li>
                     Click <b>Save &amp; regenerate address</b>.
@@ -260,9 +296,12 @@ export default function Home() {
             {/* `group` lets the summary chevron rotate on `[open]` via the
                 `group-open:` variant. `<details>` list styles + webkit marker
                 are neutralised globally in `globals.css`. */}
-            <details className="group overflow-hidden rounded-2xl border border-border-warm bg-white/55">
+            <details
+              open
+              className="group overflow-hidden rounded-2xl border border-border-warm bg-white/55"
+            >
               <summary className="flex cursor-pointer items-center justify-between px-5 py-4 text-sm font-semibold">
-                Advanced settings
+                Settings
                 <span className="text-lg text-muted transition-transform duration-150 group-open:rotate-90">
                   ›
                 </span>
@@ -295,17 +334,28 @@ export default function Home() {
                   <span className="flex items-baseline justify-between text-sm font-semibold">
                     Destination chain
                   </span>
-                  <select
-                    value={draftChain}
-                    onChange={(e) => setDraftChain(Number(e.target.value))}
-                    className="rounded-lg border border-border-warm bg-white px-3.5 py-3 text-sm text-ink outline-primary"
-                  >
-                    {CHAINS.map((chain) => (
-                      <option key={chain.id} value={chain.id}>
-                        {chain.name}
-                      </option>
-                    ))}
-                  </select>
+                  {/* `appearance-none` strips the native OS dropdown arrow so
+                      the sibling `›` chevron below (rotated 90° to point down)
+                      matches the Settings / Mock controls summaries. */}
+                  <div className="relative">
+                    <select
+                      value={draftChain}
+                      onChange={(e) => setDraftChain(Number(e.target.value))}
+                      className="w-full appearance-none rounded-lg border border-border-warm bg-white px-3.5 py-3 pr-9 text-sm text-ink outline-primary"
+                    >
+                      {CHAINS.map((chain) => (
+                        <option key={chain.id} value={chain.id}>
+                          {chain.name}
+                        </option>
+                      ))}
+                    </select>
+                    <span
+                      className="pointer-events-none absolute right-3.5 top-1/2 -translate-y-1/2 rotate-90 text-lg text-muted"
+                      aria-hidden
+                    >
+                      ›
+                    </span>
+                  </div>
                   <span className="text-[13px] text-muted">
                     Where deposits settle, regardless of which chain the funds
                     are sent from.
@@ -383,26 +433,67 @@ export default function Home() {
           </section>
 
           <aside className="justify-self-center min-[900px]:justify-self-end">
-            {recipientReady ? (
+            {!sraOpen ? (
+              // Widget dismissed via TopNav's X — surface an explicit
+              // re-open trigger so the user can bring it back without a
+              // full page reload. Mirrors the "Reconnect" pattern in
+              // zerodev-signer-demo after logout: the outer wrapper
+              // preserves the SRA card's footprint so the surrounding
+              // layout doesn't reflow when the widget is closed.
+              <div className="flex h-[810px] w-[400px] max-w-full items-center justify-center">
+                <button
+                  type="button"
+                  onClick={() => setSraOpen(true)}
+                  className="cursor-pointer rounded-3xl bg-ink px-8 py-4 text-body1 font-semibold text-white hover:bg-[#2a1c13]"
+                >
+                  + Fund
+                </button>
+              </div>
+            ) : recipientReady ? (
               <SmartRoutingAddress
                 recipient={recipient as Address}
-                onClose={() => {
-                  /* no-op — this demo has nowhere to navigate to */
-                }}
+                onClose={() => setSraOpen(false)}
                 onHelp={() => {
                   /* no-op — surfaces the ? icon in TopNav's left slot */
                 }}
               />
             ) : (
-              // Mainnet mode without a recipient — refuse to render the
-              // widget so we can't accidentally generate a real deposit
-              // address bound to an empty / dummy recipient.
-              <div className="flex h-[600px] w-[400px] max-w-full items-center justify-center rounded-4xl border border-border-warm bg-white/55 p-8">
-                <p className="text-center text-sm text-muted">
-                  Enter a delivery address in{' '}
-                  <b className="text-ink">Advanced settings</b> to generate your
-                  deposit address.
-                </p>
+              // Mainnet mode without a recipient — inline entry point so the
+              // user can seed the address here without opening Settings.
+              // Shares `draftRecipient` state with the Settings panel so both
+              // stay in sync; saving here is equivalent to Save & regenerate.
+              <div className="flex h-[600px] w-[400px] max-w-full flex-col items-center justify-center gap-4 rounded-4xl border border-border-warm bg-white/55 p-8">
+                <div className="flex flex-col items-center gap-1 text-center">
+                  <span className="text-[15px] font-semibold text-ink">
+                    Enter a delivery address
+                  </span>
+                  <span className="text-sm text-muted">
+                    Funds routed via this widget will land here.
+                  </span>
+                </div>
+                <input
+                  value={draftRecipient}
+                  onChange={(e) => setDraftRecipient(e.target.value.trim())}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && draftValid) save()
+                  }}
+                  placeholder="0x…"
+                  spellCheck={false}
+                  className="w-full rounded-xl border border-border-warm bg-white px-3.5 py-2.5 font-mono text-[13px] text-ink outline-none focus:border-ink"
+                />
+                {showError && (
+                  <span className="text-xs text-danger">
+                    That doesn't look like a valid address.
+                  </span>
+                )}
+                <button
+                  type="button"
+                  onClick={save}
+                  disabled={!draftValid}
+                  className="w-full cursor-pointer rounded-xl bg-ink px-[18px] py-[13px] text-[15px] font-semibold text-white transition-opacity duration-150 hover:not-disabled:bg-[#2a1d12] disabled:cursor-not-allowed disabled:opacity-45"
+                >
+                  Generate deposit address
+                </button>
               </div>
             )}
           </aside>
@@ -410,4 +501,53 @@ export default function Home() {
       </SmartRoutingAddressProvider>
     </main>
   )
+}
+
+/**
+ * Simulated-mode safety net: whenever the user copies the deposit address,
+ * pop a browser alert reminding them not to send real funds. Covers both
+ * copy paths — text-selection (Cmd+C) via a document `copy` listener, and
+ * the QR sheet's button (which calls `navigator.clipboard.writeText`
+ * directly) via a wrapper that restores on unmount.
+ */
+function SimulatedCopyGuard() {
+  const { addressState } = useSmartRoutingAddress()
+  const address =
+    addressState.status === 'success' ? addressState.address : undefined
+
+  useEffect(() => {
+    if (!address) return
+    const addrLower = address.toLowerCase()
+    const WARNING =
+      'This is a simulated-mode deposit address. Do not send real funds to it — status updates are mocked. Use the simulated wallet in the demo to preview the flow.'
+
+    const looksLikeThisAddress = (text: string) =>
+      text.toLowerCase().includes(addrLower)
+
+    const onCopy = (e: ClipboardEvent) => {
+      const text =
+        e.clipboardData?.getData('text') ??
+        window.getSelection()?.toString() ??
+        ''
+      if (text && looksLikeThisAddress(text)) window.alert(WARNING)
+    }
+    document.addEventListener('copy', onCopy)
+
+    const original = navigator.clipboard?.writeText?.bind(navigator.clipboard)
+    if (original) {
+      navigator.clipboard.writeText = async (text: string) => {
+        if (typeof text === 'string' && looksLikeThisAddress(text)) {
+          window.alert(WARNING)
+        }
+        return original(text)
+      }
+    }
+
+    return () => {
+      document.removeEventListener('copy', onCopy)
+      if (original) navigator.clipboard.writeText = original
+    }
+  }, [address])
+
+  return null
 }

--- a/packages/smart-routing-address-react-ui/src/components/PendingDeposits/PendingDeposits.stories.tsx
+++ b/packages/smart-routing-address-react-ui/src/components/PendingDeposits/PendingDeposits.stories.tsx
@@ -7,7 +7,6 @@ import { PendingDeposits } from './index'
 
 const config: SmartRoutingAddressConfig = {
   targetChainId: arbitrum.id,
-  targetTokenSymbol: 'USDC',
   slippage: 50,
 }
 

--- a/packages/smart-routing-address-react-ui/src/components/PendingDeposits/PendingDeposits.test.tsx
+++ b/packages/smart-routing-address-react-ui/src/components/PendingDeposits/PendingDeposits.test.tsx
@@ -12,7 +12,6 @@ afterEach(cleanup)
 
 const config: SmartRoutingAddressConfig = {
   targetChainId: arbitrum.id,
-  targetTokenSymbol: 'USDC',
   slippage: 50,
 }
 

--- a/packages/smart-routing-address-react-ui/src/components/PendingDeposits/index.tsx
+++ b/packages/smart-routing-address-react-ui/src/components/PendingDeposits/index.tsx
@@ -8,7 +8,6 @@ import type {
   SmartRoutingAddressConfig,
 } from '../../types'
 import {
-  getDestTokenSymbol,
   getSourceTokenSymbol,
   resolveDestChain,
   sourceTokensFromFees,
@@ -87,16 +86,9 @@ export function PendingDeposits({
             : undefined
           const sourceChainLogo = CHAIN_ICONS[chainId]
 
-          // Dest symbol mirrors this row's source (widget's default actions
-          // forward the deposited token). Consumer overrides via
-          // `config.targetTokenSymbol` still win.
-          const destSymbol = getDestTokenSymbol(
-            config,
-            sourceSymbol || undefined,
-          )
-          const destTokenLogo = destSymbol
-            ? TOKEN_ICONS[destSymbol.toUpperCase()]
-            : undefined
+          // Destination token equals source token — widget's default
+          // actions forward the deposited asset unchanged.
+          const destTokenLogo = sourceTokenLogo
 
           const status = STAGE_TO_STATUS[getDepositStage(deposit)]
           const amountLabel = feeData

--- a/packages/smart-routing-address-react-ui/src/pages/Deposit.tsx
+++ b/packages/smart-routing-address-react-ui/src/pages/Deposit.tsx
@@ -227,8 +227,10 @@ export function Deposit({
     return out
   }, [srcTokens, selectedTokenType])
 
+  // Only formatted when the consumer explicitly sets a slippage — otherwise
+  // the server picks its own default and there is no meaningful value to show.
   const slippage =
-    typeof config.slippage === 'number' ? formatSlippage(config.slippage) : '—'
+    typeof config.slippage === 'number' ? formatSlippage(config.slippage) : null
 
   const minDepositAmount =
     feeData && sourceSymbol
@@ -382,36 +384,38 @@ export function Deposit({
                 }
               />
               <div className="zd:flex zd:w-full zd:flex-col zd:items-start zd:gap-2 zd:px-2 zd:py-4">
-                <DataRow
-                  label="Max slippage"
-                  value={slippage}
-                  info
-                  infoTooltip={FEE_INFO.maxSlippage}
-                  trailing={
-                    breakdown?.provider &&
-                    PROVIDER_ICONS[breakdown.provider] ? (
-                      <LiveValue
-                        loading={providerFees.loading}
-                        flashKey={breakdown.provider}
-                      >
-                        <Tooltip content={`Quoted via ${breakdown.provider}`}>
-                          <button
-                            type="button"
-                            aria-label={`Quoted via ${breakdown.provider}`}
-                            className="zd:inline-flex zd:items-center zd:justify-center zd:cursor-help zd:outline-none zd:bg-transparent"
-                          >
-                            <img
-                              src={PROVIDER_ICONS[breakdown.provider]}
-                              alt=""
-                              aria-hidden
-                              className="zd:size-4 zd:shrink-0 zd:rounded-[4px] zd:object-cover"
-                            />
-                          </button>
-                        </Tooltip>
-                      </LiveValue>
-                    ) : null
-                  }
-                />
+                {slippage && (
+                  <DataRow
+                    label="Max slippage"
+                    value={slippage}
+                    info
+                    infoTooltip={FEE_INFO.maxSlippage}
+                    trailing={
+                      breakdown?.provider &&
+                      PROVIDER_ICONS[breakdown.provider] ? (
+                        <LiveValue
+                          loading={providerFees.loading}
+                          flashKey={breakdown.provider}
+                        >
+                          <Tooltip content={`Quoted via ${breakdown.provider}`}>
+                            <button
+                              type="button"
+                              aria-label={`Quoted via ${breakdown.provider}`}
+                              className="zd:inline-flex zd:items-center zd:justify-center zd:cursor-help zd:outline-none zd:bg-transparent"
+                            >
+                              <img
+                                src={PROVIDER_ICONS[breakdown.provider]}
+                                alt=""
+                                aria-hidden
+                                className="zd:size-4 zd:shrink-0 zd:rounded-[4px] zd:object-cover"
+                              />
+                            </button>
+                          </Tooltip>
+                        </LiveValue>
+                      ) : null
+                    }
+                  />
+                )}
                 <DataRow
                   label="Estimated fee"
                   value={

--- a/packages/smart-routing-address-react-ui/src/pages/Deposit.tsx
+++ b/packages/smart-routing-address-react-ui/src/pages/Deposit.tsx
@@ -33,7 +33,6 @@ import { useProviderFees } from '../hooks/useProviderFees'
 import { CHAIN_ICONS, PROVIDER_ICONS, TOKEN_ICONS } from '../iconAssets'
 import type { SourceToken } from '../types'
 import {
-  getDestTokenSymbol,
   getSourceTokenSymbol,
   resolveBaseUrl,
   resolveDestChain,
@@ -145,14 +144,13 @@ export function Deposit({
 
   const destChain = resolveDestChain(config)
   const sourceSymbol = source ? getSourceTokenSymbol(source) : undefined
-  const destSymbol = getDestTokenSymbol(config, sourceSymbol)
   const sourceTokenLogo = sourceSymbol
     ? TOKEN_ICONS[sourceSymbol.toUpperCase()]
     : undefined
   const sourceChainLogo = source ? CHAIN_ICONS[source.chain.id] : undefined
-  const destTokenLogo = destSymbol
-    ? TOKEN_ICONS[destSymbol.toUpperCase()]
-    : undefined
+  // Widget's default actions forward the deposited token, so the destination
+  // token equals the source token — same symbol, same logo.
+  const destTokenLogo = sourceTokenLogo
   const destChainLogo = CHAIN_ICONS[destChain.id]
   const feeData = source
     ? findFeeData(estimatedFees, source.chain.id, source.tokenType)
@@ -468,10 +466,10 @@ export function Deposit({
               <PillRow
                 left={
                   <Pill
-                    label={destSymbol ?? ''}
+                    label={sourceSymbol ?? ''}
                     {...(destTokenLogo && { logoUri: destTokenLogo })}
                     disabled
-                    loading={!destSymbol}
+                    loading={!sourceSymbol}
                   />
                 }
                 right={

--- a/packages/smart-routing-address-react-ui/src/pages/Deposit.tsx
+++ b/packages/smart-routing-address-react-ui/src/pages/Deposit.tsx
@@ -143,14 +143,14 @@ export function Deposit({
   const pastDepositsCount = deposits.length - newDeposits.length
 
   const destChain = resolveDestChain(config)
-  const sourceSymbol = source ? getSourceTokenSymbol(source) : undefined
-  const sourceTokenLogo = sourceSymbol
-    ? TOKEN_ICONS[sourceSymbol.toUpperCase()]
+  // Widget's default actions forward the deposited token, so the destination
+  // token equals the source token — one symbol and logo serve both cards.
+  // Only the chain differs, hence the source/dest split below.
+  const tokenSymbol = source ? getSourceTokenSymbol(source) : undefined
+  const tokenLogo = tokenSymbol
+    ? TOKEN_ICONS[tokenSymbol.toUpperCase()]
     : undefined
   const sourceChainLogo = source ? CHAIN_ICONS[source.chain.id] : undefined
-  // Widget's default actions forward the deposited token, so the destination
-  // token equals the source token — same symbol, same logo.
-  const destTokenLogo = sourceTokenLogo
   const destChainLogo = CHAIN_ICONS[destChain.id]
   const feeData = source
     ? findFeeData(estimatedFees, source.chain.id, source.tokenType)
@@ -163,15 +163,15 @@ export function Deposit({
   // Enriches the SRA fee estimate with the itemised legs it doesn't expose.
   const providerFees = useProviderFees(source, destChain, feeData, recipient)
   const breakdown =
-    feeData && sourceSymbol
-      ? buildFeeBreakdown(feeData, sourceSymbol, providerFees.fees)
+    feeData && tokenSymbol
+      ? buildFeeBreakdown(feeData, tokenSymbol, providerFees.fees)
       : null
 
   // Publish the current picker selection so hosts (e.g. a demo "send" panel)
   // can mirror the widget's route. Cleared when the picker is empty so
   // downstream mocks show their fallback instead of stale state.
   useEffect(() => {
-    if (!source || !feeData || !sourceSymbol) {
+    if (!source || !feeData || !tokenSymbol) {
       setActiveRoute(null)
       return
     }
@@ -184,7 +184,7 @@ export function Deposit({
       sourceChainId: source.chain.id,
       sourceChainName: source.chain.name,
       token,
-      symbol: sourceSymbol,
+      symbol: tokenSymbol,
       decimals: feeData.decimal,
       // `feeData.fee` is a `Hex` string from the SDK — normalise to a
       // decimal atomic-units string here so `activeRoute.feeAmount` has
@@ -194,7 +194,7 @@ export function Deposit({
       // `parseInt(x, 10)` would silently misread the hex form.
       feeAmount: BigInt(feeData.fee).toString(),
     })
-  }, [source, feeData, sourceSymbol, setActiveRoute])
+  }, [source, feeData, tokenSymbol, setActiveRoute])
 
   // Deduped list of routable token types — the token picker's rows. Chain
   // count per token drives the subtitle. Kept as SourceToken (not a bespoke
@@ -231,8 +231,8 @@ export function Deposit({
     typeof config.slippage === 'number' ? formatSlippage(config.slippage) : null
 
   const minDepositAmount =
-    feeData && sourceSymbol
-      ? `${formatDisplayAmount(feeData.minDeposit, feeData.decimal, 'up')} ${sourceSymbol}`
+    feeData && tokenSymbol
+      ? `${formatDisplayAmount(feeData.minDeposit, feeData.decimal, 'up')} ${tokenSymbol}`
       : null
 
   // Flash key re-triggers the LiveValue animation on the estimated-fee row
@@ -305,10 +305,10 @@ export function Deposit({
                   >
                     <SelectTrigger asChild>
                       <Pill
-                        label={sourceSymbol ?? ''}
-                        {...(sourceTokenLogo && { logoUri: sourceTokenLogo })}
+                        label={tokenSymbol ?? ''}
+                        {...(tokenLogo && { logoUri: tokenLogo })}
                         disabled={pickerDisabled}
-                        loading={!sourceSymbol}
+                        loading={!tokenSymbol}
                         trailingIcon={!pickerDisabled && <SelectIcon />}
                       />
                     </SelectTrigger>
@@ -466,10 +466,10 @@ export function Deposit({
               <PillRow
                 left={
                   <Pill
-                    label={sourceSymbol ?? ''}
-                    {...(destTokenLogo && { logoUri: destTokenLogo })}
+                    label={tokenSymbol ?? ''}
+                    {...(tokenLogo && { logoUri: tokenLogo })}
                     disabled
-                    loading={!sourceSymbol}
+                    loading={!tokenSymbol}
                   />
                 }
                 right={

--- a/packages/smart-routing-address-react-ui/src/pages/PastDeposits.tsx
+++ b/packages/smart-routing-address-react-ui/src/pages/PastDeposits.tsx
@@ -7,7 +7,6 @@ import { useDepositStatus } from '../hooks/useDepositStatus'
 import { CHAIN_ICONS, TOKEN_ICONS } from '../iconAssets'
 import type { DepositStage, DepositWithTimestamp } from '../types'
 import {
-  getDestTokenSymbol,
   getSourceTokenSymbol,
   resolveBaseUrl,
   resolveDestChain,
@@ -164,16 +163,9 @@ export function PastDeposits({ onSelectDeposit }: PastDepositsProps) {
                       ? TOKEN_ICONS[sourceSymbol.toUpperCase()]
                       : undefined
                     const sourceChainLogo = CHAIN_ICONS[chainId]
-                    // Dest symbol mirrors this row's source (widget's default
-                    // actions forward the deposited token). Consumer overrides
-                    // via `config.targetTokenSymbol` still win.
-                    const destSymbol = getDestTokenSymbol(
-                      config,
-                      sourceSymbol || undefined,
-                    )
-                    const destTokenLogo = destSymbol
-                      ? TOKEN_ICONS[destSymbol.toUpperCase()]
-                      : undefined
+                    // Destination token equals source token — widget's default
+                    // actions forward the deposited asset unchanged.
+                    const destTokenLogo = sourceTokenLogo
                     const amountLabel = feeData
                       ? `${formatDisplayAmount(amount, feeData.decimal, 'down')} ${sourceSymbol}`
                       : String(amount)

--- a/packages/smart-routing-address-react-ui/src/pages/TransactionDetails.tsx
+++ b/packages/smart-routing-address-react-ui/src/pages/TransactionDetails.tsx
@@ -18,7 +18,6 @@ import { CHAIN_ICONS, PROVIDER_ICONS, TOKEN_ICONS } from '../iconAssets'
 import type { DepositWithTimestamp } from '../types'
 import { getTxUrl } from '../utils/chains'
 import {
-  getDestTokenSymbol,
   getSourceTokenSymbol,
   resolveBaseUrl,
   resolveDestChain,
@@ -110,10 +109,9 @@ export function TransactionDetails({
   const sourceChainLogo = CHAIN_ICONS[chainId]
 
   const destChain = resolveDestChain(config)
-  const destSymbol = getDestTokenSymbol(config, sourceSymbol || undefined)
-  const destTokenLogo = destSymbol
-    ? TOKEN_ICONS[destSymbol.toUpperCase()]
-    : undefined
+  // Widget's default actions forward the deposited token, so destination
+  // token = source token — reuse the source logo.
+  const destTokenLogo = sourceTokenLogo
   const destChainLogo = CHAIN_ICONS[destChain.id]
 
   const stage = getDepositStage(deposit)
@@ -139,7 +137,7 @@ export function TransactionDetails({
   // this as "how much I received", so rounding to 250.00 is intuitive.
   const destHeadline =
     outAmountRaw && feeData
-      ? `${formatDisplayAmount(outAmountRaw, feeData.decimal, 'nearest')} ${destSymbol}`
+      ? `${formatDisplayAmount(outAmountRaw, feeData.decimal, 'nearest')} ${sourceSymbol}`
       : '—'
 
   // `getTxUrl` looks up the chain independently of whether `source` was

--- a/packages/smart-routing-address-react-ui/src/test/fixtures.ts
+++ b/packages/smart-routing-address-react-ui/src/test/fixtures.ts
@@ -18,7 +18,6 @@ export const TEST_PROJECT_ID = 'test-project-id'
 export const TEST_CONFIG: SmartRoutingAddressConfig = {
   projectId: TEST_PROJECT_ID,
   targetChainId: base.id,
-  targetTokenSymbol: 'USDC',
   slippage: 50,
   pollingInterval: 25,
 }

--- a/packages/smart-routing-address-react-ui/src/types.ts
+++ b/packages/smart-routing-address-react-ui/src/types.ts
@@ -33,13 +33,6 @@ export type SmartRoutingAddressConfig = {
   projectId?: string
   /** Chain id where funds settle */
   targetChainId: number
-  /**
-   * Display symbol for the token received on the target chain (e.g. `"USDC"`).
-   * Fixed by the configured actions — the single asset all deposits swap /
-   * bridge into, regardless of what the user sends. Defaults to `"USDC"`
-   * when omitted.
-   */
-  targetTokenSymbol?: string
   /** Smart routing address version, defaults to the latest stable */
   version?: SmartRoutingAddressVersion
   /**

--- a/packages/smart-routing-address-react-ui/src/utils/config.test.ts
+++ b/packages/smart-routing-address-react-ui/src/utils/config.test.ts
@@ -14,7 +14,6 @@ import {
 } from '../test/fixtures'
 import type { SmartRoutingAddressConfig } from '../types'
 import {
-  getDestTokenSymbol,
   getSourceTokenSymbol,
   resolveActions,
   resolveBaseUrl,
@@ -28,7 +27,6 @@ import {
 /** Minimal config without routes, exercising the defaults */
 const BARE_CONFIG: SmartRoutingAddressConfig = {
   targetChainId: base.id,
-  targetTokenSymbol: 'USDC',
 }
 
 describe('resolveVersion', () => {
@@ -135,10 +133,7 @@ describe('resolveSourceTokens', () => {
 
   it('keeps only stables for a destination chain without native support', () => {
     // bsc only maps USDC/USDT and is not in NATIVE_TOKENS_SUPPORTED
-    const sources = resolveSourceTokens({
-      targetChainId: bsc.id,
-      targetTokenSymbol: 'USDC',
-    })
+    const sources = resolveSourceTokens({ targetChainId: bsc.id })
     const tokenTypes = new Set(sources.map((source) => source.tokenType))
     expect([...tokenTypes].sort()).toEqual(['USDC', 'USDT'])
   })
@@ -188,21 +183,5 @@ describe('token symbols', () => {
         chain: optimism,
       }),
     ).toBe('WETH')
-  })
-
-  it('prefers the explicit target token when configured', () => {
-    expect(
-      getDestTokenSymbol({ ...BARE_CONFIG, targetTokenSymbol: 'USDC' }, 'ETH'),
-    ).toBe('USDC')
-  })
-
-  it('falls back to the source symbol when targetTokenSymbol is unset', () => {
-    const { targetTokenSymbol: _drop, ...withoutSymbol } = BARE_CONFIG
-    expect(getDestTokenSymbol(withoutSymbol, 'ETH')).toBe('ETH')
-  })
-
-  it('returns undefined when neither target nor source is provided', () => {
-    const { targetTokenSymbol: _drop, ...withoutSymbol } = BARE_CONFIG
-    expect(getDestTokenSymbol(withoutSymbol)).toBeUndefined()
   })
 })

--- a/packages/smart-routing-address-react-ui/src/utils/config.ts
+++ b/packages/smart-routing-address-react-ui/src/utils/config.ts
@@ -160,20 +160,3 @@ export function getSourceTokenSymbol(source: SourceToken): string {
   }
   return source.tokenType
 }
-
-/**
- * Display symbol for the token received on the target chain.
- *
- * Priority: (1) explicit `config.targetTokenSymbol` — a consumer that swaps
- * to a fixed settlement asset in their `actions` config should set this so
- * the label reflects what actually lands. (2) `sourceSymbol` — the widget's
- * default `resolveActions` forwards the deposited token, so when no override
- * is set the destination symbol mirrors the source. (3) `undefined` — no
- * lie, no fallback; callers already handle a missing symbol gracefully.
- */
-export function getDestTokenSymbol(
-  config: SmartRoutingAddressConfig,
-  sourceSymbol?: string,
-): string | undefined {
-  return config.targetTokenSymbol ?? sourceSymbol
-}


### PR DESCRIPTION
Closes [FS-2544](https://linear.app/offchain-labs/issue/FS-2544/sra-demo-ux-enhancements)

### Summary

This PR adds some UX enhancements to SRA demo:

- When switching to Mainnet ask the your for delivery address directly insted of telling them to set it in settings
- Rename "Advanced Settings" to "Settings" and keep it expanded by default
- Hide "Max slippage" when slippage is not set
- Show window alert when copying SRA address in Simulated mode
- Make 'X' button on SRA component functional, and add "Fund" button to demo
- Keep the delivery address saved when switching between modes
- When refreshing the page while on Mainnet, go to Mainnet (but still ask for delivery address)

Also removes `targetTokenSymbol` prop. Destination token will match the source.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
