### PR TITLE
SRA: prepare package for release

### DIFF
--- a/.changeset/dull-falcons-cough.md
+++ b/.changeset/dull-falcons-cough.md
@@ -1,0 +1,32 @@
+---
+'@zerodev/wallet-react-ui': patch
+---
+
+feat: sign in with external wallets from the SignUp page
+
+New composable units on the `SignUp` compound. Connecting an external wallet
+makes it the active wagmi connection and closes the embedded-wallet flow.
+
+- `SignUp.Wallet` pins one wallet as its own row. `walletId` is the new
+  `WalletId` union (e.g. `'metamask'`): the row connects when a live connector
+  claims the wallet (browser extension or configured SDK connector, with an
+  INSTALLED badge for announced extensions) and links to the vendor's download
+  page otherwise.
+- `SignUp.InstalledWallets` auto-discovers announced (EIP-6963) extensions:
+  one badged row per wallet, nothing when none are installed.
+  `excludeWalletIds` hides wallets by guide id or rdns (dedupe against a
+  pinned `SignUp.Wallet` row); `maxWallets` caps the list (default 4, known
+  wallets ranked first).
+- `SignUp.MoreWallets` adds a row that opens an overlay sheet with the full
+  wallet grid — every known wallet plus any other live connector.
+- New exported type `WalletId`; `AuthMethod` gains `'external-wallet'`.
+
+```tsx
+<SignUp>
+  <SignUp.Email />
+  <SignUp.Divider />
+  <SignUp.Wallet walletId="metamask" />
+  <SignUp.InstalledWallets excludeWalletIds={['metamask']} />
+  <SignUp.MoreWallets />
+</SignUp>
+```

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ If you'd rather not build your own auth and signing UI, use
 React components (`<ConnectWallet />`, `<SignatureRequest />`) built on top of
 this SDK.
 
+To let users fund a wallet from any chain / any token, mount
+[@zerodev/smart-routing-address-react-ui](./packages/smart-routing-address-react-ui/README.md) —
+a `<SmartRoutingAddress />` widget that generates a single deposit address
+and routes across chains via Across / Relay.
+
 ## React Native
 
 The SDK runs in React Native (Expo) too. The connector setup is the same, but
@@ -338,12 +343,19 @@ zerodev-wallet-sdk/
 │   │   │   ├── native/    # React Native connector, OAuth & export WebView
 │   │   │   └── provider.ts  # EIP-1193 provider
 │   │   └── dist/          # Compiled output
-│   └── wallet-react-ui/         # Drop-in React UI components
+│   ├── wallet-react-ui/         # Drop-in React UI components
+│   │   ├── src/
+│   │   │   ├── auth/      # <ConnectWallet /> + auth pages and hooks
+│   │   │   ├── signing/   # <SignatureRequest /> + signing hooks
+│   │   │   ├── shared/    # Shared components and utilities
+│   │   │   └── connector.ts # Enhanced wagmi connector (zeroDevWallet)
+│   │   └── dist/          # Compiled output
+│   └── smart-routing-address-react-ui/  # Drop-in funding widget
 │       ├── src/
