### PR TITLE
fix(react): reset wallet state across lifecycle changes

### DIFF
--- a/.changeset/safe-react-state.md
+++ b/.changeset/safe-react-state.md
@@ -1,0 +1,6 @@
+---
+'@zerodev/wallet-react': minor
+---
+
+Invalidate owner-sensitive account caches and recreate destroyed session
+providers across disconnect, logout, chain switching, and re-login.

--- a/packages/react/src/connector.test.ts
+++ b/packages/react/src/connector.test.ts
@@ -63,6 +63,15 @@ import { zeroDevWalletCore } from './core/connector.js'
 
 type ConnectorInstance = ReturnType<ReturnType<typeof zeroDevWalletCore>>
 
+function isRefreshProvider(value: unknown): value is { destroy: () => void } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'destroy' in value &&
+    typeof value.destroy === 'function'
+  )
+}
+
 function createConnector(mode?: 'EOA' | '4337' | '7702'): ConnectorInstance {
   const factory = zeroDevWalletCore({
     projectId: 'proj-test',
@@ -93,6 +102,17 @@ describe('zeroDevWallet connector — mode branching', () => {
   })
 
   describe('connect()', () => {
+    it('does not create a kernel account when Core has no live session', async () => {
+      const connector = createConnector()
+
+      await expect(connector.connect({ chainId: sepolia.id })).rejects.toThrow(
+        /not authenticated/i,
+      )
+
+      expect(createKernelAccountMock).not.toHaveBeenCalled()
+      expect(createKernelAccountClientMock).not.toHaveBeenCalled()
+    })
+
     it("default mode is '7702' (passes eip7702Account, no ECDSA plugin)", async () => {
       const connector = createConnector()
       await seedEoa(connector)
@@ -146,6 +166,39 @@ describe('zeroDevWallet connector — mode branching', () => {
         '0xcafecafecafecafecafecafecafecafecafecafe',
       ])
     })
+
+    it('retries the whole chain setup after client creation fails', async () => {
+      createKernelAccountClientMock.mockImplementationOnce(() => {
+        throw new Error('bundler client failed')
+      })
+      const connector = createConnector('4337')
+      await seedEoa(connector)
+
+      await expect(connector.connect({ chainId: sepolia.id })).rejects.toThrow(
+        'bundler client failed',
+      )
+      await connector.connect({ chainId: sepolia.id })
+
+      expect(createKernelAccountClientMock).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('switchChain()', () => {
+    it('does not persist an unsupported chain when setup fails', async () => {
+      const connector = createConnector('4337')
+      await seedEoa(connector)
+      // @ts-expect-error - getStore is added in the connector's Properties.
+      const store = await connector.getStore()
+      store.getState().setActiveChainId(sepolia.id)
+      const switchChain = connector.switchChain
+      if (!switchChain) throw new Error('Expected connector.switchChain')
+
+      await expect(switchChain({ chainId: 1 })).rejects.toThrow(
+        'Chain 1 not found in config',
+      )
+
+      await expect(connector.getChainId()).resolves.toBe(sepolia.id)
+    })
   })
 
   describe('getAccounts()', () => {
@@ -166,5 +219,34 @@ describe('zeroDevWallet connector — mode branching', () => {
       const accounts = await connector.getAccounts()
       expect(accounts).toEqual([])
     })
+  })
+
+  it('recreates the refresh provider after disconnect on the same page', async () => {
+    const connector = createConnector()
+    const firstProvider = await connector.getProvider()
+
+    await connector.disconnect()
+
+    const nextProvider = await connector.getProvider()
+    expect(nextProvider).not.toBe(firstProvider)
+  })
+
+  it('stops refresh but preserves retryable state when logout fails', async () => {
+    const connector = createConnector()
+    await seedEoa(connector)
+    // @ts-expect-error - getStore is added in the connector's Properties.
+    const store = await connector.getStore()
+    const wallet = store.getState().wallet
+    if (!wallet) throw new Error('Expected initialized wallet')
+    vi.mocked(wallet.logout).mockRejectedValueOnce(new Error('backend down'))
+    const provider = await connector.getProvider()
+    if (!isRefreshProvider(provider))
+      throw new Error('Expected refresh provider')
+    const destroy = vi.spyOn(provider, 'destroy')
+
+    await expect(connector.disconnect()).rejects.toThrow('backend down')
+
+    expect(destroy).toHaveBeenCalledOnce()
+    expect(store.getState().eoaAccount).toBe(mockEoaAccount)
   })
 })

--- a/packages/react/src/connector.test.ts
+++ b/packages/react/src/connector.test.ts
@@ -1,6 +1,6 @@
 import type { Config } from '@wagmi/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { sepolia } from 'wagmi/chains'
+import { mainnet, sepolia } from 'wagmi/chains'
 
 // SDK mocks — hoisted so they're defined before vi.mock() (which is itself
 // hoisted to the top of the file by vitest).
@@ -113,6 +113,50 @@ describe('zeroDevWallet connector — mode branching', () => {
       expect(createKernelAccountClientMock).not.toHaveBeenCalled()
     })
 
+    it('drops a stale rehydrated session when Core reports none', async () => {
+      // An older SDK version may have persisted a session into React storage.
+      // Core (mocked getSession → null) is the source of truth, so init must
+      // erase the rehydrated session while still honoring the chain preference.
+      const persistedStale = JSON.stringify({
+        state: {
+          activeChainId: sepolia.id,
+          session: {
+            id: 'stale-session',
+            userId: 'user-1',
+            organizationId: 'org-1',
+            stamperType: 'apiKey',
+            token: 'stale-jwt',
+            expiry: Date.now() + 60_000,
+            createdAt: Date.now(),
+          },
+        },
+        version: 0,
+      })
+      const persistStorage = {
+        getItem: vi.fn().mockReturnValue(persistedStale),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+      }
+      const factory = zeroDevWalletCore({
+        projectId: 'proj-test',
+        chains: [sepolia],
+        persistStorage: persistStorage as never,
+      })
+      const wagmiConfig = {
+        transports: {},
+        emitter: { emit: vi.fn() },
+        storage: null,
+      } as unknown as Config
+      const connector = factory(wagmiConfig as never) as ConnectorInstance
+
+      // @ts-expect-error - getStore is added in the connector's Properties.
+      const store = await connector.getStore()
+
+      expect(store.getState().session).toBeNull()
+      // Chain preference survives rehydration — proves the stale state loaded.
+      expect(store.getState().activeChainId).toBe(sepolia.id)
+    })
+
     it("default mode is '7702' (passes eip7702Account, no ECDSA plugin)", async () => {
       const connector = createConnector()
       await seedEoa(connector)
@@ -198,6 +242,38 @@ describe('zeroDevWallet connector — mode branching', () => {
       )
 
       await expect(connector.getChainId()).resolves.toBe(sepolia.id)
+    })
+
+    it('does not commit the new chain when its setup fails', async () => {
+      // The target chain IS in config, but building its client blows up. The
+      // active chain must stay on the previous one — no half-switched state.
+      createKernelAccountClientMock.mockImplementationOnce(() => {
+        throw new Error('chain setup failed')
+      })
+      const factory = zeroDevWalletCore({
+        projectId: 'proj-test',
+        chains: [sepolia, mainnet],
+        mode: '4337',
+      })
+      const wagmiConfig = {
+        transports: {},
+        emitter: { emit: vi.fn() },
+        storage: null,
+      } as unknown as Config
+      const connector = factory(wagmiConfig as never) as ConnectorInstance
+      await seedEoa(connector)
+      // @ts-expect-error - getStore is added in the connector's Properties.
+      const store = await connector.getStore()
+      store.getState().setActiveChainId(sepolia.id)
+      const switchChain = connector.switchChain
+      if (!switchChain) throw new Error('Expected connector.switchChain')
+
+      await expect(switchChain({ chainId: mainnet.id })).rejects.toThrow(
+        'chain setup failed',
+      )
+
+      await expect(connector.getChainId()).resolves.toBe(sepolia.id)
+      expect(store.getState().kernelAccounts.has(mainnet.id)).toBe(false)
     })
   })
 

--- a/packages/react/src/core/connector.ts
+++ b/packages/react/src/core/connector.ts
@@ -101,8 +101,14 @@ export function zeroDevWalletCore(
 
   return createConnector<Provider, Properties>((wagmiConfig) => {
     let store: ReturnType<typeof createZeroDevWalletStore>
-    let provider: ReturnType<typeof createProvider>
+    let provider: ReturnType<typeof createProvider> | undefined
     let initPromise: Promise<void> | null = null
+
+    const resetProvider = () => {
+      provider?.destroy()
+      provider = undefined
+      initPromise = null
+    }
 
     // Get transports from Wagmi config (uses user's RPC URLs)
     const transports = wagmiConfig.transports
@@ -172,7 +178,6 @@ export function zeroDevWalletCore(
               },
             }),
       })
-      store.getState().setKernelAccount(chainId, kernelAccount)
 
       const kernelClient = createKernelAccountClient({
         account: kernelAccount,
@@ -190,6 +195,7 @@ export function zeroDevWalletCore(
           ),
         }),
       })
+      store.getState().setKernelAccount(chainId, kernelAccount)
       store.getState().setKernelClient(chainId, kernelClient)
     }
 
