### PR TITLE
feat(wallet-ui): route wallet surfaces through the WalletSheet

### DIFF
--- a/packages/wallet-react-ui/README.md
+++ b/packages/wallet-react-ui/README.md
@@ -162,10 +162,12 @@ import { ConnectWallet, SignUp } from '@zerodev/wallet-react-ui'
   `WalletId` union (e.g. `'metamask'`, `'coinbase'`, `'rabby'`); the row
   connects the wallet when a live connector claims it (browser extension or a
   configured SDK connector) and is a link to the vendor's download page
-  otherwise.
+  otherwise. With WalletConnect configured, the row instead opens the pairing
+  sheet — phone pairing on one tab, the browser connect/download on the other.
 - `SignUp.InstalledWallets` auto-discovers installed wallets: one row with an
   INSTALLED badge per announced (EIP-6963) browser extension, and nothing when
-  none are installed. Wallets pinned via `SignUp.Wallet` are excluded
+  none are installed. With WalletConnect configured, rows of known wallets
+  open the pairing sheet; unknown extensions still connect directly. Wallets pinned via `SignUp.Wallet` are excluded
   automatically; `excludeWalletIds` hides further wallets by guide id or rdns,
   and `maxWallets` caps the list (default 4, known wallets ranked first).
 - `SignUp.WalletConnect` renders a "WalletConnect" row that opens a pairing
@@ -175,7 +177,9 @@ import { ConnectWallet, SignUp } from '@zerodev/wallet-react-ui'
   your wagmi config.
 - `SignUp.MoreWallets` renders a row that opens an overlay sheet with the full
   wallet grid — every known wallet plus any other live connector; installed
-  ones connect, the rest link to the vendor's download page.
+  ones connect, the rest link to the vendor's download page. With
+  WalletConnect configured, known wallets' tiles open the pairing sheet
+  instead.
 - `SignUp.Default` is the canonical composition; it accepts the same props as
   the root and forwards them.
 - Auth success/failure surfaces through wagmi — await `connect`, or watch
@@ -188,7 +192,7 @@ import { ConnectWallet, SignUp } from '@zerodev/wallet-react-ui'
 | `zeroDevWallet` | wagmi connector with kit-specific auth extensions. |
 | `zeroDevWalletConnect` | WalletConnect connector preconfigured for the kit (`showQrModal: false`). |
 | `<ConnectWallet />` | Renders the current auth step (sign-in, OTP, verifying, etc.). Props: `logo`, `renderSignUp`, `size`, `onClose`. |
-| `<SignUp />` | Compound sign-up page: `SignUp.Default` plus the composable units (`Passkey`, `Google`, `Email`, `Wallet`, `InstalledWallets`, `MoreWallets`, `Divider`). |
+| `<SignUp />` | Compound sign-up page: `SignUp.Default` plus the composable units (`Passkey`, `Google`, `Email`, `Wallet`, `WalletConnect`, `InstalledWallets`, `MoreWallets`, `Divider`). |
 | `useAuth` | Read / drive the auth flow state. |
 
 ### Types

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/InstalledWallets.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/InstalledWallets.test.tsx
@@ -45,6 +45,16 @@ type FakeConnector = {
   type: string
   icon?: string
 }
+// The root renders the single WalletSheet; probe its props instead of
+// pulling radix + the pairing hook into these tests.
+const sheetProps = vi.fn()
+vi.mock('../../components/WalletSheet', () => ({
+  WalletSheet: (props: { open: boolean }) => {
+    sheetProps(props)
+    return null
+  },
+}))
+
 const connect = vi.fn()
 let connectors: FakeConnector[] = []
 let connectPending = false