-│       │   ├── auth/      # <ConnectWallet /> + auth pages and hooks
-│       │   ├── signing/   # <SignatureRequest /> + signing hooks
-│       │   ├── shared/    # Shared components and utilities
-│       │   └── connector.ts # Enhanced wagmi connector (zeroDevWallet)
+│       │   ├── context/   # SmartRoutingAddressProvider
+│       │   ├── pages/     # <SmartRoutingAddress /> screens
+│       │   ├── components/ # QR sheet, deposit rows, fee breakdown, etc.
+│       │   └── hooks/     # useDepositStatus, useSmartRoutingAddress
 │       └── dist/          # Compiled output
 └── README.md
 ```
@@ -361,5 +373,6 @@ MIT
 ## Packages
 
 - **[@zerodev/wallet-react-ui](./packages/wallet-react-ui)** — Drop-in React UI components (`<ConnectWallet />`, `<SignatureRequest />`) and enhanced wagmi connector
+- **[@zerodev/smart-routing-address-react-ui](./packages/smart-routing-address-react-ui)** — Drop-in funding widget (`<SmartRoutingAddress />`) that generates a single deposit address routing any supported token/chain to a chosen destination
 - **[@zerodev/wallet-react](./packages/react)** — React hooks and Wagmi connector (recommended for React apps)
 - **[@zerodev/wallet-core](./packages/core)** — Core SDK (framework-agnostic)

--- a/apps/sra-demo/README.md
+++ b/apps/sra-demo/README.md
@@ -1,0 +1,53 @@
+# ZeroDev Smart Routing Address Demo
+
+A playground for the `@zerodev/smart-routing-address-react-ui` widget. Runs
+in two modes:
+
+- **Simulated** — every SRA server call is intercepted by an
+  in-memory mock, so you can exercise the full deposit lifecycle (routing,
+  fees, past deposits, error states) without any real network, funds, or
+  project ID. The banner and controls make this mode explicit.
+- **Mainnet** — the widget speaks to the live
+  SRA server. Real deposit addresses, real routing, real funds. The mode
+  toggle is persisted in `localStorage` and the recipient is cleared as a
+  safety default so you can't accidentally send funds to a stale address.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org) v18+
+- [pnpm](https://pnpm.io/)
+
+You'll need a [ZeroDev](https://dashboard.zerodev.app) account for a project
+ID if you plan to use Mainnet mode.
+
+## Installation
+
+From the repo root:
+
+```bash
+pnpm install
+```
+
+## Environment Configuration
+
+1. Copy the environment example file (if present) or create `.env`:
+
+```bash
+cp .env.example .env
+```
+
+2. Fill in the required values:
+
+```
+NEXT_PUBLIC_ZERODEV_PROJECT_ID=
+```
+
+## Running the Application
+
+1. Start the development server:
+
+```bash
+pnpm run dev
+```
+
+2. Open [http://localhost:3000](http://localhost:3000) in your browser.

--- a/packages/smart-routing-address-react-ui/CHANGELOG.md
+++ b/packages/smart-routing-address-react-ui/CHANGELOG.md
@@ -1,0 +1,28 @@
+# @zerodev/smart-routing-address-react-ui
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial public release. Ships the `SmartRoutingAddress` funding widget, the
+  `SmartRoutingAddressProvider` context, and the `useSmartRoutingAddress` /
+  `useDepositStatus` / `useNewDeposits` hooks — mount one component to give
+  users a single deposit address that routes any supported token from any
+  supported source chain into the recipient on the configured target chain,
+  with live fee quotes (Across / Relay), pending + past deposit lists, and
+  a per-deposit transaction-details view.
+
+  ```tsx
+  import {
+    SmartRoutingAddress,
+    SmartRoutingAddressProvider,
+  } from "@zerodev/smart-routing-address-react-ui";
+  import "@zerodev/smart-routing-address-react-ui/styles.css";
+  import { arbitrum } from "viem/chains";
+
+  <SmartRoutingAddressProvider
+    config={{ projectId: "…", targetChainId: arbitrum.id }}
+  >
+    <SmartRoutingAddress recipient={recipient} onClose={close} />
+  </SmartRoutingAddressProvider>;
+  ```

--- a/packages/smart-routing-address-react-ui/README.md
+++ b/packages/smart-routing-address-react-ui/README.md
@@ -1,0 +1,118 @@
+# @zerodev/smart-routing-address-react-ui
+
+React UI kit for [ZeroDev Smart Routing Address](https://docs.zerodev.app/) —
+a drop-in **funding widget** that generates a single deposit address, routes
+whatever the user sends across chains and tokens, and reports live status.
+
+Mount one component, get a full deposit-funding experience: token & source
+chain picker, QR + copy card, live fee breakdown, pending/past deposit lists,
+and a per-transaction details view. UI styling comes from
+[`@zerodev/react-ui`](../react-ui/README.md).
+
+## Installation
+
+```bash
+pnpm add @zerodev/smart-routing-address-react-ui \
+  @zerodev/smart-routing-address viem
+```
+
+> `@zerodev/smart-routing-address`, `react` (18 or 19), `react-dom`, and
+> `viem` are **peer dependencies** — install them alongside this package.
+
+## Setup
+
+### 1. Import the stylesheet once at app entry
+
+```tsx
+import '@zerodev/smart-routing-address-react-ui/styles.css'
+```
+
+### 2. Wrap the subtree in `SmartRoutingAddressProvider`
+
+The provider holds the config and lazily creates the smart routing address
+for a recipient. It doesn't render the widget — mount `<SmartRoutingAddress
+/>` inline where you want the UI.
+
+```tsx
+import {
+  SmartRoutingAddress,
+  SmartRoutingAddressProvider,
+} from '@zerodev/smart-routing-address-react-ui'
+import { arbitrum } from 'viem/chains'
+
+function Funding({ recipient }: { recipient: `0x${string}` }) {
+  return (
+    <SmartRoutingAddressProvider
+      config={{
+        projectId: 'your-project-id', // from https://dashboard.zerodev.app
+        targetChainId: arbitrum.id,
+      }}
+    >
+      <SmartRoutingAddress recipient={recipient} onClose={() => {}} />
+    </SmartRoutingAddressProvider>
+  )
+}
+```
+
+## Usage
+
+`<SmartRoutingAddress />` renders the current step (deposit, past deposits,
+or a single transaction's details) inside its own card frame. Navigation is
+owned by the widget; `onClose` fires when the top-right ✕ is tapped so the
+host app can dismiss.
+
+```tsx
+<SmartRoutingAddress
+  recipient={recipient}
+  onClose={() => setOpen(false)}
+  onHelp={() => window.open('https://your-docs.example', '_blank')}
+  size="lg" // 'sm' | 'md' | 'lg'
+/>
+```
+
+Address creation and deposit polling happen in the provider; the widget
+subscribes to state via `useSmartRoutingAddress()` / `useDepositStatus()` so
+host code can mirror the same data (e.g. show pending deposits elsewhere in
+the app).
+
+## Configuration
+
+Everything the widget needs is on the config passed to the provider.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `projectId` | `string?` | ZeroDev project id; appended to the SRA server URL. |
+| `targetChainId` | `number` | Chain id where funds settle. **Required.** |
+| `version` | `SmartRoutingAddressVersion?` | SRA manager version. Defaults to the latest stable. |
+| `actions` | `CreateSmartRoutingAddressParams['actions']?` | Destination actions per token type. When omitted, deposits are simply transferred to the recipient. |
+| `slippage` | `number?` | Max slippage in basis points (50 = 0.5%). When omitted, the SRA server picks its default. |
+| `baseUrl` | `string?` | Override the SRA server root URL; the `projectId` is appended. |
+| `pollingInterval` | `number?` | Deposit-status polling interval in ms (default 5000). |
+| `estimatedFillTimeSeconds` | `number \| Record<number, number>?` | Expected fill time, flat or per source chain id. |
+
+## API
+
+| Export | Description |
+| --- | --- |
+| `<SmartRoutingAddressProvider />` | Wraps the subtree; owns config, recipient, and the address lifecycle. |
+| `<SmartRoutingAddress />` | The funding widget UI. Props: `recipient`, `onClose`, `onHelp?`, `size?`, `className?`. |
+| `useSmartRoutingAddress()` | Read the current address state and active route from the provider. |
+| `useDepositStatus({ address })` | Poll the SRA status endpoint; returns `deposits`, `totalCount`, `hasLoaded`, `error`, `refetch`. |
+| `useNewDeposits(deposits, hasLoaded)` | Filter to deposits that arrived after mount. |
+
+### Types
+
+`SmartRoutingAddressConfig`, `SmartRoutingAddressProps`,
+`SmartRoutingAddressStep`, `SmartRoutingAddressProviderProps`,
+`UseDepositStatusParams`, `UseDepositStatusResult`,
+`UseSmartRoutingAddressResult`.
+
+## Development
+
+```bash
+pnpm build       # build the package (dist + types + css)
+pnpm dev         # watch mode (types)
+pnpm typecheck
+pnpm test        # vitest
+pnpm storybook   # component catalog
+```

--- a/packages/smart-routing-address-react-ui/package.json
+++ b/packages/smart-routing-address-react-ui/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@zerodev/smart-routing-address-react-ui",
   "version": "0.0.1",
-  "private": true,
   "description": "React hooks, provider, and UI for ZeroDev Smart Routing Address deposits",
   "repository": {
     "type": "git",

--- a/packages/smart-routing-address-react-ui/src/components/PendingDeposits/index.tsx
+++ b/packages/smart-routing-address-react-ui/src/components/PendingDeposits/index.tsx
@@ -7,6 +7,7 @@ import type {
   EstimatedFee,
   SmartRoutingAddressConfig,
 } from '../../types'
+import { getTxUrl } from '../../utils/chains'
 import {
   getSourceTokenSymbol,
   resolveDestChain,
@@ -80,7 +81,12 @@ export function PendingDeposits({
                 t.chain.id === chainId &&
                 tokenAddressMatches(t.tokenType, chainId, token),
             ) ?? null
-          const sourceSymbol = source ? getSourceTokenSymbol(source) : ''
+          // Prefer the reconstructed source's symbol; fall back to the
+          // server's `feeData.name` so past deposits whose route dropped
+          // out of the current fee estimates still get a symbol / icon.
+          const sourceSymbol = source
+            ? getSourceTokenSymbol(source)
+            : (feeData?.name ?? '')
           const sourceTokenLogo = sourceSymbol
             ? TOKEN_ICONS[sourceSymbol.toUpperCase()]
             : undefined
@@ -98,13 +104,9 @@ export function PendingDeposits({
             ? (formatRelativeTime(deposit.createdAt) ?? '')
             : ''
 
-          // Block-explorer URL for the source-chain deposit tx. viem's chain
-          // objects ship `blockExplorers.default.url`; fall through to
-          // omitting `href` when the chain doesn't advertise one.
-          const explorerBase = source?.chain.blockExplorers?.default?.url
-          const href = explorerBase
-            ? `${explorerBase}/tx/${transactionHash}`
-            : undefined
+          // Explorer URL from the chain id alone — independent of whether
+          // the deposit's token was matched in the current fee estimates.
+          const href = getTxUrl(chainId, transactionHash)
 
           const row = (
             <TxnItem

--- a/packages/smart-routing-address-react-ui/src/hooks/useProviderFees.ts
+++ b/packages/smart-routing-address-react-ui/src/hooks/useProviderFees.ts
@@ -177,6 +177,9 @@ export function useProviderFees(
     try {
       amount = BigInt(minDeposit).toString()
     } catch {
+      // Malformed `minDeposit` — nothing to quote. Clear loading so the
+      // caller doesn't sit in a spinner forever until the route changes.
+      setLoading(false)
       return
     }
 

--- a/packages/smart-routing-address-react-ui/src/pages/PastDeposits.tsx
+++ b/packages/smart-routing-address-react-ui/src/pages/PastDeposits.tsx
@@ -6,6 +6,7 @@ import { useSmartRoutingAddressContext } from '../context/SmartRoutingAddressCon
 import { useDepositStatus } from '../hooks/useDepositStatus'
 import { CHAIN_ICONS, TOKEN_ICONS } from '../iconAssets'
 import type { DepositStage, DepositWithTimestamp } from '../types'
+import { getTxUrl } from '../utils/chains'
 import {
   getSourceTokenSymbol,
   resolveBaseUrl,
@@ -156,9 +157,13 @@ export function PastDeposits({ onSelectDeposit }: PastDepositsProps) {
                           t.chain.id === chainId &&
                           tokenAddressMatches(t.tokenType, chainId, token),
                       ) ?? null
+                    // Prefer the reconstructed source's symbol; fall back to
+                    // the server's `feeData.name` so past deposits whose route
+                    // dropped out of the current fee estimates still get a
+                    // symbol / icon.
                     const sourceSymbol = source
                       ? getSourceTokenSymbol(source)
-                      : ''
+                      : (feeData?.name ?? '')
                     const sourceTokenLogo = sourceSymbol
                       ? TOKEN_ICONS[sourceSymbol.toUpperCase()]
                       : undefined
@@ -172,11 +177,9 @@ export function PastDeposits({ onSelectDeposit }: PastDepositsProps) {
                     const timestamp = deposit.createdAt
                       ? (formatRelativeTime(deposit.createdAt) ?? '')
                       : ''
-                    const explorerBase =
-                      source?.chain.blockExplorers?.default?.url
-                    const href = explorerBase
-                      ? `${explorerBase}/tx/${transactionHash}`
-                      : undefined
+                    // Explorer URL from the chain id alone — independent of
+                    // whether the deposit's token matched the current fees.
+                    const href = getTxUrl(chainId, transactionHash)
                     const status = STAGE_TO_STATUS[getDepositStage(deposit)]
 
                     const row = (

--- a/packages/smart-routing-address-react-ui/src/utils/providerFees.ts
+++ b/packages/smart-routing-address-react-ui/src/utils/providerFees.ts
@@ -1,7 +1,4 @@
 import { formatUnits } from 'viem'
-// `zod/mini` ships a tree-shakable, functional API (`z.optional(z.number())`
-// instead of `z.number().optional()`). Same runtime semantics, ~70% smaller
-// contribution to the widget bundle.
 import { z } from 'zod/mini'
 import type { EstimatedFeeData } from '../types'
 import { formatDisplayAmount, STABLE_SYMBOLS } from './format'

--- a/packages/smart-routing-address-react-ui/src/utils/providerFees.ts
+++ b/packages/smart-routing-address-react-ui/src/utils/providerFees.ts
@@ -1,5 +1,8 @@
 import { formatUnits } from 'viem'
-import { z } from 'zod'
+// `zod/mini` ships a tree-shakable, functional API (`z.optional(z.number())`
+// instead of `z.number().optional()`). Same runtime semantics, ~70% smaller
+// contribution to the widget bundle.
+import { z } from 'zod/mini'
 import type { EstimatedFeeData } from '../types'
 import { formatDisplayAmount, STABLE_SYMBOLS } from './format'
 
@@ -79,7 +82,7 @@ export const AcrossSuggestedFeesSchema = z.object({
   relayerCapitalFee: AcrossLegSchema,
   relayerGasFee: AcrossLegSchema,
   lpFee: AcrossLegSchema,
-  estimatedFillTimeSec: z.number().optional(),
+  estimatedFillTimeSec: z.optional(z.number()),
 })
 
 type AcrossLeg = z.infer<typeof AcrossLegSchema>
@@ -160,25 +163,25 @@ export function parseAcrossFees(
 // ---------------------------------------------------------------------------
 
 const RelayFeeSchema = z.object({
-  amountUsd: z.string().optional(),
+  amountUsd: z.optional(z.string()),
 })
 
 export const RelayQuoteSchema = z.object({
-  fees: z
-    .object({
-      gas: RelayFeeSchema.optional(),
-      relayer: RelayFeeSchema.optional(),
-      relayerGas: RelayFeeSchema.optional(),
-      relayerService: RelayFeeSchema.optional(),
-      app: RelayFeeSchema.optional(),
-    })
-    .optional(),
-  details: z
-    .object({
-      timeEstimate: z.number().optional(),
-    })
-    .optional(),
-  timeEstimate: z.number().optional(),
+  fees: z.optional(
+    z.object({
+      gas: z.optional(RelayFeeSchema),
+      relayer: z.optional(RelayFeeSchema),
+      relayerGas: z.optional(RelayFeeSchema),
+      relayerService: z.optional(RelayFeeSchema),
+      app: z.optional(RelayFeeSchema),
+    }),
+  ),
+  details: z.optional(
+    z.object({
+      timeEstimate: z.optional(z.number()),
+    }),
+  ),
+  timeEstimate: z.optional(z.number()),
 })
 
 type RelayFee = z.infer<typeof RelayFeeSchema>

--- a/packages/smart-routing-address-react-ui/tsconfig.build.json
+++ b/packages/smart-routing-address-react-ui/tsconfig.build.json
@@ -9,5 +9,13 @@
     "types": ["vite/client"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/test/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.tsx"
+  ]
 }

--- a/packages/smart-routing-address-react-ui/vite.config.ts
+++ b/packages/smart-routing-address-react-ui/vite.config.ts
@@ -19,7 +19,9 @@ export default defineConfig({
         'react/jsx-dev-runtime',
         '@zerodev/react-ui',
         '@zerodev/smart-routing-address',
-        'viem',
+        // Match `viem` and every subpath (`viem/chains`, `viem/utils`, etc.)
+        // — otherwise Rollup inlines `viem/chains`, ballooning the bundle.
+        /^viem(\/|$)/,
       ],
     },
     sourcemap: true,

--- a/packages/wallet-react-ui/CHANGELOG.md
+++ b/packages/wallet-react-ui/CHANGELOG.md
@@ -1,38 +1,5 @@
 # @zerodev/wallet-react-ui
 
-## 0.0.8
-
-### Patch Changes
-
-- 2b3d0e1: feat: sign in with external wallets from the SignUp page
-
-  New composable units on the `SignUp` compound. Connecting an external wallet
-  makes it the active wagmi connection and closes the embedded-wallet flow.
-
-  - `SignUp.Wallet` pins one wallet as its own row. `walletId` is the new
-    `WalletId` union (e.g. `'metamask'`): the row connects when a live connector
-    claims the wallet (browser extension or configured SDK connector, with an
-    INSTALLED badge for announced extensions) and links to the vendor's download
-    page otherwise.
-  - `SignUp.InstalledWallets` auto-discovers announced (EIP-6963) extensions:
-    one badged row per wallet, nothing when none are installed.
-    `excludeWalletIds` hides wallets by guide id or rdns (dedupe against a
-    pinned `SignUp.Wallet` row); `maxWallets` caps the list (default 4, known
-    wallets ranked first).
-  - `SignUp.MoreWallets` adds a row that opens an overlay sheet with the full
-    wallet grid — every known wallet plus any other live connector.
-  - New exported type `WalletId`; `AuthMethod` gains `'external-wallet'`.
-
-  ```tsx
-  <SignUp>
-    <SignUp.Email />
-    <SignUp.Divider />
-    <SignUp.Wallet walletId="metamask" />
-    <SignUp.InstalledWallets excludeWalletIds={["metamask"]} />
-    <SignUp.MoreWallets />
-  </SignUp>
-  ```
-
 ## 0.0.7
 
 ### Patch Changes

--- a/packages/wallet-react-ui/package.json
+++ b/packages/wallet-react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodev/wallet-react-ui",
-  "version": "0.0.8",
+  "version": "0.0.7",
   "description": "React wallet UI kit for ZeroDev (auth + signing flows)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Summary

This PR prepares the package for release:

- Adds README
- Exclude `**/*.stories.*` and `src/test/**`  in `tsconfig.build.json`
- Some optimizations to reduce bundle size

Fixes the following 2 bugs:

- `useProviderFees` doesn't set loading to false in the catch block. Could cause infinite load
- `PendingDeposits/index.tsx:78-109` - explorer link + token icon vanish whenever the deposited token isn't matched in resolved source tokens

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