@@ -209,10 +215,19 @@ export function zeroDevWalletCore(
       ? { fetchOptions: params.fetchOptions }
       : undefined
 
+    const switchActiveChain = async (chainId: number) => {
+      await setupChain(chainId, httpOpts)
+      store.getState().setActiveChainId(chainId)
+      wagmiConfig.emitter.emit('change', { chainId })
+    }
+
     // Lazy initialization - only runs on client side (idempotent)
     const initialize = async () => {
       if (initPromise) return initPromise
-      initPromise = doInitialize()
+      initPromise = doInitialize().catch((error) => {
+        initPromise = null
+        throw error
+      })
       return initPromise
     }
 
@@ -260,21 +275,24 @@ export function zeroDevWalletCore(
         projectId: params.projectId,
       })
 
-      // Create EIP-1193 provider
-      provider = createProvider({
-        store,
-        config: params,
-        chains: Array.from(params.chains),
-      })
-
       // Check for existing session (page reload)
       const session = await wallet.getSession()
       if (session) {
         console.log('Found existing session, restoring...')
         const eoaAccount = await wallet.toAccount()
         store.getState().setEoaAccount(eoaAccount)
-        store.getState().setSession(session)
       }
+      // Core is the source of truth. This explicitly erases any stale React
+      // session hydrated by an older SDK version when Core has no valid match.
+      store.getState().setSession(session ?? null)
+
+      // Start provider timers only after the validated Core session is loaded.
+      provider = createProvider({
+        store,
+        config: params,
+        chains: Array.from(params.chains),
+        switchChain: switchActiveChain,
+      })
 
       console.log('ZeroDevWallet connector initialized')
     }
@@ -360,9 +378,10 @@ export function zeroDevWalletCore(
         if (!store) return
         const wallet = store.getState().wallet
 
-        // Cleanup provider (clears timers)
-        provider?.destroy()
-
+        // Stop refresh immediately when the user asks to disconnect. If
+        // remote revocation fails, Core keeps the credentials for an explicit
+        // retry, but this dead provider cannot silently extend the session.
+        resetProvider()
         await wallet?.logout()
         store.getState().clear()
       },