@@ -68,6 +78,28 @@ beforeEach(() => {
 })
 
 describe('SignUp.InstalledWallets', () => {
+  it('routes guide-matched rows to the sheet when WalletConnect is configured, others connect directly', () => {
+    connectors = [
+      { id: 'io.metamask', type: 'injected' },
+      { id: 'com.unknown.wallet', type: 'injected', name: 'Unknown' },
+      { id: 'walletConnect', type: 'walletConnect', zdWalletConnect: true },
+    ]
+    render(
+      <SignUp>
+        <SignUp.InstalledWallets />
+      </SignUp>,
+    )
+    fireEvent.click(screen.getByText('MetaMask'))
+    expect(connect).not.toHaveBeenCalled()
+    const lastSheet = sheetProps.mock.calls.at(-1)?.[0]
+    expect(lastSheet.open).toBe(true)
+    expect(lastSheet.wallet?.id).toBe('metamask')
+
+    // No guide data → nothing for the sheet to offer (3b): direct connect.
+    fireEvent.click(screen.getByText('Unknown'))
+    expect(connect).toHaveBeenCalledTimes(1)
+  })
+
   it('renders a badged row per announced connector and nothing else', () => {
     connectors = [
       announced('io.metamask'),

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/InstalledWallets.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/InstalledWallets.test.tsx
@@ -44,6 +44,8 @@ type FakeConnector = {
   name: string
   type: string
   icon?: string
+  /** Set by the zeroDevWalletConnect factory; discovery gates on it. */
+  zdWalletConnect?: boolean
 }
 // The root renders the single WalletSheet; probe its props instead of
 // pulling radix + the pairing hook into these tests.
@@ -80,9 +82,15 @@ beforeEach(() => {
 describe('SignUp.InstalledWallets', () => {
   it('routes guide-matched rows to the sheet when WalletConnect is configured, others connect directly', () => {
     connectors = [
-      { id: 'io.metamask', type: 'injected' },
-      { id: 'com.unknown.wallet', type: 'injected', name: 'Unknown' },
-      { id: 'walletConnect', type: 'walletConnect', zdWalletConnect: true },
+      announced('io.metamask'),
+      announced('com.unknown.wallet', 'Unknown'),
+      {
+        uid: crypto.randomUUID(),
+        id: 'walletConnect',
+        name: 'WalletConnect',
+        type: 'walletConnect',
+        zdWalletConnect: true,
+      },
     ]
     render(
       <SignUp>

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/InstalledWallets.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/InstalledWallets.tsx
@@ -2,7 +2,12 @@ import { Badge, ListItem, ListItemChevron } from '@zerodev/react-ui'
 import { useConnect, useConnectors } from 'wagmi'
 import { useAuth } from '../../hooks/useAuth'
 import { isCancellationError } from '../../utils/isCancellationError'
-import { matchesWallet, WALLET_GUIDE } from '../../walletGuide'
+import { isZeroDevWalletConnect } from '../../utils/isZeroDevWalletConnect'
+import {
+  matchesWallet,
+  WALLET_GUIDE,
+  type WalletGuideEntry,
+} from '../../walletGuide'
 import { useReportPending, useSignUpContext } from './context'
 
 /** Auto-discovered rows for installed wallets: one row per announced (6963)
@@ -20,8 +25,13 @@ export function SignUpInstalledWallets({
   maxWallets?: number
 }) {
   const { goToStep } = useAuth()
-  const { authPending, guardAgreement, setError, registeredWallets } =
-    useSignUpContext()
+  const {
+    authPending,
+    guardAgreement,
+    setError,
+    registeredWallets,
+    openWalletSheet,
+  } = useSignUpContext()
   const connectors = useConnectors()
   const { mutate: connect, isPending } = useConnect()
   useReportPending(isPending)
@@ -56,6 +66,14 @@ export function SignUpInstalledWallets({
     .sort((a, b) => a.rank - b.rank)
     .slice(0, maxWallets)
 
+  const wcEnabled = connectors.some(isZeroDevWalletConnect)
+
+  const openSheet = (wallet: WalletGuideEntry) => {
+    if (authPending) return
+    if (!guardAgreement()) return
+    openWalletSheet(wallet)
+  }
+
   const startConnect = (connector: (typeof connectors)[number]) => {
     if (authPending) return
     if (!guardAgreement()) return
@@ -87,7 +105,11 @@ export function SignUpInstalledWallets({
           subtitle={<Badge text="INSTALLED" />}
           trailing={<ListItemChevron />}
           disabled={authPending}
-          onClick={() => startConnect(connector)}
+          onClick={() => {
+            const wallet = WALLET_GUIDE.find((w) => matchesWallet(connector, w))
+            if (wcEnabled && wallet) openSheet(wallet)
+            else startConnect(connector)
+          }}
         />
       ))}
     </>

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/MoreWallets.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/MoreWallets.test.tsx
@@ -66,7 +66,18 @@ type FakeConnector = {
   rdns?: string
   type?: string
   icon?: string
+  zdWalletConnect?: boolean
 }
+// The root renders the single WalletSheet; probe its props instead of
+// pulling radix + the pairing hook into these tests.
+const sheetProps = vi.fn()
+vi.mock('../../components/WalletSheet', () => ({
+  WalletSheet: (props: { open: boolean }) => {
+    sheetProps(props)
+    return null
+  },
+}))
+
 const connect = vi.fn()
 let connectors: FakeConnector[] = []
 let connectPending = false
@@ -94,6 +105,40 @@ const openSheet = () => {
 }
 
 describe('SignUp.MoreWallets', () => {
+  it('routes guide tiles to the wallet sheet and closes the grid when WalletConnect is configured', () => {
+    connectors = [
+      { id: 'io.metamask' },
+      { id: 'walletConnect', type: 'walletConnect', zdWalletConnect: true },
+    ]
+    renderMoreWallets()
+    openSheet()
+    fireEvent.click(screen.getByText('MetaMask'))
+
+    expect(connect).not.toHaveBeenCalled()
+    const lastSheet = sheetProps.mock.calls.at(-1)?.[0]
+    expect(lastSheet.open).toBe(true)
+    expect(lastSheet.wallet?.id).toBe('metamask')
+    // The grid closed so the wallet sheet isn't stacked under it.
+    expect(screen.queryByTestId('wallet-sheet')).toBeNull()
+  })
+
+  it('unmatched connector tiles still connect directly with WalletConnect configured', () => {
+    const exotic = {
+      id: 'exotic',
+      uid: 'exotic-uid',
+      name: 'Example Wallet',
+      type: 'injected',
+    }
+    connectors = [
+      exotic,
+      { id: 'walletConnect', type: 'walletConnect', zdWalletConnect: true },
+    ]
+    renderMoreWallets()
+    openSheet()
+    fireEvent.click(screen.getByText('Example Wallet'))
+    expect(connect.mock.calls[0][0]).toEqual({ connector: exotic })
+  })
+
   it('opens the grid with every guide wallet and hides non-wallet connectors', () => {
     connectors = [
       { id: 'zerodev-wallet', name: 'ZeroDev' },

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/MoreWallets.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/MoreWallets.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../components/WalletGridSheet'
 import { useAuth } from '../../hooks/useAuth'
 import { isCancellationError } from '../../utils/isCancellationError'
+import { isZeroDevWalletConnect } from '../../utils/isZeroDevWalletConnect'
 import { matchesWallet, WALLET_GUIDE } from '../../walletGuide'
 import { useReportPending, useSignUpContext } from './context'
 
@@ -17,7 +18,8 @@ export function SignUpMoreWallets({
   title?: string
 }) {
   const { goToStep } = useAuth()
-  const { authPending, guardAgreement, setError } = useSignUpContext()
+  const { authPending, guardAgreement, setError, openWalletSheet } =
+    useSignUpContext()
   const [open, setOpen] = useState(false)
   const connectors = useConnectors()
   const { mutate: connect, isPending } = useConnect()
@@ -50,8 +52,8 @@ export function SignUpMoreWallets({
     )
   }
 
-  // Claimed by a connector → connect it; otherwise the tile opens the
-  // vendor download page.
+  const wcEnabled = connectors.some(isZeroDevWalletConnect)
+
   const guideTiles: WalletTileData[] = WALLET_GUIDE.map((wallet) => {
     const installed = walletConnectors.find((c) => matchesWallet(c, wallet))
     return {
@@ -59,6 +61,13 @@ export function SignUpMoreWallets({
       name: wallet.name,
       icon: wallet.icon,
       onSelect: () => {
+        if (wcEnabled) {
+          if (authPending) return
+          if (!guardAgreement()) return
+          setOpen(false)
+          openWalletSheet(wallet)
+          return
+        }
         if (installed) {
           startConnect(installed)
           return

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/Wallet.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/Wallet.test.tsx
@@ -39,7 +39,22 @@ vi.mock('../../hooks/useAuth', () => ({
   useAuth: () => ({ goToStep }),
 }))
 
-type FakeConnector = { id: string; rdns?: string }
+type FakeConnector = {
+  id: string
+  rdns?: string
+  type?: string
+  zdWalletConnect?: boolean
+}
+// The root renders the single WalletSheet; probe its props instead of
+// pulling radix + the pairing hook into these tests.
+const sheetProps = vi.fn()
+vi.mock('../../components/WalletSheet', () => ({
+  WalletSheet: (props: { open: boolean }) => {
+    sheetProps(props)
+    return null
+  },
+}))
+
 const connect = vi.fn()
 let connectors: FakeConnector[] = []
 let connectPending = false
@@ -55,6 +70,27 @@ beforeEach(() => {
 })
 
 describe('SignUp.Wallet', () => {
+  it('opens the wallet sheet instead of connecting when WalletConnect is configured', () => {
+    const announced = { id: 'io.metamask' }
+    connectors = [
+      announced,
+      { id: 'walletConnect', type: 'walletConnect', zdWalletConnect: true },
+    ]
+    render(
+      <SignUp>
+        <SignUp.Wallet walletId="metamask" />
+      </SignUp>,
+    )
+    // Still badged — the sheet hub doesn't change the claim rules.
+    expect(screen.getByText('INSTALLED')).toBeDefined()
+
+    fireEvent.click(screen.getByText('MetaMask'))
+    expect(connect).not.toHaveBeenCalled()
+    const lastSheet = sheetProps.mock.calls.at(-1)?.[0]
+    expect(lastSheet.open).toBe(true)
+    expect(lastSheet.wallet?.id).toBe('metamask')
+  })
+
   it('connects the claiming connector and closes the flow on success', () => {
     const announced = { id: 'io.metamask' }
     connectors = [announced]

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/Wallet.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/Wallet.tsx
@@ -3,6 +3,7 @@ import { useLayoutEffect } from 'react'
 import { useConnect, useConnectors } from 'wagmi'
 import { useAuth } from '../../hooks/useAuth'
 import { isCancellationError } from '../../utils/isCancellationError'
+import { isZeroDevWalletConnect } from '../../utils/isZeroDevWalletConnect'
 import { matchesWallet, WALLET_GUIDE, type WalletId } from '../../walletGuide'
 import { useReportPending, useSignUpContext } from './context'
 
@@ -18,8 +19,13 @@ export function SignUpWallet({ walletId }: { walletId: WalletId }) {
   }
 
   const { goToStep } = useAuth()
-  const { authPending, guardAgreement, setError, registerWallet } =
-    useSignUpContext()
+  const {
+    authPending,
+    guardAgreement,
+    setError,
+    registerWallet,
+    openWalletSheet,
+  } = useSignUpContext()
   const connectors = useConnectors()
   const { mutate: connect, isPending } = useConnect()
   useReportPending(isPending)
@@ -36,6 +42,21 @@ export function SignUpWallet({ walletId }: { walletId: WalletId }) {
     title: wallet.name,
     icon: <img src={wallet.icon} alt="" className="zd:w-6 zd:h-6" />,
     trailing: <ListItemChevron />,
+  }
+
+  if (connectors.some(isZeroDevWalletConnect)) {
+    return (
+      <ListItem
+        {...shared}
+        {...(isAnnounced && { subtitle: <Badge text="INSTALLED" /> })}
+        disabled={authPending}
+        onClick={() => {
+          if (authPending) return
+          if (!guardAgreement()) return
+          openWalletSheet(wallet)
+        }}
+      />
+    )
   }
 
   if (!installed) {

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/WalletConnect.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/WalletConnect.tsx
@@ -1,8 +1,6 @@
 import { Badge, ListItem, ListItemChevron } from '@zerodev/react-ui'
-import { useState } from 'react'
 import { useConnectors } from 'wagmi'
 import { walletConnectLogo } from '../../brandAssets'
-import { WalletSheet } from '../../components/WalletSheet'
 import { isZeroDevWalletConnect } from '../../utils/isZeroDevWalletConnect'
 import { useSignUpContext } from './context'
 
@@ -10,29 +8,25 @@ import { useSignUpContext } from './context'
  * wallet's scanner can claim. Renders nothing unless a `zeroDevWalletConnect`
  * connector is in the wagmi config. */
 export function SignUpWalletConnect() {
-  const { authPending, guardAgreement } = useSignUpContext()
+  const { authPending, guardAgreement, openWalletSheet } = useSignUpContext()
   const connectors = useConnectors()
-  const [open, setOpen] = useState(false)
 
   if (!connectors.some(isZeroDevWalletConnect)) return null
 
   const handleClick = () => {
     if (authPending) return
     if (!guardAgreement()) return
-    setOpen(true)
+    openWalletSheet()
   }
 
   return (
-    <>
-      <ListItem
-        title="WalletConnect"
-        icon={<img src={walletConnectLogo} alt="" className="zd:w-6 zd:h-6" />}
-        subtitle={<Badge text="QR CODE" />}
-        trailing={<ListItemChevron />}
-        disabled={authPending}
-        onClick={handleClick}
-      />
-      <WalletSheet open={open} onOpenChange={setOpen} />
-    </>
+    <ListItem
+      title="WalletConnect"
+      icon={<img src={walletConnectLogo} alt="" className="zd:w-6 zd:h-6" />}
+      subtitle={<Badge text="QR CODE" />}
+      trailing={<ListItemChevron />}
+      disabled={authPending}
+      onClick={handleClick}
+    />
   )
 }

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/context.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/context.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect } from 'react'
 import type { EmailAuthMethod } from '../../types'
+import type { WalletGuideEntry } from '../../walletGuide'
 
 export type SignUpContextValue = {
   /** True while any method's auth attempt is in flight — used to disable
@@ -21,6 +22,9 @@ export type SignUpContextValue = {
   registeredWallets: readonly string[]
   /** Returns the unregister function. */
   registerWallet: (walletId: string) => () => void
+  /** Opens the root's single WalletSheet — a wallet's connection paths, or
+   * the generic WalletConnect pairing when called without one. */
+  openWalletSheet: (wallet?: WalletGuideEntry) => void
 }
 
 export const SignUpContext = createContext<SignUpContextValue | null>(null)

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/index.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/index.tsx
@@ -2,7 +2,9 @@ import { Button, Text } from '@zerodev/react-ui'
 import { type ReactNode, useCallback, useState } from 'react'
 import { SignUpFooter } from '../../../shared/components/SignUpFooter'
 import { BlobAnimation } from '../../components/BlobAnimation'
+import { WalletSheet } from '../../components/WalletSheet'
 import type { EmailAuthMethod } from '../../types'
+import type { WalletGuideEntry } from '../../walletGuide'
 import { SignUpContext } from './context'
 import { SignUpEmail } from './Email'
 import { SignUpGoogle } from './Google'
@@ -52,6 +54,13 @@ function SignUpRoot({
     }
   }, [])
 
+  // The page's single WalletSheet — every wallet surface opens it via
+  // `openWalletSheet` instead of mounting a sheet of its own. The box
+  // distinguishes open-without-a-wallet (generic pairing) from closed.
+  const [walletSheet, setWalletSheet] = useState<{
+    wallet?: WalletGuideEntry | undefined
+  } | null>(null)
+
   const requiresAgreement = !!(termsAndConditionsUrl || privacyPolicyUrl)
   const needsAgreement = requiresAgreement && !agreedToTerms
 
@@ -72,6 +81,7 @@ function SignUpRoot({
         setError,
         registeredWallets,
         registerWallet,
+        openWalletSheet: (wallet) => setWalletSheet({ wallet }),
       }}
     >
       {error !== null && (
@@ -125,6 +135,13 @@ function SignUpRoot({
           />
         </div>
       </div>
+      <WalletSheet
+        open={walletSheet !== null}
+        onOpenChange={(open) => {
+          if (!open) setWalletSheet(null)
+        }}
+        wallet={walletSheet?.wallet}
+      />
     </SignUpContext.Provider>
   )
 }

--- a/packages/wallet-react-ui/src/zeroDevWalletConnect.ts
+++ b/packages/wallet-react-ui/src/zeroDevWalletConnect.ts
@@ -1,3 +1,4 @@
+import type { CreateConnectorFn } from 'wagmi'
 import { type WalletConnectParameters, walletConnect } from 'wagmi/connectors'
 
 /**
@@ -11,7 +12,7 @@ import { type WalletConnectParameters, walletConnect } from 'wagmi/connectors'
  */
 export function zeroDevWalletConnect(
   params: Omit<WalletConnectParameters, 'showQrModal'>,
-): ReturnType<typeof walletConnect> {
+): CreateConnectorFn {
   if (!params.projectId) {
     throw new Error('zeroDevWalletConnect requires a WalletConnect projectId')
   }
@@ -19,8 +20,5 @@ export function zeroDevWalletConnect(
   // Stamp the connector instance so the kit's discovery can tell a
   // correctly-configured connector from a raw walletConnect(), where
   // showQrModal defaults to true.
-  return (config: Parameters<typeof create>[0]) => ({
-    ...create(config),
-    zdWalletConnect: true,
-  })
+  return (config) => Object.assign(create(config), { zdWalletConnect: true })
 }


### PR DESCRIPTION
## Summary
When WalletConnect is configured, every wallet surface opens the pairing sheet instead of connecting directly, giving users the phone-pairing path alongside the browser one.

## Changes
- `SignUpRoot` hosts one shared `WalletSheet`; `openWalletSheet` added to `SignUpContext`.
- `SignUp.Wallet` pins open the sheet (installed or not) when WC is configured; unchanged otherwise.
- `SignUp.InstalledWallets`: guide-matched rows open the sheet; unknown extensions still connect directly.
- `SignUp.MoreWallets`: guide tiles open the sheet (closing the grid); unmatched connectors connect directly.
- `SignUp.WalletConnect` uses the shared sheet instead of its own instance.
- README updates for the three units.

## Notes
- With no WalletConnect connector, all surfaces behave exactly as before.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>