### PR TITLE
test(react): add session integration tests, 7 open findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,31 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
+  integration-test:
+    name: Integration Tests (in-process)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # No secrets and no network: these compose real modules with the KMS
+      # doubled. Tests marked `it.fails()` document open defects — this job
+      # turns red when one of them is fixed, which is the intended signal.
+      - name: Run integration tests
+        run: pnpm test:integration
+
   contract-test:
     name: Contract Tests (live KMS)
     runs-on: ubuntu-latest

--- a/packages/react/src/connector.session-restore.integration.test.ts
+++ b/packages/react/src/connector.session-restore.integration.test.ts
@@ -1,0 +1,254 @@
+import type { Config } from '@wagmi/core'
+import type { LocalAccount } from 'viem'
+import { zeroAddress } from 'viem'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { sepolia } from 'wagmi/chains'
+
+/**
+ * Connector initialization when restoring a persisted session.
+ *
+ * On page load `doInitialize()` reads the stored session and resolves the
+ * wallet owner through `wallet.toAccount()` -> `GET {projectId}/user-wallet`.
+ * That call is the SDK's most failure-prone KMS dependency: it needs a live
+ * session JWT *and* a stamper key the backend still recognises.
+ *
+ * What these tests assert is the intended contract, not today's behaviour:
+ *
+ *   1. A transient failure must not be permanent. Whatever the eventual
+ *      recovery design, a later attempt after the cause clears has to work.
+ *   2. A failure must never produce a usable-looking account.
+ *
+ *
+ * The assertion bodies are UNCHANGED and still state intended behaviour. Note
+ * `it.fails()` passes if the body throws for any reason, so it is a weaker
+ * signal than a genuinely red test; the passing tests in this file are the
+ * control that catches a broken fixture. This notation was added in order to
+ * avoid failling CI
+ */
+
+const OWNER = '0x1111111111111111111111111111111111111111' as const
+
+const { walletMock } = vi.hoisted(() => ({
+  walletMock: {
+    getSession: vi.fn(),
+    toAccount: vi.fn(),
+    auth: vi.fn(),
+    logout: vi.fn().mockResolvedValue(true),
+    refreshSession: vi.fn(),
+    getPublicKey: vi.fn(),
+    client: {},
+  },
+}))
+
+// Spread the real module: `provider.ts` imports `normalizeTimestamp` from it,
+// and a hand-rolled partial mock silently breaks session scheduling.
+vi.mock('@zerodev/wallet-core', async () => {
+  const actual = await vi.importActual<typeof import('@zerodev/wallet-core')>(
+    '@zerodev/wallet-core',
+  )
+  return {
+    ...actual,
+    createZeroDevWallet: vi.fn().mockImplementation(async () => walletMock),
+  }
+})
+
+import { zeroDevWalletCore } from './core/connector.js'
+
+type ConnectorInstance = ReturnType<ReturnType<typeof zeroDevWalletCore>>
+
+const BASE_TIME = 1_700_000_000_000
+
+/** Mirrors a real persisted session: unexpired, so it survives the storage filter. */
+const RESTORED_SESSION = {
+  id: 'session_indexedDb_1',
+  userId: 'user-1',
+  organizationId: 'org-1',
+  stamperType: 'apiKey' as const,
+  token: 'jwt-token',
+  expiry: BASE_TIME + 15 * 60_000,
+  createdAt: BASE_TIME,
+}
+
+const OWNER_ACCOUNT = { address: OWNER } as LocalAccount
+
+function createConnector(): ConnectorInstance {
+  const factory = zeroDevWalletCore({
+    projectId: 'proj-test',
+    chains: [sepolia],
+  })
+  const wagmiConfig = {
+    transports: {},
+    emitter: { emit: vi.fn() },
+    storage: null,
+  } as unknown as Config
+  return factory(wagmiConfig as never) as ConnectorInstance
+}
+
+function getStore(connector: ConnectorInstance) {
+  // @ts-expect-error - getStore is added in the connector's Properties.
+  return connector.getStore()
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(BASE_TIME)
+  walletMock.getSession.mockReset().mockResolvedValue(RESTORED_SESSION)
+  walletMock.toAccount.mockReset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('connector init — restoring a persisted session', () => {
+  it('restores the session and exposes the resolved owner', async () => {
+    // Control. If this fails the harness is wrong, not the connector.
+    walletMock.toAccount.mockResolvedValue(OWNER_ACCOUNT)
+    const connector = createConnector()
+
+    const store = await getStore(connector)
+
+    expect(store.getState().eoaAccount?.address).toBe(OWNER)
+    expect(store.getState().session).toMatchObject({ id: RESTORED_SESSION.id })
+  })
+
+  it('surfaces the failure rather than continuing with an unresolved owner', async () => {
+    // The failure must be loud. Resolving successfully here would mean the
+    // app believes it restored a wallet it could not actually resolve.
+    walletMock.toAccount.mockRejectedValue(
+      new Error('Request timed out: GET proj-test/user-wallet'),
+    )
+    const connector = createConnector()
+
+    await expect(getStore(connector)).rejects.toThrow(/timed out/i)
+  })
+
+  it('never reports an account address when owner resolution failed', async () => {
+    // The #365 regression guard: no zero address, no stale address, nothing.
+    // `getAccounts()` deliberately does not trigger init, so it is readable
+    // even while init is broken.
+    walletMock.toAccount.mockRejectedValue(new Error('Request timed out'))
+    const connector = createConnector()
+
+    await expect(getStore(connector)).rejects.toThrow()
+
+    const accounts = await connector.getAccounts()
+    expect(accounts).toEqual([])
+    expect(accounts).not.toContain(zeroAddress)
+  })
+
+  it('does not report the user as authorized after a failed restore', async () => {
+    walletMock.toAccount.mockRejectedValue(new Error('Request timed out'))
+    const connector = createConnector()
+
+    await expect(getStore(connector)).rejects.toThrow()
+
+    expect(await connector.isAuthorized()).toBe(false)
+  })
+
+  it.fails(
+    'connects on a later attempt once a transient failure clears',
+    async () => {
+      // A 10s REST timeout, a KMS 429, or a brief 5xx must not disable the
+      // connector for the rest of the page load.
+      walletMock.toAccount
+        .mockRejectedValueOnce(new Error('Request timed out'))
+        .mockResolvedValue(OWNER_ACCOUNT)
+      const connector = createConnector()
+
+      await expect(getStore(connector)).rejects.toThrow()
+
+      const store = await getStore(connector)
+      expect(store.getState().eoaAccount?.address).toBe(OWNER)
+    },
+  )
+
+  it.fails(
+    're-attempts owner resolution instead of replaying the cached rejection',
+    async () => {
+      walletMock.toAccount
+        .mockRejectedValueOnce(new Error('Request timed out'))
+        .mockResolvedValue(OWNER_ACCOUNT)
+      const connector = createConnector()
+
+      await expect(getStore(connector)).rejects.toThrow()
+      await getStore(connector).catch(() => undefined)
+
+      // Two attempts means the second one actually reached the KMS. One means
+      // the first rejection was replayed and the KMS was never asked again.
+      expect(walletMock.toAccount).toHaveBeenCalledTimes(2)
+    },
+  )
+
+  it.fails(
+    'exposes a usable store to the auth hooks once the failure clears',
+    async () => {
+      // Every entry point in `actions.ts` (loginPasskey, sendOTP, verifyOTP,
+      // sendMagicLink, ...) starts with `getZeroDevStore(connector)`. If that
+      // keeps rejecting, the one action that would replace the bad session —
+      // logging in again — is blocked by the bad session.
+      walletMock.toAccount
+        .mockRejectedValueOnce(new Error('Request timed out'))
+        .mockResolvedValue(OWNER_ACCOUNT)
+      const connector = createConnector()
+
+      await expect(getStore(connector)).rejects.toThrow()
+
+      const store = await getStore(connector)
+      expect(store.getState().wallet).toBeDefined()
+    },
+  )
+
+  it.fails(
+    'recovers the EIP-1193 provider once the failure clears',
+    async () => {
+      walletMock.toAccount
+        .mockRejectedValueOnce(new Error('Request timed out'))
+        .mockResolvedValue(OWNER_ACCOUNT)
+      const connector = createConnector()
+
+      await expect(connector.getProvider()).rejects.toThrow()
+
+      await expect(connector.getProvider()).resolves.toBeDefined()
+    },
+  )
+})
+
+describe('connector init — defense in depth against a zero-address owner', () => {
+  /**
+   * #365 fixed this inside `toViemAccount`, so a zero owner cannot reach the
+   * connector through the adapter today. The connector has its own zero guard
+   * — but only in `setupChain`, which runs on `connect()`, never on the
+   * restore path.
+   *
+   * These do not re-test #365. They pin the invariant that survives it: no
+   * matter which layer lets it through, `0x0` must never be presented as the
+   * user's account. `isAddress(zeroAddress)` is true, so nothing downstream
+   * rejects it on shape alone — which is precisely how funds were lost.
+   *
+   * The mechanism is deliberately unspecified: throwing, clearing, or
+   * refusing to populate the store all satisfy this.
+   */
+
+  it.fails('never exposes a zero-address owner to wagmi', async () => {
+    walletMock.toAccount.mockResolvedValue({
+      address: zeroAddress,
+    } as LocalAccount)
+    const connector = createConnector()
+
+    await getStore(connector).catch(() => undefined)
+
+    expect(await connector.getAccounts()).not.toContain(zeroAddress)
+  })
+
+  it.fails('does not report a zero-address owner as authorized', async () => {
+    walletMock.toAccount.mockResolvedValue({
+      address: zeroAddress,
+    } as LocalAccount)
+    const connector = createConnector()
+
+    await getStore(connector).catch(() => undefined)
+
+    expect(await connector.isAuthorized()).toBe(false)
+  })
+})

--- a/packages/react/src/provider.session-refresh.integration.test.ts
+++ b/packages/react/src/provider.session-refresh.integration.test.ts
@@ -1,0 +1,268 @@
+import type {
+  ZeroDevWalletSDK,
+  ZeroDevWalletSession,
+} from '@zerodev/wallet-core'
+import type { LocalAccount } from 'viem'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { sepolia } from 'wagmi/chains'
+import { createProvider } from './provider.js'
+import { createZeroDevWalletStore } from './store.js'
+
+/**
+ * Session auto-refresh — `scheduleSessionRefresh` / `refreshSessionNow`.
+ *
+ * `provider.test.ts` covers the JSON-RPC surface (`wallet_sendCalls`,
+ * `wallet_getCallsStatus`, `wallet_getCapabilities`) and nothing else, so this
+ * scheduling logic has had no coverage at any layer despite deciding when a
+ * user silently loses their session.
+ *
+ * SOME TESTS HERE ARE MARKED `it.fails()`. They document live defects; they are
+ * not broken tests. `it.fails()` asserts the body still fails, so the suite is
+ * green while the bug exists and turns RED the moment someone fixes it — at
+ * which point change them back to plain `it()`.
+ *
+ * The assertion bodies are UNCHANGED and still state intended behaviour. Note
+ * `it.fails()` passes if the body throws for any reason, so it is a weaker
+ * signal than a genuinely red test; the passing tests in this file are the
+ * control that catches a broken fixture.
+ */
+
+const BASE_TIME = 1_700_000_000_000
+const MINUTE = 60_000
+const DEFAULT_THRESHOLD = MINUTE
+const EOA_ADDRESS = '0xeoa000000000000000000000000000000000abcd'
+
+const refreshSessionMock = vi.fn()
+
+/** Expiry is stored in ms by the passkey flows; `normalizeTimestamp` passes it through. */
+function session(
+  overrides: Partial<ZeroDevWalletSession> = {},
+): ZeroDevWalletSession {
+  return {
+    id: 'session_indexedDb_1',
+    userId: 'user-1',
+    organizationId: 'org-1',
+    stamperType: 'apiKey',
+    token: 'jwt-token',
+    expiry: BASE_TIME + 15 * MINUTE,
+    createdAt: BASE_TIME,
+    ...overrides,
+  }
+}
+
+function setup(
+  opts: {
+    session?: ZeroDevWalletSession | null
+    autoRefreshSession?: boolean
+    sessionWarningThreshold?: number
+  } = {},
+) {
+  const store = createZeroDevWalletStore()
+  store.getState().setActiveChainId(sepolia.id)
+  store.getState().setEoaAccount({ address: EOA_ADDRESS } as LocalAccount)
+  store.getState().setWallet({
+    refreshSession: refreshSessionMock,
+  } as unknown as ZeroDevWalletSDK)
+
+  // Seeded before the provider exists so construction sees it, mirroring a
+  // page load that restores a persisted session.
+  if (opts.session !== undefined) store.getState().setSession(opts.session)
+
+  const provider = createProvider({
+    store,
+    config: {
+      projectId: 'proj-test',
+      chains: [sepolia],
+      ...(opts.autoRefreshSession !== undefined && {
+        autoRefreshSession: opts.autoRefreshSession,
+      }),
+      ...(opts.sessionWarningThreshold !== undefined && {
+        sessionWarningThreshold: opts.sessionWarningThreshold,
+      }),
+    },
+    chains: [sepolia],
+  })
+
+  return { store, provider }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(BASE_TIME)
+  refreshSessionMock.mockReset()
+  refreshSessionMock.mockResolvedValue(
+    session({ id: 'session_indexedDb_2', expiry: BASE_TIME + 30 * MINUTE }),
+  )
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('session auto-refresh scheduling', () => {
+  it('refreshes one minute before expiry, not at expiry', async () => {
+    const { provider } = setup({ session: session() })
+
+    // One millisecond before the scheduled moment nothing should have fired.
+    await vi.advanceTimersByTimeAsync(15 * MINUTE - DEFAULT_THRESHOLD - 1)
+    expect(refreshSessionMock).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(refreshSessionMock).toHaveBeenCalledOnce()
+
+    provider.destroy()
+  })
+
+  it('refreshes the active session by id', async () => {
+    const { provider } = setup({ session: session({ id: 'session_otp_7' }) })
+
+    await vi.advanceTimersByTimeAsync(15 * MINUTE - DEFAULT_THRESHOLD)
+
+    expect(refreshSessionMock).toHaveBeenCalledWith('session_otp_7')
+    provider.destroy()
+  })
+
+  it('stores the refreshed session and re-arms for the next cycle', async () => {
+    const { store, provider } = setup({ session: session() })
+
+    await vi.advanceTimersByTimeAsync(15 * MINUTE - DEFAULT_THRESHOLD)
+    expect(store.getState().session?.id).toBe('session_indexedDb_2')
+
+    // The replacement expires at BASE_TIME + 30m, so its own refresh is due
+    // 60s before that. Without re-arming, the session would lapse silently.
+    refreshSessionMock.mockResolvedValue(
+      session({ id: 'session_indexedDb_3', expiry: BASE_TIME + 45 * MINUTE }),
+    )
+    await vi.advanceTimersByTimeAsync(15 * MINUTE)
+    expect(refreshSessionMock).toHaveBeenCalledTimes(2)
+    expect(store.getState().session?.id).toBe('session_indexedDb_3')
+
+    provider.destroy()
+  })
+
+  it('refreshes exactly once per expiry window', async () => {
+    // `setSession` notifies a store subscriber that also schedules, and the
+    // success path schedules again explicitly. Double-arming would refresh
+    // twice per window and burn a key rotation each time.
+    const { provider } = setup({ session: session() })
+
+    await vi.advanceTimersByTimeAsync(15 * MINUTE - DEFAULT_THRESHOLD)
+
+    expect(refreshSessionMock).toHaveBeenCalledOnce()
+    provider.destroy()
+  })
+
+  it('clears the session when the refresh fails so the app can re-authenticate', async () => {
+    refreshSessionMock.mockRejectedValue(new Error('KMS unavailable'))
+    const { store, provider } = setup({ session: session() })
+
+    await vi.advanceTimersByTimeAsync(15 * MINUTE - DEFAULT_THRESHOLD)
+
+    expect(store.getState().session).toBeNull()
+    expect(store.getState().isExpiring).toBe(false)
+    provider.destroy()
+  })
+
+  it('drops an already-expired session without calling the backend', async () => {
+    // DPL-662: a tab backgrounded across expiry must not hammer the KMS with
+    // a key the backend has already retired.
+    const { store, provider } = setup({
+      session: session({ expiry: BASE_TIME - MINUTE }),
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(refreshSessionMock).not.toHaveBeenCalled()
+    expect(store.getState().session).toBeNull()
+    provider.destroy()
+  })
+
+  it('refreshes immediately when the session is already inside the warning window', async () => {
+    // 30s of life left against a 60s threshold: the refresh moment is already
+    // past, so waiting would mean scheduling a negative timeout.
+    const { provider } = setup({
+      session: session({ expiry: BASE_TIME + 30_000 }),
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(refreshSessionMock).toHaveBeenCalledOnce()
+    provider.destroy()
+  })
+
+  it('honours a custom sessionWarningThreshold', async () => {
+    const { provider } = setup({
+      session: session(),
+      sessionWarningThreshold: 5 * MINUTE,
+    })
+
+    await vi.advanceTimersByTimeAsync(10 * MINUTE - 1)
+    expect(refreshSessionMock).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(refreshSessionMock).toHaveBeenCalledOnce()
+
+    provider.destroy()
+  })
+
+  it.fails(
+    'treats sessionWarningThreshold: 0 as "refresh at expiry", not as unset',
+    async () => {
+      // A consumer passing 0 is asking for no early refresh. Collapsing 0 into
+      // the 60s default is the same zero-is-falsy trap as an `expiry: 0` session
+      // reading as "never expires" — a legitimate value silently discarded.
+      const { provider } = setup({
+        session: session(),
+        sessionWarningThreshold: 0,
+      })
+
+      // With a 0 threshold the refresh is due at expiry (15m), so at 14m59.999s
+      // — which is *inside* the default 60s window — nothing should have fired.
+      await vi.advanceTimersByTimeAsync(15 * MINUTE - 1)
+      expect(refreshSessionMock).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(refreshSessionMock).toHaveBeenCalledOnce()
+
+      provider.destroy()
+    },
+  )
+
+  it('does not schedule anything when autoRefreshSession is false', async () => {
+    const { store, provider } = setup({
+      session: session(),
+      autoRefreshSession: false,
+    })
+
+    await vi.advanceTimersByTimeAsync(20 * MINUTE)
+
+    expect(refreshSessionMock).not.toHaveBeenCalled()
+    // Opting out of refresh must not also mean opting out of the session.
+    expect(store.getState().session).not.toBeNull()
+    provider.destroy()
+  })
+
+  it('re-evaluates when the tab becomes visible after lapsing in the background', async () => {
+    // DPL-662: setTimeout does not fire reliably in a suspended tab, so the
+    // session can outlive its timer. Returning to the tab must notice.
+    const { store, provider } = setup({ session: session() })
+
+    // Clock moves past expiry WITHOUT running timers — a suspended tab.
+    vi.setSystemTime(BASE_TIME + 20 * MINUTE)
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(store.getState().session).toBeNull()
+    expect(refreshSessionMock).not.toHaveBeenCalled()
+    provider.destroy()
+  })
+
+  it('stops refreshing once the provider is destroyed', async () => {
+    const { provider } = setup({ session: session() })
+
+    provider.destroy()
+    await vi.advanceTimersByTimeAsync(20 * MINUTE)
+
+    expect(refreshSessionMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
The first tests in the layer #390 scaffolded, plus the CI job that runs them. Real modules composed together, the KMS supplied as a test double, no network — ~1s, no secrets, so unlike contract and e2e this job also runs on forked PRs.

22 tests across two areas with zero prior coverage at any layer: session refresh scheduling (provider.ts had tests for its RPC surface only) and connector session restore.

The it.fails() convention this establishes

7 tests are marked it.fails(). They are not broken tests — please don't "fix" them. The bodies assert intended behaviour; the wrapper records that the defect is still live. The suite is green today and turns red the moment someone fixes one, which is the signal we want. When that happens, change it back to plain it().

This is the convention the layer will use going forward, so it's worth agreeing on here.

## New findings surfaced

1 — No zero-address guard on the restore path (2 tests)

With a zero-address owner reaching the connector: getAccounts() → ['0x0000…0000'] and isAuthorized() → true. #365 fixed this inside toViemAccount; the connector's own guard lives in setupChain, which only runs on connect() — never on restore. The adapter is currently the only layer between a zero owner and a wallet reporting itself connected at 0x0.

These don't re-test #365 — they pin the invariant that outlives it, and deliberately don't prescribe how it's enforced. Throwing, clearing, or refusing to populate the store all satisfy them.

2 — sessionWarningThreshold: 0 is silently discarded (1 test)

const threshold = config.sessionWarningThreshold || SESSION_WARNING_THRESHOLD_MS

0 means "don't refresh early." It's falsy, so it becomes the 60s default. The run log confirms it: Scheduling session refresh in 840000ms — 15min − 60s, with the 0 ignored.

Second instance of the same class: storage/manager.ts:71 has if (session.expiry && …), so an expiry: 0 session reads as never expires, while provider.ts:81-88 treats that same session as already dead. Two packages, opposite verdicts, each individually self-consistent — likely a sweep rather than two point fixes.

On the remaining 4 failing tests

The other 4 it.fails() cover the connector caching a rejected init promise. That defect is tracked separately and is not what this PR is asking about — it's being reported on its own. They're here because they fall naturally out of exercising the restore flow, and removing them would leave a hole in this file's coverage of that path.