@@ -396,6 +415,9 @@ export function zeroDevWalletCore(
 
       async getProvider() {
         await initialize()
+        if (!provider) {
+          throw new Error('ZeroDevWallet provider failed to initialize')
+        }
         return provider
       },
 
@@ -407,11 +429,12 @@ export function zeroDevWalletCore(
           throw new NotAuthenticatedError()
         }
 
-        store.getState().setActiveChainId(chainId)
-        await setupChain(chainId, httpOpts)
-
-        wagmiConfig.emitter.emit('change', { chainId })
-        return params.chains.find((c) => c.id === chainId)!
+        const chain = params.chains.find(
+          (candidate) => candidate.id === chainId,
+        )
+        if (!chain) throw new Error(`Chain ${chainId} not found in config`)
+        await switchActiveChain(chainId)
+        return chain
       },
 
       async isAuthorized() {
@@ -438,7 +461,7 @@ export function zeroDevWalletCore(
       },
       onDisconnect() {
         console.log('Disconnect event')
-        provider?.destroy()
+        resetProvider()
         store.getState().clear()
       },
     }

--- a/packages/react/src/getSessionIdWeb.ts
+++ b/packages/react/src/getSessionIdWeb.ts
@@ -14,6 +14,7 @@ function openOAuthPopup(url: string): Window | null {
   )
 
   if (authWindow) {
+    authWindow.opener = null
     authWindow.location.href = url
   }
 

--- a/packages/react/src/native/oauth/expoWebBrowser.test.ts
+++ b/packages/react/src/native/oauth/expoWebBrowser.test.ts
@@ -56,6 +56,25 @@ describe('createOAuthGetSessionIdWithExpoWebBrowser', () => {
     expect(h.remove).toHaveBeenCalledOnce()
   })
 
+  it('resolves with the session id from a matching deep link', async () => {
+    // The browser branch never settles, so the win must come from the
+    // expo-linking deep-link listener delivering a matching callback URL.
+    h.openAuthSessionAsync.mockReturnValueOnce(new Promise(() => {}))
+    const getSessionId = createOAuthGetSessionIdWithExpoWebBrowser({
+      redirectUri: 'myapp://oauth/callback',
+    })
+    const result = getSessionId({
+      oauthUrl: 'https://accounts.google.com/oauth',
+      provider: 'google',
+    })
+    h.listener?.({
+      url: 'myapp://oauth/callback?oauth_success=true&session_id=deeplinked',
+    })
+
+    await expect(result).resolves.toBe('deeplinked')
+    expect(h.remove).toHaveBeenCalledOnce()
+  })
+
   it('rejects a browser result from a different callback URL', async () => {
     h.openAuthSessionAsync.mockResolvedValueOnce({
       type: 'success',

--- a/packages/react/src/native/oauth/expoWebBrowser.test.ts
+++ b/packages/react/src/native/oauth/expoWebBrowser.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  listener: undefined as ((event: { url: string }) => void) | undefined,
+  remove: vi.fn(),
+  openAuthSessionAsync: vi.fn(),
+  dismissBrowser: vi.fn(),
+}))
+
+vi.mock('expo-linking', () => ({
+  addEventListener: vi.fn(
+    (_type: string, listener: (event: { url: string }) => void) => {
+      h.listener = listener
+      return { remove: h.remove }
+    },
+  ),
+}))
+
+vi.mock('expo-web-browser', () => ({
+  openAuthSessionAsync: h.openAuthSessionAsync,
+  dismissBrowser: h.dismissBrowser,
+}))
+
+import { createOAuthGetSessionIdWithExpoWebBrowser } from './expoWebBrowser.js'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.listener = undefined
+  h.dismissBrowser.mockResolvedValue(undefined)
+})
+
+describe('createOAuthGetSessionIdWithExpoWebBrowser', () => {
+  it('ignores unrelated deep links and accepts the exact configured callback', async () => {
+    let finishBrowser!: (result: { type: string; url: string }) => void
+    h.openAuthSessionAsync.mockReturnValueOnce(
+      new Promise((resolve) => {
+        finishBrowser = resolve
+      }),
+    )
+    const getSessionId = createOAuthGetSessionIdWithExpoWebBrowser({
+      redirectUri: 'myapp://oauth/callback',
+    })
+    const result = getSessionId({
+      oauthUrl: 'https://accounts.google.com/oauth',
+      provider: 'google',
+    })
+    h.listener?.({
+      url: 'myapp://other/callback?oauth_success=true&session_id=attacker',
+    })
+    finishBrowser({
+      type: 'success',
+      url: 'myapp://oauth/callback?oauth_success=true&session_id=valid',
+    })
+
+    await expect(result).resolves.toBe('valid')
+    expect(h.remove).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a browser result from a different callback URL', async () => {
+    h.openAuthSessionAsync.mockResolvedValueOnce({
+      type: 'success',
+      url: 'myapp://other/callback?oauth_success=true&session_id=attacker',
+    })
+    const getSessionId = createOAuthGetSessionIdWithExpoWebBrowser({
+      redirectUri: 'myapp://oauth/callback',
+    })
+
+    await expect(
+      getSessionId({
+        oauthUrl: 'https://accounts.google.com/oauth',
+        provider: 'google',
+      }),
+    ).rejects.toThrow(/did not match/)
+  })
+})

--- a/packages/react/src/native/oauth/expoWebBrowser.ts
+++ b/packages/react/src/native/oauth/expoWebBrowser.ts
@@ -2,6 +2,15 @@ import * as Linking from 'expo-linking'
 import * as WebBrowser from 'expo-web-browser'
 import type { GetOAuthSessionIdFn } from '../../authenticateOAuth.js'
 
