### PR TITLE
feat: style BottomSheet in wallet-ui

### DIFF
--- a/packages/react-ui/src/components/BottomSheet/index.tsx
+++ b/packages/react-ui/src/components/BottomSheet/index.tsx
@@ -52,13 +52,13 @@ export function BottomSheetContent({
       >
         <div
           aria-hidden
-          className="zd:absolute zd:inset-0 zd:pointer-events-none"
+          className="zd:absolute zd:inset-0 zd:z-0 zd:pointer-events-none"
           style={{
             background:
               'radial-gradient(ellipse 78% 65% at 5% 105%, rgba(69,171,251,0.35) 0%, rgba(69,171,251,0) 72%), radial-gradient(ellipse 82% 65% at 100% 105%, rgba(250,200,172,0.65) 0%, rgba(250,200,172,0) 72%), radial-gradient(ellipse 58% 52% at 100% 100%, rgba(242,123,62,0.35) 0%, rgba(242,123,62,0) 72%)',
           }}
         />
-        {children}
+        <div className="zd:relative zd:z-10">{children}</div>
       </Dialog.Content>
     </Dialog.Portal>
   )

--- a/packages/react-ui/src/components/BottomSheet/index.tsx
+++ b/packages/react-ui/src/components/BottomSheet/index.tsx
@@ -50,6 +50,14 @@ export function BottomSheetContent({
           className,
         )}
       >
+        <div
+          aria-hidden
+          className="zd:absolute zd:inset-0 zd:pointer-events-none"
+          style={{
+            background:
+              'radial-gradient(ellipse 78% 65% at 5% 105%, rgba(69,171,251,0.35) 0%, rgba(69,171,251,0) 72%), radial-gradient(ellipse 82% 65% at 100% 105%, rgba(250,200,172,0.65) 0%, rgba(250,200,172,0) 72%), radial-gradient(ellipse 58% 52% at 100% 100%, rgba(242,123,62,0.35) 0%, rgba(242,123,62,0) 72%)',
+          }}
+        />
         {children}
       </Dialog.Content>
     </Dialog.Portal>

--- a/packages/smart-routing-address-react-ui/src/components/QrSheet/index.tsx
+++ b/packages/smart-routing-address-react-ui/src/components/QrSheet/index.tsx
@@ -28,17 +28,8 @@ export function QrSheet({ open, onOpenChange, address, onCopy }: QrSheetProps) {
     <BottomSheet open={open} onOpenChange={onOpenChange}>
       <BottomSheetContent>
         <BottomSheetTitle>Your deposit address</BottomSheetTitle>
-        {/* Bottom-half gradient — light blue at bottom-left fading into
-            peach/orange at bottom-right — mirrors the "amorphic" image used
-            in the Figma design. Colors echo `MultiRadialBackground`. */}
-        <div
-          aria-hidden
-          className="zd:absolute zd:inset-0 zd:pointer-events-none"
-          style={{
-            background:
-              'radial-gradient(ellipse 78% 65% at 5% 105%, rgba(69,171,251,0.35) 0%, rgba(69,171,251,0) 72%), radial-gradient(ellipse 82% 65% at 100% 105%, rgba(250,200,172,0.65) 0%, rgba(250,200,172,0) 72%), radial-gradient(ellipse 58% 52% at 100% 100%, rgba(242,123,62,0.35) 0%, rgba(242,123,62,0) 72%)',
-          }}
-        />
+        {/* Accent gradient is baked into `BottomSheetContent`; content sits
+            above it via `zd:relative`. */}
         <div className="zd:relative zd:flex zd:flex-col zd:gap-6 zd:items-center zd:pt-6 zd:px-4 zd:pb-3">
           <div className="zd:flex zd:flex-col zd:gap-3 zd:items-center">
             <Text className="zd:text-h2 zd:text-center">

--- a/packages/wallet-react-ui/src/auth/components/WalletSheet/WalletSheet.test.tsx
+++ b/packages/wallet-react-ui/src/auth/components/WalletSheet/WalletSheet.test.tsx
@@ -106,7 +106,9 @@ describe('WalletSheet', () => {
     const wc = fakeWcConnector()
     connectors = [wc]
     render(<WalletSheet open onOpenChange={() => {}} />)
-    expect(screen.getByText('Generating connection link…')).toBeDefined()
+    // Pending state: no QR yet, copy stays disabled until the URI arrives.
+    expect(screen.queryByTestId('qr')).toBeNull()
+    expect(screen.getByText('Copy link').closest('button')?.disabled).toBe(true)
     expect(screen.queryByText('Mobile')).toBeNull()
 
     act(() => wc.emit({ type: 'display_uri', data: 'wc:raw@2' }))

--- a/packages/wallet-react-ui/src/auth/components/WalletSheet/index.tsx
+++ b/packages/wallet-react-ui/src/auth/components/WalletSheet/index.tsx
@@ -154,12 +154,18 @@ function SheetBody({ wallet }: { wallet?: WalletGuideEntry | undefined }) {
             <Text className="zd:text-center zd:text-red-500">{shownError}</Text>
             <Button action="secondary" text="Try again" onClick={retry} />
           </div>
-        ) : qrValue ? (
+        ) : (
           <>
             <div className="zd:bg-white zd:rounded-2xl zd:p-2 zd:border zd:border-greyScale/10">
-              <QrCode value={qrValue} size={176} />
+              {qrValue ? (
+                <QrCode value={qrValue} size={176} />
+              ) : (
+                <div className="zd:w-[176px] zd:h-[176px] zd:flex zd:items-center zd:justify-center">
+                  <div className="zd:w-8 zd:h-8 zd:border-2 zd:border-solarOrange zd:border-t-transparent zd:rounded-full zd:animate-spin" />
+                </div>
+              )}
             </div>
-            {wallet?.mobileLink && (
+            {qrValue && wallet?.mobileLink && (
               <a
                 href={qrValue}
                 className="zd:w-full zd:rounded-2xl zd:bg-greyScale/10 zd:py-2 zd:text-center zd:text-body2 zd:font-semibold"
@@ -171,12 +177,9 @@ function SheetBody({ wallet }: { wallet?: WalletGuideEntry | undefined }) {
               action="secondary"
               text={copied ? 'Copied' : 'Copy link'}
               onClick={copyUri}
+              disabled={!qrValue}
             />
           </>
-        ) : (
-          <Text className="zd:text-center zd:text-greyScale/50">
-            Generating connection link…
-          </Text>
         )
       ) : shownError ? (
         <div className="zd:flex zd:flex-col zd:gap-2 zd:items-center">


### PR DESCRIPTION
## Summary
Bake the blue/orange accent gradient into `BottomSheet` so every sheet shares it, and show a spinner in the pairing sheet while the QR loads.

## Changes
- `BottomSheetContent` renders the bottom-half radial gradient (light blue → peach/orange), clipped to the panel corners and sitting behind content.
- SRA's `QrSheet` drops its now-redundant inline gradient copy, inheriting the shared one.
- `WalletSheet` shows a spinner in the QR frame until the pairing URI arrives, then swaps to the QR; Copy stays disabled and the deep-link is hidden until then.

## Notes
- The gradient now applies to all `BottomSheet` consumers (WalletSheet, MoreWallets grid, SRA QrSheet).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>