+function isExpectedCallback(url: URL, redirectUri: string): boolean {
+  const expected = new URL(redirectUri)
+  return (
+    url.protocol === expected.protocol &&
+    url.host === expected.host &&
+    url.pathname === expected.pathname
+  )
+}
+
 /**
  * Races two observation primitives because iOS and Android deliver the
  * backend's OAuth redirect through different OS mechanisms:
@@ -16,31 +25,30 @@ export function createOAuthGetSessionIdWithExpoWebBrowser(params: {
   redirectUri: string
 }): GetOAuthSessionIdFn {
   return async ({ oauthUrl }) => {
-    // fromDeepLink is resolved from *outside* its executor — by the
-    // Linking listener below. new Promise's executor runs synchronously,
-    // so resolveLink/rejectLink point at this promise's resolvers by the
-    // next statement. The `!` tells TS to trust that definite assignment.
-    let resolveLink!: (sid: string) => void
-    let rejectLink!: (err: Error) => void
-    const fromDeepLink = new Promise<string>((res, rej) => {
-      resolveLink = res
-      rejectLink = rej
-    })
-
     // When the OS wakes the app with the callback URL, this fires.
     // We filter to our OAuth callbacks, extract session_id, and settle
-    // fromDeepLink via the captured resolver.
-    const sub = Linking.addEventListener('url', ({ url }) => {
-      const q = new URL(url).searchParams
-      const error = q.get('error')
-      if (error) {
-        rejectLink(new Error(error || 'OAuth authentication failed'))
-        return
-      }
-      if (q.get('oauth_success') !== 'true') return
-      const sid = q.get('session_id')
-      if (sid) resolveLink(sid)
-      else rejectLink(new Error('OAuth redirect missing session_id'))
+    // fromDeepLink with the promise's own resolver.
+    let sub: ReturnType<typeof Linking.addEventListener> | undefined
+    const fromDeepLink = new Promise<string>((resolve, reject) => {
+      sub = Linking.addEventListener('url', ({ url }) => {
+        let parsed: URL
+        try {
+          parsed = new URL(url)
+        } catch {
+          return
+        }
+        if (!isExpectedCallback(parsed, params.redirectUri)) return
+        const q = parsed.searchParams
+        const error = q.get('error')
+        if (error) {
+          reject(new Error(error || 'OAuth authentication failed'))
+          return
+        }
+        if (q.get('oauth_success') !== 'true') return
+        const sid = q.get('session_id')
+        if (sid) resolve(sid)
+        else reject(new Error('OAuth redirect missing session_id'))
+      })
     })
 
     // The other path: the auth browser session observes the redirect to
@@ -60,8 +68,14 @@ export function createOAuthGetSessionIdWithExpoWebBrowser(params: {
     ).then((r) => {
       if (r.type !== 'success') throw new Error('OAuth cancelled or failed')
       const parsed = new URL(r.url)
+      if (!isExpectedCallback(parsed, params.redirectUri)) {
+        throw new Error('OAuth callback URL did not match redirectUri')
+      }
       const error = parsed.searchParams.get('error')
       if (error) throw new Error(error || 'OAuth authentication failed')
+      if (parsed.searchParams.get('oauth_success') !== 'true') {
+        throw new Error('OAuth callback missing success marker')
+      }
       const sid = parsed.searchParams.get('session_id')
       if (!sid) throw new Error('OAuth redirect missing session_id')
       return sid
@@ -72,7 +86,7 @@ export function createOAuthGetSessionIdWithExpoWebBrowser(params: {
     } finally {
       // Drop the listener — a leaked subscription would fire on unrelated
       // deep links later in the app's lifetime.
-      sub.remove()
+      sub?.remove()
       // Close the auth tab if the deep-link branch settled the race — the
       // OS brought the app to foreground but left the Custom Tab in the
       // back stack. When fromBrowser already won, the auth session has

--- a/packages/react/src/provider.test.ts
+++ b/packages/react/src/provider.test.ts
@@ -414,6 +414,7 @@ describe('provider state safety', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_700_000_000_000)
     vi.spyOn(console, 'error').mockImplementation(() => {})
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
     const store = createZeroDevWalletStore()
     const session = {
       id: 'session-1',
@@ -442,6 +443,13 @@ describe('provider state safety', () => {
     expect(store.getState().session).toEqual(session)
     expect(store.getState().eoaAccount?.address).toBe(EOA_ADDRESS)
     expect(vi.getTimerCount()).toBeGreaterThan(0)
+    // The retry must land within the 5s cap, not just "some timer exists".
+    // The session has 30s left, so an uncapped retry would schedule 30_000ms.
+    const scheduledDelays = setTimeoutSpy.mock.calls
+      .map(([, delay]) => delay)
+      .filter((delay): delay is number => typeof delay === 'number')
+    expect(scheduledDelays.length).toBeGreaterThan(0)
+    expect(Math.max(...scheduledDelays)).toBeLessThanOrEqual(5_000)
     provider.destroy()
   })
 
@@ -545,6 +553,18 @@ describe('provider state safety', () => {
       provider.request({
         method: 'personal_sign',
         params: ['0x1234', '0x2222222222222222222222222222222222222222'],
+      }),
+    ).rejects.toThrow('Invalid from address')
+  })
+
+  it('rejects eth_signTypedData_v4 for an address other than the active owner', async () => {
+    const provider = createTestProvider('EOA')
+
+    await expect(
+      provider.request({
+        method: 'eth_signTypedData_v4',
+        // Typed-data params are [address, typedData] — address comes first.
+        params: ['0x2222222222222222222222222222222222222222', '{}'],
       }),
     ).rejects.toThrow('Invalid from address')
   })

--- a/packages/react/src/provider.test.ts
+++ b/packages/react/src/provider.test.ts
@@ -1,12 +1,13 @@
 import type { KernelAccountClient } from '@zerodev/sdk'
-import type { LocalAccount } from 'viem'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { privateKeyToAccount } from 'viem/accounts'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mainnet, sepolia } from 'wagmi/chains'
-import type { WalletMode } from './connector.js'
+import type { WalletMode } from './core/connector.js'
 import { createProvider } from './provider.js'
 import { createZeroDevWalletStore } from './store.js'
 
-const EOA_ADDRESS = '0xeoa000000000000000000000000000000000abcd'
+const EOA_ACCOUNT = privateKeyToAccount(`0x${'11'.repeat(32)}`)
+const EOA_ADDRESS = EOA_ACCOUNT.address
 
 const sendUserOperationMock = vi.fn()
 const getUserOperationReceiptMock = vi.fn()
@@ -19,7 +20,7 @@ const mockKernelClient = {
 function createTestProvider(mode?: WalletMode) {
   const store = createZeroDevWalletStore()
   store.getState().setActiveChainId(sepolia.id)
-  store.getState().setEoaAccount({ address: EOA_ADDRESS } as LocalAccount)
+  store.getState().setEoaAccount(EOA_ACCOUNT)
   store.getState().setKernelClient(sepolia.id, mockKernelClient)
 
   return createProvider({
@@ -36,6 +37,10 @@ function createTestProvider(mode?: WalletMode) {
 beforeEach(() => {
   sendUserOperationMock.mockReset()
   getUserOperationReceiptMock.mockReset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
 })
 
 describe('wallet_sendCalls', () => {
@@ -237,7 +242,7 @@ describe('wallet_getCallsStatus', () => {
     // status response must reflect the bundle's chain, not the active one.
     const store = createZeroDevWalletStore()
     store.getState().setActiveChainId(sepolia.id)
-    store.getState().setEoaAccount({ address: EOA_ADDRESS } as LocalAccount)
+    store.getState().setEoaAccount(EOA_ACCOUNT)
     store.getState().setKernelClient(mainnet.id, mockKernelClient)
     const provider = createProvider({
       store,
@@ -292,5 +297,255 @@ describe('wallet_getCapabilities', () => {
     })) as Record<string, { atomic: { status: string } }>
 
     expect(result['0xaa36a7'].atomic.status).toBe('unsupported')
+  })
+})
+
+describe('provider state safety', () => {
+  it('auto-refreshes a 15-minute session at the default one-minute threshold', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_700_000_000_000)
+    const store = createZeroDevWalletStore()
+    const wallet = {
+      refreshSession: vi.fn().mockReturnValue(new Promise(() => {})),
+    }
+    store.getState().setWallet(wallet as never)
+    store.getState().setSession({
+      id: 'fifteen-minute-session',
+      userId: 'user-1',
+      organizationId: 'org-1',
+      stamperType: 'apiKey',
+      token: 'jwt',
+      expiry: Date.now() + 15 * 60_000,
+      createdAt: Date.now(),
+    })
+
+    const provider = createProvider({
+      store,
+      config: { projectId: 'proj-test', chains: [sepolia] },
+      chains: [sepolia],
+    })
+    vi.advanceTimersByTime(14 * 60_000 - 1)
+    expect(wallet.refreshSession).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(wallet.refreshSession).toHaveBeenCalledOnce()
+    provider.destroy()
+  })
+
+  it('does not let an in-flight refresh restore a cleared session', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_700_000_000_000)
+    const store = createZeroDevWalletStore()
+    const session = {
+      id: 'session-1',
+      userId: 'user-1',
+      organizationId: 'org-1',
+      stamperType: 'apiKey' as const,
+      token: 'jwt',
+      expiry: Date.now() + 30_000,
+      createdAt: Date.now(),
+    }
+    const replacement = { ...session, id: 'session-2', token: 'new-jwt' }
+    let resolveRefresh = (_session: typeof replacement) => {}
+    const refresh = new Promise<typeof replacement>((resolve) => {
+      resolveRefresh = resolve
+    })
+    const wallet = { refreshSession: vi.fn().mockReturnValue(refresh) }
+    store.getState().setWallet(wallet as never)
+    store.getState().setSession(session)
+    store.getState().setEoaAccount(EOA_ACCOUNT)
+
+    const provider = createProvider({
+      store,
+      config: { projectId: 'proj-test', chains: [sepolia] },
+      chains: [sepolia],
+    })
+    await vi.waitFor(() => expect(wallet.refreshSession).toHaveBeenCalledOnce())
+
+    store.getState().clear()
+    resolveRefresh(replacement)
+    await refresh
+    await Promise.resolve()
+
+    expect(store.getState().session).toBeNull()
+    expect(store.getState().eoaAccount).toBeNull()
+    provider.destroy()
+  })
+
+  it('clears a session that expired while hidden without refreshing it', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_700_000_000_000)
+    const store = createZeroDevWalletStore()
+    const wallet = { refreshSession: vi.fn() }
+    store.getState().setWallet(wallet as never)
+    store.getState().setSession({
+      id: 'expired-in-background',
+      userId: 'user-1',
+      organizationId: 'org-1',
+      stamperType: 'apiKey',
+      token: 'jwt',
+      expiry: Date.now() + 120_000,
+      createdAt: Date.now(),
+    })
+    store.getState().setEoaAccount(EOA_ACCOUNT)
+    store
+      .getState()
+      .setKernelAccount(sepolia.id, { address: EOA_ADDRESS } as never)
+    store.getState().setKernelClient(sepolia.id, mockKernelClient)
+
+    const provider = createProvider({
+      store,
+      config: { projectId: 'proj-test', chains: [sepolia] },
+      chains: [sepolia],
+    })
+    vi.setSystemTime(Date.now() + 121_000)
+    expect(document.visibilityState).toBe('visible')
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    expect(wallet.refreshSession).not.toHaveBeenCalled()
+    expect(store.getState().session).toBeNull()
+    expect(store.getState().eoaAccount).toBeNull()
+    expect(store.getState().kernelAccounts.size).toBe(0)
+    expect(store.getState().kernelClients.size).toBe(0)
+    provider.destroy()
+  })
+
+  it('preserves a still-valid identity when auto-refresh fails transiently', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_700_000_000_000)
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const store = createZeroDevWalletStore()
+    const session = {
+      id: 'session-1',
+      userId: 'user-1',
+      organizationId: 'org-1',
+      stamperType: 'apiKey' as const,
+      token: 'jwt',
+      expiry: Date.now() + 30_000,
+      createdAt: Date.now(),
+    }
+    const wallet = {
+      refreshSession: vi.fn().mockRejectedValue(new Error('network down')),
+    }
+    store.getState().setWallet(wallet as never)
+    store.getState().setSession(session)
+    store.getState().setEoaAccount(EOA_ACCOUNT)
+
+    const provider = createProvider({
+      store,
+      config: { projectId: 'proj-test', chains: [sepolia] },
+      chains: [sepolia],
+    })
+    await vi.waitFor(() => expect(wallet.refreshSession).toHaveBeenCalledOnce())
+    await Promise.resolve()
+
+    expect(store.getState().session).toEqual(session)
+    expect(store.getState().eoaAccount?.address).toBe(EOA_ADDRESS)
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+    provider.destroy()
+  })
+
+  it('clears a session rejected during auto-refresh instead of retrying it', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_700_000_000_000)
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const store = createZeroDevWalletStore()
+    const wallet = {
+      refreshSession: vi.fn().mockRejectedValue({ status: 401 }),
+      logout: vi.fn().mockResolvedValue(true),
+    }
+    store.getState().setWallet(wallet as never)
+    store.getState().setSession({
+      id: 'rejected-session',
+      userId: 'user-1',
+      organizationId: 'org-1',
+      stamperType: 'apiKey',
+      token: 'jwt',
+      expiry: Date.now() + 30_000,
+      createdAt: Date.now(),
+    })
+    store.getState().setEoaAccount(EOA_ACCOUNT)
+
+    const provider = createProvider({
+      store,
+      config: { projectId: 'proj-test', chains: [sepolia] },
+      chains: [sepolia],
+    })
+    await vi.waitFor(() => expect(wallet.logout).toHaveBeenCalledOnce())
+
+    expect(wallet.logout).toHaveBeenCalledWith()
+    expect(store.getState().session).toBeNull()
+    expect(store.getState().eoaAccount).toBeNull()
+    provider.destroy()
+  })
+
+  it('preserves retryable state when rejected-session cleanup also fails', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_700_000_000_000)
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const store = createZeroDevWalletStore()
+    const session = {
+      id: 'rejected-session',
+      userId: 'user-1',
+      organizationId: 'org-1',
+      stamperType: 'apiKey' as const,
+      token: 'jwt',
+      expiry: Date.now() + 30_000,
+      createdAt: Date.now(),
+    }
+    const wallet = {
+      refreshSession: vi.fn().mockRejectedValue({ status: 401 }),
+      logout: vi.fn().mockRejectedValue(new Error('backend unavailable')),
+    }
+    store.getState().setWallet(wallet as never)
+    store.getState().setSession(session)
+    store.getState().setEoaAccount(EOA_ACCOUNT)
+
+    const provider = createProvider({
+      store,
+      config: { projectId: 'proj-test', chains: [sepolia] },
+      chains: [sepolia],
+    })
+    await vi.waitFor(() => expect(wallet.logout).toHaveBeenCalledOnce())
+    await Promise.resolve()
+
+    expect(store.getState().session).toEqual(session)
+    expect(store.getState().eoaAccount).toBe(EOA_ACCOUNT)
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+    provider.destroy()
+  })
+
+  it('does not commit a provider chain switch when setup fails', async () => {
+    const store = createZeroDevWalletStore()
+    store.getState().setActiveChainId(sepolia.id)
+    store.getState().setEoaAccount(EOA_ACCOUNT)
+    const switchChain = vi.fn().mockRejectedValue(new Error('setup failed'))
+    const provider = createProvider({
+      store,
+      config: { projectId: 'proj-test', chains: [sepolia, mainnet] },
+      chains: [sepolia, mainnet],
+      switchChain,
+    })
+
+    await expect(
+      provider.request({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: '0x1' }],
+      }),
+    ).rejects.toThrow('setup failed')
+
+    expect(store.getState().activeChainId).toBe(sepolia.id)
+    provider.destroy()
+  })
+
+  it('rejects personal_sign for an address other than the active owner', async () => {
+    const provider = createTestProvider('EOA')
+
+    await expect(
+      provider.request({
+        method: 'personal_sign',
+        params: ['0x1234', '0x2222222222222222222222222222222222222222'],
+      }),
+    ).rejects.toThrow('Invalid from address')
   })
 })

--- a/packages/react/src/provider.ts
+++ b/packages/react/src/provider.ts
@@ -144,6 +144,10 @@ export function createProvider({
         if (store.getState().session?.id !== session.id) return
         store.getState().setIsExpiring(false)
 
+        // Duck-typed on `status` rather than `err instanceof RestRequestError`:
+        // RestRequestError is internal to @zerodev/wallet-core (not in its
+        // public entry, see utils/query.ts), so an instanceof check here would
+        // require a deep import.
         if (
           typeof err === 'object' &&
           err !== null &&

--- a/packages/react/src/provider.ts
+++ b/packages/react/src/provider.ts
@@ -55,6 +55,7 @@ type CreateProviderParams = {
   store: ReturnType<typeof createZeroDevWalletStore>
   config: ConnectorCoreParams
   chains: Chain[]
+  switchChain?: (chainId: number) => Promise<void>
 }
 
 export type ZeroDevProvider = ReturnType<typeof Provider.createEmitter> & {
@@ -65,11 +66,13 @@ export type ZeroDevProvider = ReturnType<typeof Provider.createEmitter> & {
 export function createProvider({
   store,
   config,
+  switchChain,
 }: CreateProviderParams): ZeroDevProvider {
   // Mirrors the default in `connector.ts` — keep these in sync.
   const mode: WalletMode = config.mode ?? '7702'
   const emitter = Provider.createEmitter()
   let sessionRefreshTimer: ReturnType<typeof setTimeout> | null = null
+  let refreshPromise: Promise<void> | null = null
 
   // Session auto-refresh logic
   const scheduleSessionRefresh = () => {
@@ -98,7 +101,7 @@ export function createProvider({
     }
 
     const threshold =
-      config.sessionWarningThreshold || SESSION_WARNING_THRESHOLD_MS
+      config.sessionWarningThreshold ?? SESSION_WARNING_THRESHOLD_MS
     const refreshAt = expiryMs - threshold
     const timeUntilRefresh = refreshAt - now
 
@@ -113,27 +116,66 @@ export function createProvider({
     }
   }
 
-  const refreshSessionNow = async () => {
+  const refreshSessionNow = async (): Promise<void> => {
+    if (refreshPromise) return refreshPromise
+
     const state = store.getState()
     if (!state.wallet || !state.session) return
 
-    console.log('Auto-refreshing session...')
-    store.getState().setIsExpiring(true)
-
-    try {
-      const newSession = await state.wallet.refreshSession(state.session.id)
-      console.log('Session refreshed successfully')
-      store.getState().setSession(newSession || null)
-      store.getState().setIsExpiring(false)
-
-      if (newSession) {
-        scheduleSessionRefresh()
-      }
-    } catch (err) {
-      console.error('Session refresh failed:', err)
-      store.getState().setIsExpiring(false)
+    const wallet = state.wallet
+    const session = state.session
+    if (normalizeTimestamp(session.expiry) <= Date.now()) {
       store.getState().clear()
+      return
     }
+
+    refreshPromise = (async () => {
+      console.log('Auto-refreshing session...')
+      store.getState().setIsExpiring(true)
+
+      try {
+        const newSession = await wallet.refreshSession(session.id)
+        if (store.getState().session?.id !== session.id) return
+        console.log('Session refreshed successfully')
+        store.getState().setSession(newSession || null)
+        store.getState().setIsExpiring(false)
+      } catch (err) {
+        console.error('Session refresh failed:', err)
+        if (store.getState().session?.id !== session.id) return
+        store.getState().setIsExpiring(false)
+
+        if (
+          typeof err === 'object' &&
+          err !== null &&
+          'status' in err &&
+          err.status === 401
+        ) {
+          try {
+            await wallet.logout()
+            store.getState().clear()
+            return
+          } catch (logoutError) {
+            console.error('Failed to clear rejected session:', logoutError)
+          }
+        }
+
+        const timeRemaining = normalizeTimestamp(session.expiry) - Date.now()
+        if (timeRemaining <= 0) {
+          store.getState().clear()
+          return
+        }
+        // A temporary backend/network failure must not discard a still-valid
+        // identity. Retry without recursively re-entering the warning window.
+        sessionRefreshTimer = setTimeout(
+          () => refreshSessionNow(),
+          Math.min(5_000, timeRemaining),
+        )
+      }
+    })().finally(() => {
+      refreshPromise = null
+    })
+
+    return refreshPromise
   }
 
   // Subscribe to session changes
@@ -371,7 +413,8 @@ export function createProvider({
             throw new Error('Missing sign parameters')
           }
 
-          const [message] = params
+          const [message, address] = params
+          validateFromAddress(activeChainId, address)
           const account = await signerForActiveChain(state, activeChainId, mode)
           if (!account) throw new NotAuthenticatedError()
 
@@ -385,7 +428,8 @@ export function createProvider({
             throw new Error('Missing typed data parameters')
           }
 
-          const [, typedDataJson] = params
+          const [address, typedDataJson] = params
+          validateFromAddress(activeChainId, address)
           const account = await signerForActiveChain(state, activeChainId, mode)
           if (!account) throw new NotAuthenticatedError()
 
@@ -400,9 +444,15 @@ export function createProvider({
 
           const [{ chainId }] = params
           const chainId_number = parseInt(chainId, 16)
-
-          // Update active chain
-          store.getState().setActiveChainId(chainId_number)
+          if (
+            !config.chains.some((candidate) => candidate.id === chainId_number)
+          ) {
+            throw new Error(`Chain ${chainId_number} not found in config`)
+          }
+          if (!switchChain) {
+            throw new Error('Chain switching is not configured')
+          }
+          await switchChain(chainId_number)
 
           // Emit chainChanged event
           emitter.emit('chainChanged', chainId)

--- a/packages/react/src/store.test.ts
+++ b/packages/react/src/store.test.ts
@@ -1,0 +1,45 @@
+import type { KernelAccountClient } from '@zerodev/sdk'
+import { createWalletClient, http } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { describe, expect, it } from 'vitest'
+import { mainnet } from 'wagmi/chains'
+import { createZeroDevWalletStore } from './store.js'
+
+describe('createZeroDevWalletStore', () => {
+  it('invalidates every derived signer cache when wallet ownership changes', () => {
+    const store = createZeroDevWalletStore()
+    const firstOwner = privateKeyToAccount(`0x${'11'.repeat(32)}`)
+    const secondOwner = privateKeyToAccount(`0x${'22'.repeat(32)}`)
+    store.getState().setEoaAccount(firstOwner)
+    store
+      .getState()
+      .setKernelAccount(1, { address: firstOwner.address } as never)
+    store.getState().setKernelClient(1, {} as KernelAccountClient)
+    store.getState().setWalletClient(
+      1,
+      createWalletClient({
+        account: firstOwner,
+        chain: mainnet,
+        transport: http(),
+      }),
+    )
+
+    store.getState().setEoaAccount(secondOwner)
+
+    expect(store.getState().kernelAccounts.size).toBe(0)
+    expect(store.getState().kernelClients.size).toBe(0)
+    expect(store.getState().walletClients.size).toBe(0)
+  })
+
+  it('retains derived clients when a refreshed signer has the same address', () => {
+    const store = createZeroDevWalletStore()
+    const owner = privateKeyToAccount(`0x${'11'.repeat(32)}`)
+    store.getState().setEoaAccount(owner)
+    const kernelClient = {} as KernelAccountClient
+    store.getState().setKernelClient(1, kernelClient)
+
+    store.getState().setEoaAccount(owner)
+
+    expect(store.getState().kernelClients.get(1)).toBe(kernelClient)
+  })
+})

--- a/packages/react/src/store.test.ts
+++ b/packages/react/src/store.test.ts
@@ -42,4 +42,26 @@ describe('createZeroDevWalletStore', () => {
 
     expect(store.getState().kernelClients.get(1)).toBe(kernelClient)
   })
+
+  it('never persists the session (Core owns session state)', () => {
+    const store = createZeroDevWalletStore()
+    store.getState().setSession({
+      id: 'sess-1',
+      userId: 'user-1',
+      organizationId: 'org-1',
+      stamperType: 'apiKey',
+      token: 'jwt',
+      expiry: Date.now() + 60_000,
+      createdAt: Date.now(),
+    })
+
+    // Sanity: the live state actually holds a session, so the assertion below
+    // only passes because partialize strips it — not because it was absent.
+    expect(store.getState().session).not.toBeNull()
+
+    const { partialize } = store.persist.getOptions()
+    const persisted = partialize?.(store.getState())
+
+    expect(persisted).not.toHaveProperty('session')
+  })
 })

--- a/packages/react/src/store.ts
+++ b/packages/react/src/store.ts
@@ -68,8 +68,9 @@ export type CreateStoreOptions = {
   storage?: StateStorage<void>
 }
 
-export const createZeroDevWalletStore = (options?: CreateStoreOptions) =>
-  create<ZeroDevWalletState>()(
+export const createZeroDevWalletStore = (options?: CreateStoreOptions) => {
+  const storage = options?.storage
+  return create<ZeroDevWalletState>()(
     subscribeWithSelector(
       persist(
         (set, get) => ({
@@ -87,7 +88,20 @@ export const createZeroDevWalletStore = (options?: CreateStoreOptions) =>
           // Actions
           setWallet: (wallet) => set({ wallet }),
 
-          setEoaAccount: (account) => set({ eoaAccount: account }),
+          setEoaAccount: (account) => {
+            const previous = get().eoaAccount
+            const ownerChanged =
+              (previous?.address.toLowerCase() ?? null) !==
+              (account?.address.toLowerCase() ?? null)
+            set({
+              eoaAccount: account,
+              ...(ownerChanged && {
+                kernelAccounts: new Map(),
+                kernelClients: new Map(),
+                walletClients: new Map(),
+              }),
+            })
+          },
 
           setKernelAccount: (chainId, account) => {
             const accounts = new Map(get().kernelAccounts)
@@ -128,13 +142,13 @@ export const createZeroDevWalletStore = (options?: CreateStoreOptions) =>
         }),
         {
           name: 'zerodev-wallet',
-          // Only persist session data, not clients or accounts
+          // Core owns and validates session persistence. React only remembers
+          // the preferred chain; duplicating JWT state creates stale identities.
           partialize: (state) => ({
-            session: state.session,
             activeChainId: state.activeChainId,
           }),
-          ...(options?.storage && {
-            storage: createJSONStorage(() => options.storage!),
+          ...(storage && {
+            storage: createJSONStorage(() => storage),
           }),
           // We'll handle hydration manually to ensure it completes before we use the store
           skipHydration: true,
@@ -142,3 +156,4 @@ export const createZeroDevWalletStore = (options?: CreateStoreOptions) =>
       ),
     ),
   )
+}


### PR DESCRIPTION
Stack 2 of 3. Depends on #383.

## Summary
- Invalidate owner-sensitive account caches when owners or chains change.
- Destroy and clear session providers during disconnect/logout, then recreate them on re-login.
- Prevent stale providers from silently losing automatic refresh after logout and reconnect.
- Reset OAuth preparation state during teardown.
- Cover browser and native OAuth cancellation/cleanup paths.

## Verification
- Full React package and test typecheck passes.
- Provider, connector, store, and OAuth lifecycle tests pass.
- Live browser refresh, reload, signing, and logout coverage is added in stack 3.

## Review focus
Please review provider ownership, cache invalidation boundaries, reconnect behavior, and teardown ordering.