### PR TITLE
test(sra-coverage): adds browser e2e coverage for SRA

### DIFF
--- a/apps/qa-lab-testing/next.config.ts
+++ b/apps/qa-lab-testing/next.config.ts
@@ -12,6 +12,10 @@ const nextConfig: NextConfig = {
     '@zerodev/wallet-react-ui',
     '@zerodev/wallet-core',
   ],
+  experimental: {
+    externalDir: true,
+    extensionAlias: { '.js': ['.ts', '.js'] },
+  },
   webpack: (config) => {
     config.ignoreWarnings = [
       ...(config.ignoreWarnings ?? []),

--- a/apps/qa-lab-testing/src/app/(lab)/sra/page.tsx
+++ b/apps/qa-lab-testing/src/app/(lab)/sra/page.tsx
@@ -13,9 +13,10 @@ export default function SraPage() {
     <>
       <FeatureHeader featureId="sra">
         <p className="mt-2 max-w-3xl text-sm leading-6 text-[var(--muted)]">
-          Live against the real SRA server: deposit addresses and routes are
-          genuine, and anything sent to one moves real funds. Deposit simulation
-          is not wired up yet.
+          Live against the real SRA server by default: deposit addresses and
+          routes are genuine, and anything sent to one moves real funds. Turn on{" "}
+          <b>Mock SRA server</b> to drive the widget against canned responses
+          instead — no network, no funds, and deposits you can step through.
         </p>
       </FeatureHeader>
 

--- a/apps/qa-lab-testing/src/app/components/sra/SraDepositPanel.tsx
+++ b/apps/qa-lab-testing/src/app/components/sra/SraDepositPanel.tsx
@@ -1,16 +1,26 @@
 "use client";
 
 import {
+  createSraMocks,
+  type SraErrorMode,
+  type SraMockHandle,
+} from "@mocks/definitions/sra.js";
+import { providerFees } from "@mocks/definitions/providerFees.js";
+import {
+  installMockFetch,
+  uninstallMockFetch,
+} from "@mocks/installMockFetch.js";
+import {
   SmartRoutingAddress,
   type SmartRoutingAddressConfig,
   SmartRoutingAddressProvider,
 } from "@zerodev/smart-routing-address-react-ui";
-import { Plus } from "lucide-react";
-import { useState } from "react";
+import { AlertTriangle, FlaskConical, Plus } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { arbitrum } from "viem/chains";
 import { useAccount } from "wagmi";
-import { SraMockControls } from "./SraMockControls";
-
+import { cn } from "../../lib/utils";
+import { type SraMockActions, SraMockControls } from "./SraMockControls";
 
 const TARGET_CHAIN = arbitrum;
 
@@ -18,22 +28,176 @@ const SRA_CONFIG: SmartRoutingAddressConfig = {
   targetChainId: TARGET_CHAIN.id,
 };
 
+/**
+ * How long a simulated deposit sits in each stage. Longer than the widget's
+ * hardcoded 5s poll, so every stage is sampled at least once whatever moment
+ * the injection lands on.
+ */
+const STAGE_MS = 6000;
+
 export function SraDepositPanel() {
   const { address } = useAccount();
   const [open, setOpen] = useState(true);
+  const [mockOn, setMockOn] = useState(false);
+  const [mockReady, setMockReady] = useState(false);
+  const [mockNonce, setMockNonce] = useState(0);
+  const [errorMode, setErrorMode] = useState<SraErrorMode>("none");
+  const [sponsored, setSponsored] = useState(false);
+  const mocks = useRef<SraMockHandle | null>(null);
+  const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  const clearTimers = useCallback(() => {
+    for (const id of timers.current) clearTimeout(id);
+    timers.current = [];
+  }, []);
+
+  useEffect(() => {
+    if (!mockOn) return;
+    const handle = createSraMocks();
+    mocks.current = handle;
+    // Passthrough, never "block": this patches fetch for the whole page and
+    // the wallet SDK's own traffic has to keep working.
+    installMockFetch({
+      mocks: [...handle.mocks, ...providerFees],
+      unmatched: "passthrough",
+    });
+    setMockReady(true);
+    return () => {
+      clearTimers();
+      uninstallMockFetch();
+      mocks.current = null;
+      setMockReady(false);
+    };
+  }, [mockOn, clearTimers]);
+
+  const remount = useCallback(() => {
+    clearTimers();
+    setMockNonce((nonce) => nonce + 1);
+  }, [clearTimers]);
+
+  const simulate = ({ failed }: { failed: boolean }) => {
+    const handle = mocks.current;
+    if (!handle) return;
+    clearTimers();
+    handle.startDeposit();
+    timers.current.push(
+      setTimeout(
+        () => (failed ? handle.fail() : handle.advance("bridging")),
+        STAGE_MS,
+      ),
+    );
+    if (!failed) {
+      timers.current.push(
+        setTimeout(() => handle.advance("completed"), STAGE_MS * 2),
+      );
+    }
+  };
+
+  const actions: SraMockActions = {
+    simulateReceived: () => simulate({ failed: false }),
+    simulateFailed: () => simulate({ failed: true }),
+    addPast: ({ count, failed }) => {
+      mocks.current?.addPastDeposits(count, { failed });
+      remount();
+    },
+    clearDeposits: () => {
+      mocks.current?.clearDeposits();
+      remount();
+    },
+    pickErrorMode: (mode) => {
+      const next = errorMode === mode ? "none" : mode;
+      setErrorMode(next);
+      mocks.current?.setErrorMode(next);
+      remount();
+    },
+    toggleSponsored: () => {
+      const next = !sponsored;
+      setSponsored(next);
+      mocks.current?.setSponsored(next);
+      remount();
+    },
+  };
+
+  const toggleMock = (next: boolean) => {
+    setMockOn(next);
+    setErrorMode("none");
+    setSponsored(false);
+  };
+
+  const mockSettled = mockOn === mockReady;
 
   return (
     <div
       className="flex h-full flex-col rounded-lg border border-gray-200 bg-white p-4 sm:p-5"
       data-testid="sra-deposit-panel"
+      data-mock={mockOn ? "on" : "off"}
     >
-      <div>
-        <h3 className="text-base font-semibold text-gray-900">Deposit funds</h3>
-        <p className="mt-1 text-sm text-gray-500">
-          The <code>SmartRoutingAddress</code> widget, with the connected wallet
-          as the deposit recipient. Funds settle on {TARGET_CHAIN.name} (chain{" "}
-          {TARGET_CHAIN.id}) regardless of the chain the wallet is on.
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="text-base font-semibold text-gray-900">
+            Deposit funds
+          </h3>
+          <p className="mt-1 text-sm text-gray-500">
+            The <code>SmartRoutingAddress</code> widget, with the connected
+            wallet as the deposit recipient. Funds settle on {TARGET_CHAIN.name}{" "}
+            (chain {TARGET_CHAIN.id}) regardless of the chain the wallet is on.
+          </p>
+        </div>
+
+        <label className="flex shrink-0 cursor-pointer items-center gap-2.5">
+          <span className="text-sm font-semibold text-gray-700">
+            Mock SRA server
+          </span>
+          <span className="relative inline-flex h-6 w-11 shrink-0">
+            <input
+              type="checkbox"
+              checked={mockOn}
+              onChange={(event) => toggleMock(event.target.checked)}
+              data-testid="sra-mock-toggle"
+              className="peer absolute inset-0 z-10 m-0 h-full w-full cursor-pointer opacity-0"
+            />
+            <span
+              aria-hidden
+              className={cn(
+                "pointer-events-none h-6 w-11 rounded-full transition-colors",
+                "after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5",
+                "after:rounded-full after:bg-white after:shadow after:transition-transform",
+                "bg-red-500 peer-checked:bg-emerald-500 peer-checked:after:translate-x-5",
+                "peer-focus-visible:ring-2 peer-focus-visible:ring-gray-950 peer-focus-visible:ring-offset-2",
+              )}
+            />
+          </span>
+        </label>
+      </div>
+
+      <div
+        role="status"
+        data-testid="sra-mock-status"
+        className={cn(
+          "mt-3 flex items-start gap-2 rounded-lg border px-3 py-2 text-sm",
+          mockOn
+            ? "border-emerald-200 bg-emerald-50 text-emerald-900"
+            : "border-red-200 bg-red-50 text-red-900",
+        )}
+      >
+        {mockOn ? (
+          <FlaskConical className="mt-0.5 h-4 w-4 shrink-0 text-emerald-700" />
+        ) : (
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-600" />
+        )}
+        <span>
+          {mockOn ? (
+            <>
+              <b>Mocked — do not send funds.</b> The deposit address below is
+              fabricated. Anything sent to it is unrecoverable.
+            </>
+          ) : (
+            <>
+              <b>Live network — real funds.</b> The deposit address below is
+              genuine, and anything sent to it moves real money.
+            </>
+          )}
+        </span>
       </div>
 
       <div className="mt-4">
@@ -42,16 +206,33 @@ export function SraDepositPanel() {
             Connect a wallet to generate a deposit address.
           </p>
         ) : open ? (
-          <SmartRoutingAddressProvider config={SRA_CONFIG}>
+          <SmartRoutingAddressProvider
+            key={mockOn ? `mock-${mockNonce}` : "live"}
+            config={SRA_CONFIG}
+          >
             <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
-              <div className="shrink-0">
-                <SmartRoutingAddress
-                  recipient={address}
-                  onClose={() => setOpen(false)}
-                />
+              <div className="min-h-[600px] w-[400px] shrink-0">
+                {mockSettled ? (
+                  <SmartRoutingAddress
+                    recipient={address}
+                    onClose={() => setOpen(false)}
+                  />
+                ) : (
+                  <p
+                    className="text-sm text-gray-500"
+                    data-testid="sra-mock-switching"
+                  >
+                    Switching mock layer…
+                  </p>
+                )}
               </div>
               <div className="min-w-64 flex-1">
-                <SraMockControls />
+                <SraMockControls
+                  enabled={mockOn}
+                  errorMode={errorMode}
+                  sponsored={sponsored}
+                  actions={actions}
+                />
               </div>
             </div>
           </SmartRoutingAddressProvider>

--- a/apps/qa-lab-testing/src/app/components/sra/SraMockControls.tsx
+++ b/apps/qa-lab-testing/src/app/components/sra/SraMockControls.tsx
@@ -1,25 +1,69 @@
 "use client";
 
+import type { SraErrorMode } from "@mocks/definitions/sra.js";
 import { FlaskConical } from "lucide-react";
+import { cn } from "../../lib/utils";
 
-export function SraMockControls() {
+export type SraMockActions = {
+  /** Inject a deposit that walks pending → bridging → completed. */
+  simulateReceived: () => void;
+  /** Inject a deposit that walks pending → failed. */
+  simulateFailed: () => void;
+  addPast: (options: { count: number; failed: boolean }) => void;
+  clearDeposits: () => void;
+  pickErrorMode: (mode: Exclude<SraErrorMode, "none">) => void;
+  toggleSponsored: () => void;
+};
+
+export function SraMockControls({
+  enabled,
+  errorMode,
+  sponsored,
+  actions,
+}: {
+  enabled: boolean;
+  errorMode: SraErrorMode;
+  sponsored: boolean;
+  actions: SraMockActions;
+}) {
   return (
     <div
-      className="rounded-lg border border-dashed border-amber-300 bg-amber-50/50 p-3"
+      className={cn(
+        "rounded-lg p-3",
+        enabled
+          ? "border border-emerald-300 bg-emerald-50/50"
+          : "border border-dashed border-amber-300 bg-amber-50/50",
+      )}
       data-testid="sra-mock-controls"
+      data-enabled={String(enabled)}
     >
       <div className="flex items-center gap-2">
-        <FlaskConical className="h-4 w-4 shrink-0 text-amber-700" />
+        <FlaskConical
+          className={cn(
+            "h-4 w-4 shrink-0",
+            enabled ? "text-emerald-700" : "text-amber-700",
+          )}
+        />
         <span className="text-sm font-semibold text-gray-900">
           Deposit simulation
         </span>
-        <span className="rounded-full bg-amber-100 px-2 py-0.5 font-mono text-[11px] font-semibold uppercase tracking-wider text-amber-800">
-          not wired
+        <span
+          className={cn(
+            "rounded-full px-2 py-0.5 font-mono text-[11px] font-semibold uppercase tracking-wider",
+            enabled
+              ? "bg-emerald-100 text-emerald-800"
+              : "bg-amber-100 text-amber-800",
+          )}
+        >
+          {/* Not "live": the banner above uses that for the real network, and
+              the two states must never share a word. */}
+          {enabled ? "mocking" : "off"}
         </span>
       </div>
       <p className="mt-1.5 text-xs text-gray-600">
-        Needs a mocked SRA server to do anything — the widget above is talking
-        to the real one. Landing with the mocking layer.
+        {enabled
+          ? "Driving a mocked SRA server. Nothing here touches a chain."
+          : "Turn on “Mock SRA server” above — the widget is talking to the real one."}
       </p>
 
       <div className="mt-3">
@@ -29,7 +73,8 @@ export function SraMockControls() {
         <div className="flex flex-wrap gap-2">
           <button
             type="button"
-            disabled
+            disabled={!enabled}
+            onClick={actions.simulateReceived}
             data-testid="sra-mock-simulate-received"
             className={BUTTON}
           >
@@ -37,7 +82,8 @@ export function SraMockControls() {
           </button>
           <button
             type="button"
-            disabled
+            disabled={!enabled}
+            onClick={actions.simulateFailed}
             data-testid="sra-mock-simulate-failed"
             className={BUTTON}
           >
@@ -51,17 +97,27 @@ export function SraMockControls() {
           Past deposits
         </div>
         <div className="flex flex-wrap gap-2">
-          {PAST_DEPOSIT_ACTIONS.map(([id, label]) => (
+          {PAST_DEPOSIT_ADDS.map(([id, label, count, failed]) => (
             <button
               key={id}
               type="button"
-              disabled
+              disabled={!enabled}
+              onClick={() => actions.addPast({ count, failed })}
               data-testid={`sra-mock-past-${id}`}
-              className={id === "clear" ? BUTTON_DANGER : BUTTON}
+              className={BUTTON}
             >
               {label}
             </button>
           ))}
+          <button
+            type="button"
+            disabled={!enabled}
+            onClick={actions.clearDeposits}
+            data-testid="sra-mock-past-clear"
+            className={BUTTON_DANGER}
+          >
+            Clear
+          </button>
         </div>
       </div>
 
@@ -73,13 +129,19 @@ export function SraMockControls() {
           {ERROR_MODES.map(([id, label]) => (
             <label
               key={id}
-              className="flex cursor-not-allowed items-center gap-2 text-xs text-gray-500"
+              className={cn(
+                "flex items-center gap-2 text-xs",
+                enabled
+                  ? "cursor-pointer text-gray-700"
+                  : "cursor-not-allowed text-gray-500",
+              )}
             >
               <input
                 type="checkbox"
-                disabled
-                checked={false}
-                readOnly
+                className="enabled:cursor-pointer"
+                disabled={!enabled}
+                checked={errorMode === id}
+                onChange={() => actions.pickErrorMode(id)}
                 data-testid={`sra-mock-error-${id}`}
               />
               {label}
@@ -88,12 +150,20 @@ export function SraMockControls() {
         </div>
       </div>
 
-      <label className="mt-3 flex cursor-not-allowed items-center gap-2 text-xs font-semibold text-gray-500">
+      <label
+        className={cn(
+          "mt-3 flex items-center gap-2 text-xs font-semibold",
+          enabled
+            ? "cursor-pointer text-gray-700"
+            : "cursor-not-allowed text-gray-500",
+        )}
+      >
         <input
           type="checkbox"
-          disabled
-          checked={false}
-          readOnly
+          className="enabled:cursor-pointer"
+          disabled={!enabled}
+          checked={sponsored}
+          onChange={actions.toggleSponsored}
           data-testid="sra-mock-sponsored"
         />
         Sponsored fees
@@ -102,21 +172,23 @@ export function SraMockControls() {
   );
 }
 
-const PAST_DEPOSIT_ACTIONS = [
-  ["add", "Add"],
-  ["add-failed", "Add failed"],
-  ["add-25", "Add 25"],
-  ["clear", "Clear"],
+const PAST_DEPOSIT_ADDS = [
+  ["add", "Add", 1, false],
+  ["add-failed", "Add failed", 1, true],
+  ["add-25", "Add 25", 25, false],
 ] as const;
 
 const ERROR_MODES = [
   ["address-create-failed", "Address creation fails (TC-03)"],
   ["route-not-found", "No routes found (TC-05)"],
   ["polling-failed", "Deposit polling fails"],
-] as const;
+] as const satisfies readonly (readonly [
+  Exclude<SraErrorMode, "none">,
+  string,
+])[];
 
 const BUTTON =
-  "rounded-md border border-gray-300 bg-white px-2.5 py-1 text-xs font-semibold text-gray-700 disabled:cursor-not-allowed disabled:opacity-50";
+  "rounded-md border border-gray-300 bg-white px-2.5 py-1 text-xs font-semibold text-gray-700 transition-colors enabled:cursor-pointer enabled:hover:border-gray-400 enabled:hover:bg-gray-100 enabled:active:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50";
 
 const BUTTON_DANGER =
-  "rounded-md border border-red-300 bg-red-50 px-2.5 py-1 text-xs font-semibold text-red-700 disabled:cursor-not-allowed disabled:opacity-50";
+  "rounded-md border border-red-300 bg-red-50 px-2.5 py-1 text-xs font-semibold text-red-700 transition-colors enabled:cursor-pointer enabled:hover:border-red-400 enabled:hover:bg-red-100 enabled:active:bg-red-200 disabled:cursor-not-allowed disabled:opacity-50";

--- a/apps/qa-lab-testing/tsconfig.json
+++ b/apps/qa-lab-testing/tsconfig.json
@@ -18,6 +18,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
+    "paths": {
+      "@mocks/*": [
+        "../../e2e/mocks/*"
+      ]
+    },
     "plugins": [
       {
         "name": "next"

--- a/e2e/browser/sra-deposit.spec.ts
+++ b/e2e/browser/sra-deposit.spec.ts
@@ -1,0 +1,265 @@
+/**
+ * Browser E2E for the SRA deposit widget, driven entirely by mocked backend
+ * responses — no live SRA server, no bridge quotes, no funds.
+ *
+ * The widget's lifecycle is one polled method answering differently over time,
+ * so the spec advances the mock between assertions rather than waiting on a
+ * real deposit.
+ */
+
+import { expect, type Locator, type Page } from '@playwright/test'
+import { test } from '../fixtures/authed-session.js'
+import { ping } from '../helpers/temp-email.js'
+import {
+  providerFees,
+  RELAY_FEES_USD,
+  RELAY_PROVIDER_NAME,
+} from '../mocks/definitions/providerFees.js'
+import {
+  buildPastDeposits,
+  createSraMocks,
+  SRA_MOCK_ADDRESS,
+  type SraMockHandle,
+} from '../mocks/definitions/sra.js'
+import { routeMocks } from '../mocks/routeMocks.js'
+
+/**
+ * The widget polls every 5s and the interval is not configurable, so every
+ * assertion after an `advance()` has to tolerate one whole interval of the
+ * previous stage still being on screen. Playwright retries, so this is a
+ * timeout rather than a sleep.
+ */
+const POLL_WINDOW_MS = 20_000
+
+/** Minimums the default routes quote, per symbol. */
+const MIN_DEPOSIT = { USDC: '1.25', USDT: '0.52' } as const
+
+const widgetOf = (page: Page) => page.getByTestId('sra-deposit-panel')
+
+const card = (page: Page, title: string) =>
+  widgetOf(page).getByText(title, { exact: true }).locator('../..')
+
+/** Installs the mocks, then navigates to the SRA feature. */
+async function openSra(page: Page, sra: SraMockHandle) {
+  // Two installs rather than one array: the returned handle then counts SRA
+  // traffic only. The bridge quotes are served by the earlier registration,
+  // which the SRA install falls through to.
+  await routeMocks(page, providerFees)
+  const mocked = await routeMocks(page, sra.mocks)
+  // Client-side nav — a full load drops the wallet into a reconnect, and the
+  // widget renders nothing without a connected account.
+  await page.getByTestId('nav-feature-sra').click()
+  await expect(page.getByTestId('sra-surface')).toBeVisible()
+  return mocked
+}
+
+/**
+ * The first status response is the baseline: the widget treats everything in
+ * it as already-past, so a deposit advanced before it lands never renders as
+ * new.
+ */
+async function waitForFirstPoll(sra: SraMockHandle) {
+  await expect
+    .poll(() => sra.calls().status, { timeout: POLL_WINDOW_MS })
+    .toBeGreaterThan(0)
+}
+
+async function switchToken({
+  page,
+  send,
+  from,
+  to,
+}: {
+  page: Page
+  send: Locator
+  from: string
+  to: string
+}) {
+  await send.getByRole('button', { name: from }).click()
+  await page.getByRole('option', { name: new RegExp(`^${to}`) }).click()
+}
+
+test.describe('SRA deposits', () => {
+  test.beforeEach(async () => {
+    try {
+      await ping()
+    } catch {
+      test.skip(true, 'Email service unavailable')
+    }
+  })
+
+  test('drives one deposit from detected through routing to received', async ({
+    authedPage: page,
+  }) => {
+    const sra = createSraMocks()
+    const mocked = await openSra(page, sra)
+    const widget = widgetOf(page)
+
+    await expect(widget.getByTestId('address-display-address')).toHaveText(
+      SRA_MOCK_ADDRESS,
+      { timeout: POLL_WINDOW_MS },
+    )
+    expect(sra.calls().create).toBeGreaterThan(0)
+
+    await waitForFirstPoll(sra)
+    const pending = widget.getByRole('region', { name: 'Pending deposits' })
+
+    sra.advance('pending')
+    await expect(pending.getByText('Detected', { exact: true })).toBeVisible({
+      timeout: POLL_WINDOW_MS,
+    })
+
+    sra.advance()
+    await expect(pending.getByText('Routing', { exact: true })).toBeVisible({
+      timeout: POLL_WINDOW_MS,
+    })
+
+    sra.advance()
+    await expect(pending.getByText('Received', { exact: true })).toBeVisible({
+      timeout: POLL_WINDOW_MS,
+    })
+
+    await expect(pending.getByRole('listitem')).toHaveCount(1)
+    expect(mocked.hits()).toBe(sra.calls().create + sra.calls().status)
+  })
+
+  test('shows a deposit that fails after bridging as Failed', async ({
+    authedPage: page,
+  }) => {
+    const sra = createSraMocks()
+    await openSra(page, sra)
+    const widget = widgetOf(page)
+    await waitForFirstPoll(sra)
+
+    const pending = widget.getByRole('region', { name: 'Pending deposits' })
+
+    sra.advance('bridging')
+    await expect(pending.getByText('Routing', { exact: true })).toBeVisible({
+      timeout: POLL_WINDOW_MS,
+    })
+
+    sra.fail()
+    await expect(pending.getByText('Failed', { exact: true })).toBeVisible({
+      timeout: POLL_WINDOW_MS,
+    })
+  })
+
+  test('arrives as whichever token is selected to send', async ({
+    authedPage: page,
+  }) => {
+    const sra = createSraMocks()
+    await openSra(page, sra)
+    const widget = widgetOf(page)
+    const send = card(page, 'Send')
+    const arrivesAs = card(page, 'Arrives as')
+
+    const expectQuotedIn = async (symbol: keyof typeof MIN_DEPOSIT) => {
+      await expect(send.getByText(symbol, { exact: true })).toBeVisible({
+        timeout: POLL_WINDOW_MS,
+      })
+      await expect(arrivesAs.getByText(symbol, { exact: true })).toBeVisible()
+      await expect(
+        arrivesAs.getByText('Arbitrum One', { exact: true }),
+      ).toBeVisible()
+
+      await expect(
+        widget.getByText(`${MIN_DEPOSIT[symbol]} ${symbol}`, { exact: true }),
+      ).toBeVisible()
+    }
+
+    await expectQuotedIn('USDC')
+    await switchToken({ page, send, from: 'USDC', to: 'USDT' })
+    await expectQuotedIn('USDT')
+    // Back again, so the first result can't have been a fluke of load order.
+    await switchToken({ page, send, from: 'USDT', to: 'USDC' })
+    await expectQuotedIn('USDC')
+  })
+
+  test('offers every network the token claims to support', async ({
+    authedPage: page,
+  }) => {
+    const sra = createSraMocks()
+    await openSra(page, sra)
+    const send = card(page, 'Send')
+    await expect(send.getByText('USDC', { exact: true })).toBeVisible({
+      timeout: POLL_WINDOW_MS,
+    })
+
+    await send.getByRole('button', { name: 'USDC' }).click()
+    const option = page.getByRole('option', { name: /^USDT/ })
+    const claimed = Number(
+      /(\d+)\s*networks?/.exec((await option.textContent()) ?? '')?.[1],
+    )
+    expect(claimed).toBeGreaterThan(1)
+    await option.click()
+
+    await send.getByRole('button').nth(1).click()
+    await expect(page.getByRole('option')).toHaveCount(claimed)
+  })
+
+  test('opens a past deposit and shows the route it was made on', async ({
+    authedPage: page,
+  }) => {
+    const sra = createSraMocks({ pastDeposits: buildPastDeposits(0, 3) })
+    await openSra(page, sra)
+    const widget = widgetOf(page)
+
+    await widget.getByText(/^Past deposits \(3\)$/).click()
+    await widget.getByRole('listitem').first().click()
+
+    await expect(widget.getByText('From network')).toBeVisible()
+    // Everything below is what the mock reported for the default route:
+    // 250 USDC sent on OP Mainnet, settling on Arbitrum less the 0.15 fee
+    await expect(widget.getByText('250 USDC', { exact: true })).toBeVisible()
+    await expect(widget.getByText('249.85 USDC', { exact: true })).toBeVisible()
+    await expect(widget.getByText('OP Mainnet', { exact: true })).toBeVisible()
+    await expect(
+      widget.getByText('Arbitrum One', { exact: true }),
+    ).toBeVisible()
+
+    await widget.getByRole('button', { name: 'Show fee details' }).click()
+    const panel = widget.getByRole('region', { name: 'Fee breakdown' })
+    await expect(panel.getByText('Provider', { exact: true })).toBeVisible()
+    await expect(
+      panel.getByText(RELAY_PROVIDER_NAME, { exact: true }),
+    ).toBeVisible()
+  })
+
+  test('breaks the quote down into its provider legs', async ({
+    authedPage: page,
+  }) => {
+    const sra = createSraMocks()
+    await openSra(page, sra)
+    const send = card(page, 'Send')
+    await expect(send.getByText('USDC', { exact: true })).toBeVisible({
+      timeout: POLL_WINDOW_MS,
+    })
+
+    await send.getByRole('button', { name: 'Show fee details' }).click()
+
+    await expect(send.getByText('Provider', { exact: true })).toBeVisible()
+    await expect(
+      send.getByText(RELAY_PROVIDER_NAME, { exact: true }),
+    ).toBeVisible()
+
+    for (const label of [
+      'Execution Fee',
+      'Service Fee',
+      'Destination Gas',
+      'Origin Gas',
+    ]) {
+      await expect(send.getByText(label, { exact: true })).toBeVisible()
+    }
+
+    await expect(send.getByText('$0.15', { exact: true })).toBeVisible()
+    await expect(
+      send.getByText(`$${RELAY_FEES_USD.service}`, { exact: true }),
+    ).toBeVisible()
+    await expect(
+      send.getByText(`$${RELAY_FEES_USD.destinationGas}`, { exact: true }),
+    ).toBeVisible()
+    await expect(
+      send.getByText(`$${RELAY_FEES_USD.originGas}`, { exact: true }),
+    ).toBeVisible()
+  })
+})

--- a/e2e/browser/sra-deposit.spec.ts
+++ b/e2e/browser/sra-deposit.spec.ts
@@ -197,6 +197,68 @@ test.describe('SRA deposits', () => {
     await expect(page.getByRole('option')).toHaveCount(claimed)
   })
 
+  test('shows the create-failure card and recovers on retry', async ({
+    authedPage: page,
+  }) => {
+    const sra = createSraMocks({ errorMode: 'address-create-failed' })
+    await openSra(page, sra)
+    const widget = widgetOf(page)
+
+    await expect(widget.getByRole('alert')).toContainText(
+      'Failed to create deposit address...',
+      { timeout: POLL_WINDOW_MS },
+    )
+
+    sra.setErrorMode('none')
+    await widget.getByRole('button', { name: 'Retry' }).click()
+
+    await expect(widget.getByTestId('address-display-address')).toHaveText(
+      SRA_MOCK_ADDRESS,
+      { timeout: POLL_WINDOW_MS },
+    )
+    await expect(widget.getByRole('alert')).toHaveCount(0)
+    expect(sra.calls().create).toBeGreaterThan(1)
+  })
+
+  test('shows the no-routes card when creation returns no estimates', async ({
+    authedPage: page,
+  }) => {
+    const sra = createSraMocks({ errorMode: 'route-not-found' })
+    await openSra(page, sra)
+    const widget = widgetOf(page)
+
+    await expect(widget.getByRole('alert')).toContainText(
+      'No routes found, try one more time...',
+      { timeout: POLL_WINDOW_MS },
+    )
+
+    await expect(widget.getByTestId('address-display-address')).toHaveText(
+      SRA_MOCK_ADDRESS,
+    )
+  })
+
+  test('shows the polling-failure card only once a poll has succeeded', async ({
+    authedPage: page,
+  }) => {
+    const sra = createSraMocks()
+    await openSra(page, sra)
+    const widget = widgetOf(page)
+
+    await waitForFirstPoll(sra)
+    await expect(widget.getByRole('alert')).toHaveCount(0)
+
+    sra.setErrorMode('polling-failed')
+    await expect(widget.getByRole('alert')).toContainText(
+      'Failed to load deposits, try again...',
+      { timeout: POLL_WINDOW_MS },
+    )
+
+    sra.setErrorMode('none')
+    await expect(widget.getByRole('alert')).toHaveCount(0, {
+      timeout: POLL_WINDOW_MS,
+    })
+  })
+
   test('opens a past deposit and shows the route it was made on', async ({
     authedPage: page,
   }) => {

--- a/e2e/mocks/README.md
+++ b/e2e/mocks/README.md
@@ -48,7 +48,7 @@ Then the assertion can only pass if the mock actually served it.
 | --- | --- |
 | `url` | Exact string or `RegExp`, matched against the **full** URL (host + path). |
 | `method` | `GET` \| `POST` \| `PUT` \| `PATCH` \| `DELETE`. |
-| `response` | JSON body returned on match. |
+| `response` | JSON body returned on match, or `(request) => body` computed per request. |
 | `status` | Defaults to `200`. |
 | `payload` | Optional **subset** match on the JSON body — listed keys must match, extra keys are ignored. |
 | `bodyIncludes` | Optional raw substring match on the body. |
@@ -109,3 +109,58 @@ You don't need to get `id` right in a definition. Both adapters copy the
 request's `id` onto a JSON-RPC response (`jsonRpc.ts`) — clients correlate a
 reply to its call by that field, and viem rejects a mismatch with a vague
 transport error that never mentions ids.
+
+### Dynamic responses
+
+`response` can be a function of `{ url, method, body }`, re-evaluated on every
+request. Two things need that.
+
+**The answer changes over time.** A polled endpoint only progresses because
+successive responses differ; a static `response` would repeat the first one
+forever. Keep the state in a factory and return a control beside the mocks —
+never at module scope, since specs share one module instance (`workers: 1`) and
+module state leaks into the next test.
+
+```ts
+export function depositMocks() {
+  let stage = 'pending'
+
+  const mocks: MockRequest[] = [
+    {
+      url: /\/v2$/,
+      method: 'POST',
+      payload: { method: 'zd_getSmartRoutingAddressStatus' },
+      response: () => ({ jsonrpc: '2.0', result: { stage } }),
+    },
+  ]
+
+  return { mocks, advance: (next: string) => void (stage = next) }
+}
+```
+
+```ts
+const deposit = depositMocks()
+await routeMocks(page, deposit.mocks)
+
+await expect(row).toHaveText('Detected')
+deposit.advance('completed') // the next poll reads the new value
+await expect(row).toHaveText('Received')
+```
+
+No sleeps: `advance()` changes what the next poll returns, and Playwright's
+assertions retry until it lands.
+
+**The answer depends on the request.** Read `body` to size a reply to what was
+asked — a multicall must return one result per batched call:
+
+```ts
+response: ({ body }) => ({
+  jsonrpc: '2.0',
+  result: JSON.parse(body).params[0].calls.map(() => '0x1'),
+})
+```
+
+Both adapters resolve it through `resolveMockResponse`, which invokes the
+function *then* echoes the JSON-RPC id. Never call `echoJsonRpcId` directly on
+a `MockRequest.response`: a function satisfies its `object` parameter, so it
+would pass through un-invoked and serialise to an empty body.

--- a/e2e/mocks/README.md
+++ b/e2e/mocks/README.md
@@ -103,6 +103,31 @@ rather than quietly hit staging:
 await routeMocks(page, userWallet, { unmatched: 'block' })
 ```
 
+### Several installs on one page
+
+`routeMocks` can be called more than once. Playwright runs handlers
+newest-first, and an install that matches nothing defers to the one before it,
+so definitions compose which results in a clash:
+
+```ts
+await routeMocks(page, userWallet)
+await routeMocks(page, sraDeposit.mocks)
+```
+
+`handle.dispose()` removes one install and leaves the rest, for a spec that
+wants to prove the mock was what changed the result:
+
+```ts
+const mocked = await routeMocks(page, userWallet)
+await expect(address).toHaveText(MOCK_WALLET_ADDRESS)
+
+await mocked.dispose()
+await page.reload()
+await expect(address).not.toHaveText(MOCK_WALLET_ADDRESS)
+```
+
+Otherwise no teardown is needed — routes belong to the page.
+
 ### JSON-RPC ids
 
 You don't need to get `id` right in a definition. Both adapters copy the

--- a/e2e/mocks/definitions/providerFees.ts
+++ b/e2e/mocks/definitions/providerFees.ts
@@ -1,0 +1,42 @@
+import type { MockRequest } from '../types.js'
+
+/**
+ * Mocks the bridge-quote APIs the widget calls alongside the SRA server.
+ */
+
+const ACROSS_URL_PATTERN = /^https:\/\/app\.across\.to\/api\/suggested-fees/
+const RELAY_URL_PATTERN = /^https:\/\/api\.relay\.link\/quote$/
+
+/** Values are USD strings, as Relay reports them. Distinct so a row showing
+ * the wrong leg's amount is visible rather than plausible. */
+export const RELAY_FEES_USD = {
+  service: '0.34',
+  destinationGas: '0.21',
+  originGas: '0.12',
+} as const
+
+export const RELAY_FILL_TIME_SEC = 30
+
+export const providerFees: MockRequest[] = [
+  {
+    url: ACROSS_URL_PATTERN,
+    method: 'GET',
+    // Any non-2xx makes the widget discard the quote instead of rendering it.
+    status: 503,
+    response: { error: 'Mock: Across unavailable' },
+  },
+  {
+    url: RELAY_URL_PATTERN,
+    method: 'POST',
+    response: {
+      fees: {
+        relayerService: { amountUsd: RELAY_FEES_USD.service },
+        relayerGas: { amountUsd: RELAY_FEES_USD.destinationGas },
+        gas: { amountUsd: RELAY_FEES_USD.originGas },
+      },
+      details: { timeEstimate: RELAY_FILL_TIME_SEC },
+    },
+  },
+]
+
+export const RELAY_PROVIDER_NAME = 'Relay'

--- a/e2e/mocks/definitions/sra.ts
+++ b/e2e/mocks/definitions/sra.ts
@@ -1,0 +1,467 @@
+import type { Address, Hash } from 'viem'
+import { getAddress, numberToHex } from 'viem'
+import { arbitrum, base, optimism } from 'viem/chains'
+import type { MockRequest, MockRequestContext } from '../types.js'
+
+/**
+ * Mocks the Smart Routing Address backend.
+ */
+
+/** The SDK's default server; the lab sets no `baseUrl`, so this is the URL
+ * both RPCs reach. The optional segment is the `/v2/<projectId>` form. */
+export const SRA_RPC_URL_PATTERN =
+  /^https:\/\/api\.smart-routing-address\.zerodev\.app\/v2(\/[^/?]+)?$/
+
+export const SRA_CREATE_METHOD = 'zd_createSmartRoutingAddress'
+export const SRA_STATUS_METHOD = 'zd_getSmartRoutingAddressStatus'
+
+/**
+ * Fabricated, so an assertion on it cannot pass on real data.
+ */
+export const SRA_MOCK_ADDRESS: Address = getAddress(
+  '0x5ea1f7c2b4e0d3a9c61b8e0d2f7a4c9b3d6e1a02',
+)
+
+/**
+ * Constructs a hash by combining a head and tail with zero-padding in between.
+ * @param head The leading segment of the hash.
+ * @param tail The trailing segment of the hash.
+ * @returns The combined hash as a `Hash` type.
+ */
+const hash = (head: string, tail: string): Hash =>
+  `0x${head}${'0'.repeat(64 - head.length - tail.length)}${tail}` as Hash
+
+export const SRA_DEPOSIT_HASH = hash('dead', 'beef')
+const BRIDGE_HASH = hash('b41d', '6e00')
+const EXECUTION_HASH = hash('e4ec', '0001')
+const pastHash = (index: number) =>
+  hash('9a57', index.toString(16).padStart(4, '0'))
+
+export const SRA_DEST_CHAIN_ID = arbitrum.id
+
+export type SraSymbol = 'USDC' | 'USDT'
+
+/**
+ * Addresses must be the ones in the SDK's `SUPPORTED_TOKENS`, or
+ * `sourceTokensFromFees` resolves nothing and the widget shows "No routes
+ * found" even on the happy path.
+ */
+const TOKENS: Record<number, Record<SraSymbol, Address>> = {
+  [optimism.id]: {
+    USDC: getAddress('0x0b2c639c533813f4aa9d7837caf62653d097ff85'),
+    USDT: getAddress('0x94b008aa00579c1307b0ef2c499ad98a8ce58e58'),
+  },
+  [base.id]: {
+    USDC: getAddress('0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'),
+    USDT: getAddress('0xfde4c96c8593536e31f229ea8f37b2ada2699bb2'),
+  },
+  [arbitrum.id]: {
+    USDC: getAddress('0xaf88d065e77c8cc2239327c5edb3a432268e5831'),
+    USDT: getAddress('0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9'),
+  },
+}
+
+const DECIMALS: Record<SraSymbol, number> = { USDC: 6, USDT: 6 }
+
+export type SraRoute = { chainId: number; symbol: SraSymbol }
+
+export function sraTokenAddress(chainId: number, symbol: SraSymbol): Address {
+  const token = TOKENS[chainId]?.[symbol]
+  if (!token) throw new Error(`no ${symbol} configured on chain ${chainId}`)
+  return token
+}
+
+/**
+ * Two symbols over two chains, so the token picker has something to choose
+ * between and each token reports more than one network.
+ */
+export const SRA_DEFAULT_ROUTES: readonly SraRoute[] = [
+  { chainId: optimism.id, symbol: 'USDC' },
+  { chainId: base.id, symbol: 'USDC' },
+  { chainId: optimism.id, symbol: 'USDT' },
+  { chainId: base.id, symbol: 'USDT' },
+]
+
+/** 250 whole tokens gross, 0.15 as the fee. */
+const WHOLE_AMOUNT = 250n
+const WHOLE_FEE = 15n
+
+const atomic = (whole: bigint, decimals: number, divisor = 1n) =>
+  ((whole * 10n ** BigInt(decimals)) / divisor).toString()
+
+export const sraDepositAmount = (symbol: SraSymbol) =>
+  atomic(WHOLE_AMOUNT, DECIMALS[symbol])
+const sraFeeAmount = (symbol: SraSymbol) =>
+  atomic(WHOLE_FEE, DECIMALS[symbol], 100n)
+
+export type SraFeeData = {
+  token: Address
+  name: string
+  decimal: number
+  fee: `0x${string}`
+  minDeposit: `0x${string}`
+  maxDeposit: `0x${string}`
+  isSponsored: boolean
+}
+
+export type SraEstimatedFee = { chainId: number; data: SraFeeData[] }
+
+/** `fee` / `minDeposit` / `maxDeposit` are hex, `decimal` a number and `name`
+ * a display symbol — the shape the widget's own fixtures use. */
+function feesFromRoutes(
+  routes: readonly SraRoute[],
+  sponsored: boolean,
+): SraEstimatedFee[] {
+  const byChain = new Map<number, SraFeeData[]>()
+  for (const route of routes) {
+    const decimal = DECIMALS[route.symbol]
+    const data = byChain.get(route.chainId) ?? []
+    data.push({
+      token: sraTokenAddress(route.chainId, route.symbol),
+      name: route.symbol,
+      decimal,
+      fee: numberToHex(BigInt(sraFeeAmount(route.symbol))),
+      minDeposit: numberToHex(10n ** BigInt(decimal)),
+      maxDeposit: numberToHex(5_000n * 10n ** BigInt(decimal)),
+      isSponsored: sponsored,
+    })
+    byChain.set(route.chainId, data)
+  }
+  return [...byChain].map(([chainId, data]) => ({ chainId, data }))
+}
+
+export type SraStage = 'pending' | 'bridging' | 'completed' | 'failed'
+
+export type SraErrorMode =
+  | 'none'
+  | 'address-create-failed'
+  | 'route-not-found'
+  | 'polling-failed'
+
+export type SraDeposit = {
+  deposit: {
+    chainId: number
+    token: Address
+    amount: string
+    blockNumber: string
+    transactionHash: Hash
+  }
+  bridge: { blockNumber: string; transactionHash: Hash } | null
+  execution: {
+    blockNumber: string
+    chainId: number | null
+    outputToken: Address
+    transactionHash: Hash
+    outputAmount: string
+  } | null
+  error: string | null
+  createdAt: string
+}
+
+export const SRA_FAILURE_REASONS = [
+  'Deposit was below the route minimum',
+  'Deposit exceeded the route maximum',
+  'Route expired before it could be filled',
+] as const
+
+export type SraMockOptions = {
+  routes?: readonly SraRoute[]
+  destChainId?: number
+  depositRoute?: SraRoute
+  errorMode?: SraErrorMode
+  sponsored?: boolean
+  pastDeposits?: SraDeposit[]
+  stage?: SraStage | null
+}
+
+export type SraMockHandle = {
+  mocks: MockRequest[]
+  routes: readonly SraRoute[]
+  stage: () => SraStage | null
+  /** No argument walks pending → bridging → completed and stops. */
+  advance: (stage?: SraStage) => SraStage
+  fail: (reason?: string) => void
+  /** Move the deposit onto another route, to match a picker selection. */
+  setDepositRoute: (route: SraRoute) => void
+  depositRoute: () => SraRoute
+  setErrorMode: (mode: SraErrorMode) => void
+  setSponsored: (value: boolean) => void
+  addPastDeposits: (
+    count: number,
+    options?: { failed?: boolean; route?: SraRoute },
+  ) => void
+  clearPastDeposits: () => void
+  reset: () => void
+  /** Per-RPC counts; `MockHandle.hits()` is an aggregate over both. */
+  calls: () => { create: number; status: number }
+  smartRoutingAddress: Address
+  depositHash: Hash
+}
+
+const NEXT_STAGE: Record<SraStage, SraStage> = {
+  pending: 'bridging',
+  bridging: 'completed',
+  completed: 'completed',
+  failed: 'failed',
+}
+
+/** Overwritten by `echoJsonRpcId` with the request's own id. */
+const RPC_ID = 1
+
+const rpcResult = (result: object) => ({ jsonrpc: '2.0', id: RPC_ID, result })
+
+/** HTTP 200, not a 4xx: `jsonRpcCall` turns an `error` member into an API
+ * error, while a bad status short-circuits earlier as a network error. */
+const rpcError = (message: string) => ({
+  jsonrpc: '2.0',
+  id: RPC_ID,
+  error: { code: -32000, message },
+})
+
+function netAmount(amount: string, fee: string): string {
+  const gross = BigInt(amount)
+  const cost = BigInt(fee)
+  return (gross > cost ? gross - cost : 0n).toString()
+}
+
+/** `deepHexlify` leaves numbers alone, so these arrive as numbers. Defaults
+ * mirror the SDK's own. */
+function readPaging(body: string): { page: number; pageSize: number } {
+  try {
+    const parsed = JSON.parse(body) as {
+      params?: { page?: unknown; pageSize?: unknown }[]
+    }
+    const first = parsed.params?.[0]
+    return {
+      page: typeof first?.page === 'number' ? first.page : 1,
+      pageSize: typeof first?.pageSize === 'number' ? first.pageSize : 50,
+    }
+  } catch {
+    return { page: 1, pageSize: 50 }
+  }
+}
+
+/**
+ * A deposit on `route`, settling as the same symbol on `destChainId` — the
+ * widget shows the source symbol as what arrives, so the two must agree.
+ */
+function depositOn(
+  route: SraRoute,
+  destChainId: number,
+  transactionHash: Hash,
+  parts: {
+    bridgeHash?: Hash
+    executionHash?: Hash
+    error?: string | null
+    createdAt: string
+  },
+): SraDeposit {
+  const amount = sraDepositAmount(route.symbol)
+  return {
+    deposit: {
+      chainId: route.chainId,
+      token: sraTokenAddress(route.chainId, route.symbol),
+      amount,
+      blockNumber: '0x1',
+      transactionHash,
+    },
+    bridge: parts.bridgeHash
+      ? { blockNumber: '0x2', transactionHash: parts.bridgeHash }
+      : null,
+    execution: parts.executionHash
+      ? {
+          blockNumber: '0x3',
+          chainId: destChainId,
+          outputToken: sraTokenAddress(destChainId, route.symbol),
+          transactionHash: parts.executionHash,
+          outputAmount: netAmount(amount, sraFeeAmount(route.symbol)),
+        }
+      : null,
+    error: parts.error ?? null,
+    createdAt: parts.createdAt,
+  }
+}
+
+/** Historical rows spread over days so date grouping has something to group. */
+export function buildPastDeposits(
+  startIndex: number,
+  count: number,
+  options: {
+    failed?: boolean
+    route?: SraRoute
+    destChainId?: number
+  } = {},
+): SraDeposit[] {
+  const route = options.route ?? SRA_DEFAULT_ROUTES[0]
+  const destChainId = options.destChainId ?? SRA_DEST_CHAIN_ID
+  const sixHours = 6 * 60 * 60 * 1000
+  return Array.from({ length: count }, (_, offset) => {
+    const index = startIndex + offset
+    const failed = options.failed === true
+    return depositOn(route, destChainId, pastHash(index), {
+      ...(failed ? {} : { bridgeHash: pastHash(index) }),
+      ...(failed ? {} : { executionHash: pastHash(index) }),
+      error: failed
+        ? (SRA_FAILURE_REASONS[index % SRA_FAILURE_REASONS.length] ?? null)
+        : null,
+      createdAt: new Date(Date.now() - index * sixHours).toISOString(),
+    })
+  })
+}
+
+export function createSraMocks(options: SraMockOptions = {}): SraMockHandle {
+  type Live = {
+    stage: SraStage
+    bridged: boolean
+    reason: string | null
+    createdAt: string
+  }
+
+  const startLive = (stage: SraStage): Live => ({
+    stage,
+    bridged: stage === 'bridging' || stage === 'completed',
+    reason: null,
+    createdAt: new Date().toISOString(),
+  })
+
+  const routes = options.routes ?? SRA_DEFAULT_ROUTES
+  const destChainId = options.destChainId ?? SRA_DEST_CHAIN_ID
+  const firstRoute = routes[0]
+  if (!firstRoute) throw new Error('createSraMocks needs at least one route')
+
+  let live: Live | null = null
+  let route: SraRoute = firstRoute
+  let errorMode: SraErrorMode = 'none'
+  let sponsored = false
+  let past: SraDeposit[] = []
+  let pastCount = 0
+  let statusSucceeded = false
+  const counters = { create: 0, status: 0 }
+
+  const liveDeposit = (): SraDeposit | null => {
+    if (!live) return null
+    return depositOn(route, destChainId, SRA_DEPOSIT_HASH, {
+      ...(live.bridged && { bridgeHash: BRIDGE_HASH }),
+      ...(live.stage === 'completed' && { executionHash: EXECUTION_HASH }),
+      error: live.stage === 'failed' ? live.reason : null,
+      createdAt: live.createdAt,
+    })
+  }
+
+  const statusResult = (request: MockRequestContext): object => {
+    const current = liveDeposit()
+    const all = current ? [current, ...past] : [...past]
+    const { page, pageSize } = readPaging(request.body)
+    const totalPages = Math.max(1, Math.ceil(all.length / pageSize))
+    const start = (page - 1) * pageSize
+    return {
+      deposits: all.slice(start, start + pageSize),
+      totalCount: all.length,
+      nextPage: page < totalPages ? page + 1 : null,
+      totalPages,
+    }
+  }
+
+  const reset = (): void => {
+    live = options.stage ? startLive(options.stage) : null
+    route = options.depositRoute ?? firstRoute
+    errorMode = options.errorMode ?? 'none'
+    sponsored = options.sponsored ?? false
+    past = [...(options.pastDeposits ?? [])]
+    pastCount = past.length
+    statusSucceeded = false
+    counters.create = 0
+    counters.status = 0
+  }
+
+  reset()
+
+  const mocks: MockRequest[] = [
+    {
+      url: SRA_RPC_URL_PATTERN,
+      method: 'POST',
+      payload: { method: SRA_CREATE_METHOD },
+      response: () => {
+        counters.create += 1
+        // A remount restarts polling, so the widget needs one good response
+        // before it will show a polling error again.
+        statusSucceeded = false
+        if (errorMode === 'address-create-failed') {
+          return rpcError('Mock: address creation unavailable')
+        }
+        return rpcResult({
+          smartRoutingAddress: SRA_MOCK_ADDRESS,
+          estimatedFees:
+            errorMode === 'route-not-found'
+              ? []
+              : feesFromRoutes(routes, sponsored),
+        })
+      },
+    },
+    {
+      url: SRA_RPC_URL_PATTERN,
+      method: 'POST',
+      payload: { method: SRA_STATUS_METHOD },
+      response: (request) => {
+        counters.status += 1
+        // The widget only renders a polling error once a status call has
+        // already succeeded, so the first one after a create always does.
+        if (errorMode === 'polling-failed' && statusSucceeded) {
+          return rpcError('Mock: status endpoint unavailable')
+        }
+        statusSucceeded = true
+        return rpcResult(statusResult(request))
+      },
+    },
+  ]
+
+  const advance = (stage?: SraStage): SraStage => {
+    if (!live) {
+      live = startLive(stage ?? 'pending')
+      return live.stage
+    }
+    const next = stage ?? NEXT_STAGE[live.stage]
+    live.stage = next
+    live.bridged ||= next === 'bridging' || next === 'completed'
+    return next
+  }
+
+  return {
+    mocks,
+    routes,
+    stage: () => live?.stage ?? null,
+    advance,
+    fail: (reason) => {
+      advance('failed')
+      if (live) live.reason = reason ?? SRA_FAILURE_REASONS[0]
+    },
+    setDepositRoute: (next) => {
+      route = next
+    },
+    depositRoute: () => route,
+    setErrorMode: (mode) => {
+      errorMode = mode
+    },
+    setSponsored: (value) => {
+      sponsored = value
+    },
+    addPastDeposits: (count, addOptions = {}) => {
+      past = [
+        ...buildPastDeposits(pastCount, count, {
+          route,
+          destChainId,
+          ...addOptions,
+        }),
+        ...past,
+      ]
+      pastCount += count
+    },
+    clearPastDeposits: () => {
+      past = []
+    },
+    reset,
+    calls: () => ({ ...counters }),
+    smartRoutingAddress: SRA_MOCK_ADDRESS,
+    depositHash: SRA_DEPOSIT_HASH,
+  }
+}

--- a/e2e/mocks/definitions/sra.ts
+++ b/e2e/mocks/definitions/sra.ts
@@ -1,6 +1,15 @@
 import type { Address, Hash } from 'viem'
-import { getAddress, numberToHex } from 'viem'
-import { arbitrum, base, optimism } from 'viem/chains'
+import { getAddress, numberToHex, parseUnits } from 'viem'
+import {
+  arbitrum,
+  base,
+  bsc,
+  linea,
+  mainnet,
+  mode,
+  optimism,
+  polygon,
+} from 'viem/chains'
 import type { MockRequest, MockRequestContext } from '../types.js'
 
 /**
@@ -46,14 +55,30 @@ export type SraSymbol = 'USDC' | 'USDT'
  * `sourceTokensFromFees` resolves nothing and the widget shows "No routes
  * found" even on the happy path.
  */
-const TOKENS: Record<number, Record<SraSymbol, Address>> = {
+const TOKENS: Record<number, Partial<Record<SraSymbol, Address>>> = {
+  [mainnet.id]: {
+    USDT: getAddress('0xdac17f958d2ee523a2206206994597c13d831ec7'),
+  },
   [optimism.id]: {
     USDC: getAddress('0x0b2c639c533813f4aa9d7837caf62653d097ff85'),
     USDT: getAddress('0x94b008aa00579c1307b0ef2c499ad98a8ce58e58'),
   },
+  [bsc.id]: {
+    USDC: getAddress('0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d'),
+    USDT: getAddress('0x55d398326f99059ff775485246999027b3197955'),
+  },
+  [polygon.id]: {
+    USDT: getAddress('0xc2132d05d31c914a87c6611c10748aeb04b58e8f'),
+  },
   [base.id]: {
     USDC: getAddress('0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'),
     USDT: getAddress('0xfde4c96c8593536e31f229ea8f37b2ada2699bb2'),
+  },
+  [mode.id]: {
+    USDT: getAddress('0xf0f161fda2712db8b566946122a5af183995e2ed'),
+  },
+  [linea.id]: {
+    USDT: getAddress('0xa219439258ca9da29e9cc4ce5596924745e12b93'),
   },
   [arbitrum.id]: {
     USDC: getAddress('0xaf88d065e77c8cc2239327c5edb3a432268e5831'),
@@ -63,7 +88,12 @@ const TOKENS: Record<number, Record<SraSymbol, Address>> = {
 
 const DECIMALS: Record<SraSymbol, number> = { USDC: 6, USDT: 6 }
 
-export type SraRoute = { chainId: number; symbol: SraSymbol }
+export type SraRoute = {
+  chainId: number
+  symbol: SraSymbol
+  /** Whole tokens, e.g. `'0.52'`. Rendered as "Min deposit" in the widget. */
+  minDeposit?: string
+}
 
 export function sraTokenAddress(chainId: number, symbol: SraSymbol): Address {
   const token = TOKENS[chainId]?.[symbol]
@@ -72,27 +102,35 @@ export function sraTokenAddress(chainId: number, symbol: SraSymbol): Address {
 }
 
 /**
- * Two symbols over two chains, so the token picker has something to choose
- * between and each token reports more than one network.
+ * Two symbols over an uneven spread of chains, so the token picker has
+ * something to choose between and each token reports a different network
+ * count. Distinct `minDeposit`s per symbol make it visible which route the
+ * widget is quoting.
  */
 export const SRA_DEFAULT_ROUTES: readonly SraRoute[] = [
-  { chainId: optimism.id, symbol: 'USDC' },
-  { chainId: base.id, symbol: 'USDC' },
-  { chainId: optimism.id, symbol: 'USDT' },
-  { chainId: base.id, symbol: 'USDT' },
+  { chainId: optimism.id, symbol: 'USDC', minDeposit: '1.25' },
+  { chainId: bsc.id, symbol: 'USDC', minDeposit: '1.25' },
+  { chainId: base.id, symbol: 'USDC', minDeposit: '1.25' },
+  { chainId: mainnet.id, symbol: 'USDT', minDeposit: '0.52' },
+  { chainId: optimism.id, symbol: 'USDT', minDeposit: '0.52' },
+  { chainId: bsc.id, symbol: 'USDT', minDeposit: '0.52' },
+  { chainId: polygon.id, symbol: 'USDT', minDeposit: '0.52' },
+  { chainId: base.id, symbol: 'USDT', minDeposit: '0.52' },
+  { chainId: mode.id, symbol: 'USDT', minDeposit: '0.52' },
+  { chainId: linea.id, symbol: 'USDT', minDeposit: '0.52' },
 ]
 
-/** 250 whole tokens gross, 0.15 as the fee. */
-const WHOLE_AMOUNT = 250n
-const WHOLE_FEE = 15n
+/** 250 whole tokens gross, 0.15 as the fee, 1 as the default minimum. */
+const DEPOSIT_WHOLE = '250'
+const FEE_WHOLE = '0.15'
+const MIN_DEPOSIT_WHOLE = '1'
 
-const atomic = (whole: bigint, decimals: number, divisor = 1n) =>
-  ((whole * 10n ** BigInt(decimals)) / divisor).toString()
+const atomic = (whole: string, symbol: SraSymbol) =>
+  parseUnits(whole, DECIMALS[symbol]).toString()
 
 export const sraDepositAmount = (symbol: SraSymbol) =>
-  atomic(WHOLE_AMOUNT, DECIMALS[symbol])
-const sraFeeAmount = (symbol: SraSymbol) =>
-  atomic(WHOLE_FEE, DECIMALS[symbol], 100n)
+  atomic(DEPOSIT_WHOLE, symbol)
+const sraFeeAmount = (symbol: SraSymbol) => atomic(FEE_WHOLE, symbol)
 
 export type SraFeeData = {
   token: Address
@@ -121,7 +159,9 @@ function feesFromRoutes(
       name: route.symbol,
       decimal,
       fee: numberToHex(BigInt(sraFeeAmount(route.symbol))),
-      minDeposit: numberToHex(10n ** BigInt(decimal)),
+      minDeposit: numberToHex(
+        BigInt(atomic(route.minDeposit ?? MIN_DEPOSIT_WHOLE, route.symbol)),
+      ),
       maxDeposit: numberToHex(5_000n * 10n ** BigInt(decimal)),
       isSponsored: sponsored,
     })

--- a/e2e/mocks/definitions/sra.ts
+++ b/e2e/mocks/definitions/sra.ts
@@ -45,6 +45,10 @@ const BRIDGE_HASH = hash('b41d', '6e00')
 const EXECUTION_HASH = hash('e4ec', '0001')
 const pastHash = (index: number) =>
   hash('9a57', index.toString(16).padStart(4, '0'))
+/** Second and later live deposits; the first keeps `SRA_DEPOSIT_HASH`. The
+ * index sits in the tail so truncated rows stay tellable apart on screen. */
+const liveHash = (index: number) =>
+  hash('dead', `beef${index.toString(16).padStart(2, '0')}`)
 
 export const SRA_DEST_CHAIN_ID = arbitrum.id
 
@@ -218,8 +222,15 @@ export type SraMockHandle = {
   mocks: MockRequest[]
   routes: readonly SraRoute[]
   stage: () => SraStage | null
-  /** No argument walks pending → bridging → completed and stops. */
+  /** No argument walks pending → bridging → completed and stops. Acts on the
+   * most recent deposit. */
   advance: (stage?: SraStage) => SraStage
+  /**
+   * Begin a new deposit with its own hash, and make it the one `advance`
+   * acts on. Reusing a hash would mutate a row the widget has already seen,
+   * which it never re-reports as newly arrived.
+   */
+  startDeposit: (stage?: SraStage) => SraStage
   fail: (reason?: string) => void
   /** Move the deposit onto another route, to match a picker selection. */
   setDepositRoute: (route: SraRoute) => void
@@ -230,7 +241,8 @@ export type SraMockHandle = {
     count: number,
     options?: { failed?: boolean; route?: SraRoute },
   ) => void
-  clearPastDeposits: () => void
+  /** Live and past alike — the clean slate the lab's "Clear" offers. */
+  clearDeposits: () => void
   reset: () => void
   /** Per-RPC counts; `MockHandle.hits()` is an aggregate over both. */
   calls: () => { create: number; status: number }
@@ -355,13 +367,19 @@ export function createSraMocks(options: SraMockOptions = {}): SraMockHandle {
     bridged: boolean
     reason: string | null
     createdAt: string
+    /** Own hash, so a second deposit is a second row rather than a mutation
+     * of the first — which the widget would never show as newly arrived. */
+    hash: Hash
+    route: SraRoute
   }
 
-  const startLive = (stage: SraStage): Live => ({
+  const startLive = (stage: SraStage, index: number, on: SraRoute): Live => ({
     stage,
     bridged: stage === 'bridging' || stage === 'completed',
     reason: null,
     createdAt: new Date().toISOString(),
+    hash: index === 0 ? SRA_DEPOSIT_HASH : liveHash(index),
+    route: on,
   })
 
   const routes = options.routes ?? SRA_DEFAULT_ROUTES
@@ -369,7 +387,7 @@ export function createSraMocks(options: SraMockOptions = {}): SraMockHandle {
   const firstRoute = routes[0]
   if (!firstRoute) throw new Error('createSraMocks needs at least one route')
 
-  let live: Live | null = null
+  let lives: Live[] = []
   let route: SraRoute = firstRoute
   let errorMode: SraErrorMode = 'none'
   let sponsored = false
@@ -378,19 +396,19 @@ export function createSraMocks(options: SraMockOptions = {}): SraMockHandle {
   let statusSucceeded = false
   const counters = { create: 0, status: 0 }
 
-  const liveDeposit = (): SraDeposit | null => {
-    if (!live) return null
-    return depositOn(route, destChainId, SRA_DEPOSIT_HASH, {
-      ...(live.bridged && { bridgeHash: BRIDGE_HASH }),
-      ...(live.stage === 'completed' && { executionHash: EXECUTION_HASH }),
-      error: live.stage === 'failed' ? live.reason : null,
-      createdAt: live.createdAt,
-    })
-  }
+  const liveDeposits = (): SraDeposit[] =>
+    lives.map((entry) =>
+      depositOn(entry.route, destChainId, entry.hash, {
+        ...(entry.bridged && { bridgeHash: BRIDGE_HASH }),
+        ...(entry.stage === 'completed' && { executionHash: EXECUTION_HASH }),
+        error: entry.stage === 'failed' ? entry.reason : null,
+        createdAt: entry.createdAt,
+      }),
+    )
 
   const statusResult = (request: MockRequestContext): object => {
-    const current = liveDeposit()
-    const all = current ? [current, ...past] : [...past]
+    // Newest first, as the server reports them.
+    const all = [...liveDeposits().reverse(), ...past]
     const { page, pageSize } = readPaging(request.body)
     const totalPages = Math.max(1, Math.ceil(all.length / pageSize))
     const start = (page - 1) * pageSize
@@ -403,8 +421,8 @@ export function createSraMocks(options: SraMockOptions = {}): SraMockHandle {
   }
 
   const reset = (): void => {
-    live = options.stage ? startLive(options.stage) : null
     route = options.depositRoute ?? firstRoute
+    lives = options.stage ? [startLive(options.stage, 0, route)] : []
     errorMode = options.errorMode ?? 'none'
     sponsored = options.sponsored ?? false
     past = [...(options.pastDeposits ?? [])]
@@ -455,25 +473,32 @@ export function createSraMocks(options: SraMockOptions = {}): SraMockHandle {
     },
   ]
 
+  const current = (): Live | undefined => lives[lives.length - 1]
+
+  const startDeposit = (stage: SraStage = 'pending'): SraStage => {
+    lives.push(startLive(stage, lives.length, route))
+    return stage
+  }
+
   const advance = (stage?: SraStage): SraStage => {
-    if (!live) {
-      live = startLive(stage ?? 'pending')
-      return live.stage
-    }
-    const next = stage ?? NEXT_STAGE[live.stage]
-    live.stage = next
-    live.bridged ||= next === 'bridging' || next === 'completed'
+    const entry = current()
+    if (!entry) return startDeposit(stage ?? 'pending')
+    const next = stage ?? NEXT_STAGE[entry.stage]
+    entry.stage = next
+    entry.bridged ||= next === 'bridging' || next === 'completed'
     return next
   }
 
   return {
     mocks,
     routes,
-    stage: () => live?.stage ?? null,
+    stage: () => current()?.stage ?? null,
     advance,
+    startDeposit,
     fail: (reason) => {
       advance('failed')
-      if (live) live.reason = reason ?? SRA_FAILURE_REASONS[0]
+      const entry = current()
+      if (entry) entry.reason = reason ?? SRA_FAILURE_REASONS[0]
     },
     setDepositRoute: (next) => {
       route = next
@@ -496,7 +521,8 @@ export function createSraMocks(options: SraMockOptions = {}): SraMockHandle {
       ]
       pastCount += count
     },
-    clearPastDeposits: () => {
+    clearDeposits: () => {
+      lives = []
       past = []
     },
     reset,

--- a/e2e/mocks/installMockFetch.test.ts
+++ b/e2e/mocks/installMockFetch.test.ts
@@ -342,4 +342,73 @@ describe('installMockFetch', () => {
     const res = await fetch(RPC_URL, { method: 'POST', body: '{}' })
     expect(await res.json()).toEqual({ v: 'second' })
   })
+
+  it('resolves a function response instead of stringifying the function', async () => {
+    installMockFetch({
+      mocks: [
+        { url: RPC_URL, method: 'POST', response: () => ({ v: 'computed' }) },
+      ],
+    })
+
+    const res = await fetch(RPC_URL, { method: 'POST', body: '{}' })
+
+    // The symptom differs from the Playwright adapter's — here an unresolved
+    // function reaches `new Response(undefined)` and serves an empty body — so
+    // parity is tested rather than assumed.
+    expect(await res.json()).toEqual({ v: 'computed' })
+  })
+
+  it('re-evaluates a function response on every request', async () => {
+    let served = 0
+    installMockFetch({
+      mocks: [
+        {
+          url: RPC_URL,
+          method: 'POST',
+          response: () => ({ served: ++served }),
+        },
+      ],
+    })
+
+    const first = await fetch(RPC_URL, { method: 'POST', body: '{}' })
+    const second = await fetch(RPC_URL, { method: 'POST', body: '{}' })
+
+    expect(await first.json()).toEqual({ served: 1 })
+    expect(await second.json()).toEqual({ served: 2 })
+  })
+
+  it("echoes the request's JSON-RPC id onto a function response", async () => {
+    installMockFetch({
+      mocks: [
+        {
+          url: RPC_URL,
+          method: 'POST',
+          payload: { method: 'eth_getBalance' },
+          response: () => ({ jsonrpc: '2.0', id: 1, result: '0xbalance' }),
+        },
+      ],
+    })
+
+    const res = await fetch(RPC_URL, rpcInit('eth_getBalance', [], 99))
+
+    expect(await res.json()).toMatchObject({ id: 99, result: '0xbalance' })
+  })
+
+  it('passes the matched url, method and body to a function response', async () => {
+    installMockFetch({
+      mocks: [
+        { url: RPC_URL, method: 'POST', response: (request) => ({ request }) },
+      ],
+    })
+
+    const init = rpcInit('eth_call', ['0xdead'])
+    const res = await fetch(RPC_URL, init)
+
+    // Mirrors the assertion in routeMocks.test.ts: `describeRequest` builds
+    // this context itself, so a regression there is invisible to the shared
+    // matcher tests.
+    expect(await res.json()).toEqual({
+      request: { url: RPC_URL, method: 'POST', body: init.body },
+    })
+  })
 })

--- a/e2e/mocks/installMockFetch.ts
+++ b/e2e/mocks/installMockFetch.ts
@@ -6,9 +6,13 @@
  * by hand — it needs no test runner, just the app itself.
  */
 
-import { echoJsonRpcId } from './jsonRpc.js'
 import { orderMocks } from './orderMocks.js'
-import type { MockRequest, UnmatchedPolicy } from './types.js'
+import { resolveMockResponse } from './resolveResponse.js'
+import type {
+  MockRequest,
+  MockRequestContext,
+  UnmatchedPolicy,
+} from './types.js'
 
 let active: MockRequest[] = []
 let unmatchedPolicy: UnmatchedPolicy = 'passthrough'
@@ -66,7 +70,7 @@ function urlMatches(pattern: string | RegExp, url: string): boolean {
 /** First match wins, after `orderMocks` has sorted by priority. */
 export function matchMock(
   mocks: readonly MockRequest[],
-  request: { url: string; method: string; body: string },
+  request: MockRequestContext,
 ): MockRequest | undefined {
   return mocks.find((mock) => {
     if (mock.method !== request.method) return false
@@ -97,7 +101,7 @@ function jsonResponse(body: object, status: number): Response {
 async function describeRequest(
   input: RequestInfo | URL,
   init?: RequestInit,
-): Promise<{ url: string; method: string; body: string }> {
+): Promise<MockRequestContext> {
   if (input instanceof Request) {
     let body = ''
     try {
@@ -137,7 +141,7 @@ export function installMockFetch(options?: {
 
     if (mock) {
       return jsonResponse(
-        echoJsonRpcId(mock.response, request.body),
+        resolveMockResponse(mock, request),
         mock.status ?? 200,
       )
     }

--- a/e2e/mocks/resolveResponse.test.ts
+++ b/e2e/mocks/resolveResponse.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { resolveMockResponse } from './resolveResponse.js'
+import type { MockRequest, MockRequestContext } from './types.js'
+
+const request: MockRequestContext = {
+  url: 'http://rpc.test/v1',
+  method: 'POST',
+  body: JSON.stringify({ jsonrpc: '2.0', id: 7, method: 'eth_chainId' }),
+}
+
+const mock = (response: MockRequest['response']): MockRequest => ({
+  url: request.url,
+  method: 'POST',
+  response,
+})
+
+describe('resolveMockResponse', () => {
+  it('returns a static response as authored', () => {
+    expect(resolveMockResponse(mock({ result: '0x1' }), request)).toEqual({
+      result: '0x1',
+    })
+  })
+
+  it('invokes a function response with the request', () => {
+    const resolved = resolveMockResponse(
+      mock((received) => ({ received })),
+      request,
+    )
+
+    expect(resolved).toEqual({ received: request })
+  })
+
+  it('echoes the JSON-RPC id onto a function response', () => {
+    const resolved = resolveMockResponse(
+      mock(() => ({ jsonrpc: '2.0', id: 0, result: '0x1' })),
+      request,
+    )
+
+    // Echoing before invoking would no-op: `echoJsonRpcId` skips anything that
+    // isn't an object, and a function is not one, so id 0 would survive.
+    expect(resolved).toEqual({ jsonrpc: '2.0', id: 7, result: '0x1' })
+  })
+
+  it('leaves a non-JSON-RPC function response untouched', () => {
+    const resolved = resolveMockResponse(
+      mock(() => ({ walletAddresses: ['0xabc'] })),
+      request,
+    )
+
+    expect(resolved).toEqual({ walletAddresses: ['0xabc'] })
+  })
+})

--- a/e2e/mocks/resolveResponse.ts
+++ b/e2e/mocks/resolveResponse.ts
@@ -1,0 +1,17 @@
+import { echoJsonRpcId } from './jsonRpc.js'
+import type { MockRequest, MockRequestContext } from './types.js'
+
+/**
+ * Shared by both adapters so a function response behaves identically in each.
+ *
+ * Invoke before echoing: `echoJsonRpcId` takes an `object`, which a function
+ * satisfies, so the reverse order would return it un-invoked.
+ */
+export function resolveMockResponse(
+  mock: MockRequest,
+  request: MockRequestContext,
+): object {
+  const body =
+    typeof mock.response === 'function' ? mock.response(request) : mock.response
+  return echoJsonRpcId(body, request.body)
+}

--- a/e2e/mocks/routeMocks.test.ts
+++ b/e2e/mocks/routeMocks.test.ts
@@ -308,4 +308,110 @@ describe('routeMocks', () => {
 
     expect(handle.hits()).toBe(0)
   })
+
+  it('resolves a function response instead of serialising the function', async () => {
+    const router = createRouter()
+    await routeMocks(router.page, [
+      { ...userWallet, response: () => ({ walletAddresses: ['0xdynamic'] }) },
+    ])
+
+    const res = await router.send({ url: 'https://kms.test/p/user-wallet' })
+
+    // `JSON.stringify(fn)` is `undefined`, so an unresolved function serves an
+    // empty body instead of failing loudly.
+    expect(res.json).toEqual({ walletAddresses: ['0xdynamic'] })
+  })
+
+  it('re-evaluates a function response on every request', async () => {
+    const router = createRouter()
+    let served = 0
+    await routeMocks(router.page, [
+      { ...userWallet, response: () => ({ served: ++served }) },
+    ])
+
+    const first = await router.send({ url: 'https://kms.test/p/user-wallet' })
+    const second = await router.send({ url: 'https://kms.test/p/user-wallet' })
+
+    // A definition that changes state between assertions depends on this;
+    // resolving once at install would serve the same body forever.
+    expect(first.json).toEqual({ served: 1 })
+    expect(second.json).toEqual({ served: 2 })
+  })
+
+  it("echoes the request's JSON-RPC id onto a function response", async () => {
+    const router = createRouter()
+    await routeMocks(router.page, [
+      {
+        url: RPC_URL,
+        method: 'POST',
+        payload: { method: 'eth_chainId' },
+        response: () => ({ jsonrpc: '2.0', id: 0, result: '0x1' }),
+      },
+    ])
+
+    const res = await router.send({
+      url: RPC_URL,
+      method: 'POST',
+      postData: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 7,
+        method: 'eth_chainId',
+      }),
+    })
+
+    // `echoJsonRpcId` takes an `object` and a function passes that check, so a
+    // function resolved in the wrong order slips through un-echoed.
+    expect(res.json).toEqual({ jsonrpc: '2.0', id: 7, result: '0x1' })
+  })
+
+  it('never invokes the function of a mock that lost on priority', async () => {
+    const router = createRouter()
+    let loserCalls = 0
+    await routeMocks(router.page, [
+      {
+        ...userWallet,
+        priority: 5,
+        response: () => ({ winner: true }),
+      },
+      {
+        ...userWallet,
+        priority: 1,
+        response: () => {
+          loserCalls += 1
+          return { winner: false }
+        },
+      },
+    ])
+
+    const res = await router.send({ url: 'https://kms.test/p/user-wallet' })
+
+    // A stateful definition advances on being served, so invoking a loser
+    // would move state no test asked to move.
+    expect(res.json).toEqual({ winner: true })
+    expect(loserCalls).toBe(0)
+  })
+
+  it('passes the matched url, method and body to a function response', async () => {
+    const router = createRouter()
+    const postData = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_call',
+    })
+    await routeMocks(router.page, [
+      {
+        url: RPC_URL,
+        method: 'POST',
+        response: (request) => ({ seen: request }),
+      },
+    ])
+
+    const res = await router.send({ url: RPC_URL, method: 'POST', postData })
+
+    // Reading the request is what lets a response depend on what was asked —
+    // sizing a multicall reply to its batch, or paging a list.
+    expect(res.json).toEqual({
+      seen: { url: RPC_URL, method: 'POST', body: postData },
+    })
+  })
 })

--- a/e2e/mocks/routeMocks.test.ts
+++ b/e2e/mocks/routeMocks.test.ts
@@ -7,55 +7,73 @@ type Fulfilled = { status?: number; contentType?: string; body?: string }
 type RouteHandler = (route: unknown) => Promise<unknown>
 
 /**
- * Stands in for a Playwright `Page`. `routeMocks` only ever calls `page.route`,
- * so capturing the handler is enough to exercise it without a browser — these
- * stay in the fast suite alongside the matcher's own tests.
+ * Stands in for a Playwright `Page`, modelling the parts `routeMocks` uses:
+ * handlers run in reverse registration order, `fallback()` defers to the next
+ * one, and `continue()` goes straight to the network without consulting it.
  */
 function createRouter() {
-  let handler: RouteHandler | undefined
-  let pattern: string | undefined
+  let installed: { pattern: string; handler: RouteHandler }[] = []
 
   const page = {
-    route: async (p: string, h: RouteHandler) => {
-      pattern = p
-      handler = h
+    route: async (pattern: string, handler: RouteHandler) => {
+      installed.push({ pattern, handler })
+    },
+    unroute: async (_pattern: string, handler: RouteHandler) => {
+      installed = installed.filter((entry) => entry.handler !== handler)
     },
   }
 
-  /** Drives one request through the installed handler. */
+  /** Drives one request through the installed handlers. */
   async function send(request: {
     url: string
     method?: string
     /** Absent means a body-less request, where Playwright returns null. */
     postData?: string
   }) {
-    if (!handler) throw new Error('routeMocks never installed a route')
-
     let fulfilled: Fulfilled | undefined
     let continued = false
+    /** Every handler deferred, so Playwright would perform the request. */
+    let fellThrough = false
 
-    await handler({
-      request: () => ({
-        url: () => request.url,
-        method: () => request.method ?? 'GET',
-        postData: () => request.postData ?? null,
-      }),
-      fulfill: async (options: Fulfilled) => {
-        fulfilled = options
-      },
-      continue: async () => {
-        continued = true
-      },
-    })
+    const ordered = [...installed].reverse()
+    let next = 0
+    const run = async (): Promise<void> => {
+      const entry = ordered[next++]
+      if (!entry) {
+        fellThrough = true
+        return
+      }
+      await entry.handler({
+        request: () => ({
+          url: () => request.url,
+          method: () => request.method ?? 'GET',
+          postData: () => request.postData ?? null,
+        }),
+        fulfill: async (options: Fulfilled) => {
+          fulfilled = options
+        },
+        continue: async () => {
+          continued = true
+        },
+        fallback: run,
+      })
+    }
+    await run()
 
     return {
       fulfilled,
       continued,
+      fellThrough,
       json: fulfilled?.body ? JSON.parse(fulfilled.body) : undefined,
     }
   }
 
-  return { page: page as unknown as Page, send, pattern: () => pattern }
+  return {
+    page: page as unknown as Page,
+    send,
+    pattern: () => installed[0]?.pattern,
+    installed: () => installed.length,
+  }
 }
 
 const RPC_URL = 'https://rpc.test/v1'
@@ -115,7 +133,7 @@ describe('routeMocks', () => {
 
     const res = await router.send({ url: 'https://kms.test/p/something-else' })
 
-    expect(res.continued).toBe(true)
+    expect(res.fellThrough).toBe(true)
     expect(res.fulfilled).toBeUndefined()
   })
 
@@ -147,7 +165,7 @@ describe('routeMocks', () => {
       method: 'POST',
     })
 
-    expect(res.continued).toBe(true)
+    expect(res.fellThrough).toBe(true)
   })
 
   it('lets a higher-priority mock win regardless of listed order', async () => {
@@ -279,7 +297,7 @@ describe('routeMocks', () => {
 
     // Reaching the substring check with a null body would throw inside the
     // route handler rather than simply not match.
-    expect(res.continued).toBe(true)
+    expect(res.fellThrough).toBe(true)
     expect(res.fulfilled).toBeUndefined()
   })
 
@@ -307,6 +325,47 @@ describe('routeMocks', () => {
     await router.send({ url: 'https://kms.test/p/unmatched' })
 
     expect(handle.hits()).toBe(0)
+  })
+
+  it('defers unmatched traffic to an earlier install instead of the network', async () => {
+    const router = createRouter()
+    await routeMocks(router.page, [userWallet])
+    await routeMocks(router.page, [
+      { url: RPC_URL, method: 'POST', response: { unrelated: true } },
+    ])
+
+    const res = await router.send({ url: 'https://kms.test/p/user-wallet' })
+
+    // Playwright runs the last registration first and `continue()` skips the
+    // rest, so a second install would otherwise silently blind the first —
+    // serving real data rather than failing.
+    expect(res.json).toEqual({ walletAddresses: ['0xabc'] })
+    expect(res.continued).toBe(false)
+  })
+
+  it('stops serving once disposed', async () => {
+    const router = createRouter()
+    const handle = await routeMocks(router.page, [userWallet])
+
+    await handle.dispose()
+    const res = await router.send({ url: 'https://kms.test/p/user-wallet' })
+
+    expect(res.fulfilled).toBeUndefined()
+    expect(res.fellThrough).toBe(true)
+  })
+
+  it('disposes only its own handler', async () => {
+    const router = createRouter()
+    const first = await routeMocks(router.page, [userWallet])
+    await routeMocks(router.page, [
+      { ...userWallet, response: { walletAddresses: ['0xsecond'] } },
+    ])
+
+    await first.dispose()
+    const res = await router.send({ url: 'https://kms.test/p/user-wallet' })
+
+    expect(router.installed()).toBe(1)
+    expect(res.json).toEqual({ walletAddresses: ['0xsecond'] })
   })
 
   it('resolves a function response instead of serialising the function', async () => {

--- a/e2e/mocks/routeMocks.ts
+++ b/e2e/mocks/routeMocks.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test'
+import type { Page, Route } from '@playwright/test'
 import { matchMock } from './installMockFetch.js'
 import { orderMocks } from './orderMocks.js'
 import { resolveMockResponse } from './resolveResponse.js'
@@ -28,7 +28,11 @@ export type MockHandle = {
    * worth guarding.
    */
   hits: () => number
+  /** Remove this install, leaving any other untouched. */
+  dispose: () => Promise<void>
 }
+
+const ALL_REQUESTS = '**/*'
 
 export async function routeMocks(
   page: Page,
@@ -39,7 +43,7 @@ export async function routeMocks(
   const ordered = orderMocks(mocks)
   let hits = 0
 
-  await page.route('**/*', async (route) => {
+  const handler = async (route: Route) => {
     const request = route.request()
     const context: MockRequestContext = {
       url: request.url(),
@@ -60,7 +64,10 @@ export async function routeMocks(
           }),
         })
       }
-      return route.continue()
+      // `fallback`, not `continue`: handlers run newest-first, and `continue`
+      // would send the request off without consulting an earlier install,
+      // silently blinding it.
+      return route.fallback()
     }
 
     hits += 1
@@ -71,7 +78,12 @@ export async function routeMocks(
       contentType: 'application/json',
       body: JSON.stringify(resolveMockResponse(mock, context)),
     })
-  })
+  }
 
-  return { hits: () => hits }
+  await page.route(ALL_REQUESTS, handler)
+
+  return {
+    hits: () => hits,
+    dispose: () => page.unroute(ALL_REQUESTS, handler),
+  }
 }

--- a/e2e/mocks/routeMocks.ts
+++ b/e2e/mocks/routeMocks.ts
@@ -1,8 +1,12 @@
 import type { Page } from '@playwright/test'
 import { matchMock } from './installMockFetch.js'
-import { echoJsonRpcId } from './jsonRpc.js'
 import { orderMocks } from './orderMocks.js'
-import type { MockRequest, UnmatchedPolicy } from './types.js'
+import { resolveMockResponse } from './resolveResponse.js'
+import type {
+  MockRequest,
+  MockRequestContext,
+  UnmatchedPolicy,
+} from './types.js'
 
 /**
  * Serves `MockRequest[]` to a page through Playwright's own request
@@ -37,12 +41,12 @@ export async function routeMocks(
 
   await page.route('**/*', async (route) => {
     const request = route.request()
-    const body = request.postData() ?? ''
-    const mock = matchMock(ordered, {
+    const context: MockRequestContext = {
       url: request.url(),
       method: request.method(),
-      body,
-    })
+      body: request.postData() ?? '',
+    }
+    const mock = matchMock(ordered, context)
 
     if (!mock) {
       if (unmatched === 'block') {
@@ -51,8 +55,8 @@ export async function routeMocks(
           contentType: 'application/json',
           body: JSON.stringify({
             error: 'No mock matched',
-            method: request.method(),
-            url: request.url(),
+            method: context.method,
+            url: context.url,
           }),
         })
       }
@@ -65,7 +69,7 @@ export async function routeMocks(
     await route.fulfill({
       status: mock.status ?? 200,
       contentType: 'application/json',
-      body: JSON.stringify(echoJsonRpcId(mock.response, body)),
+      body: JSON.stringify(resolveMockResponse(mock, context)),
     })
   })
 

--- a/e2e/mocks/types.ts
+++ b/e2e/mocks/types.ts
@@ -8,6 +8,17 @@ export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
  */
 export type UnmatchedPolicy = 'passthrough' | 'block'
 
+/** The request as both adapters see it. `body` is `''` when there is none. */
+export interface MockRequestContext {
+  url: string
+  method: string
+  body: string
+}
+
+export type MockResponseFn = (request: MockRequestContext) => object
+
+export type MockResponse = object | MockResponseFn
+
 export interface MockRequest {
   /**
    * Matched against the request's REAL full URL (host + path), because the
@@ -29,8 +40,8 @@ export interface MockRequest {
    * them apart, e.g. `'0x70a08231'` for `balanceOf`.
    */
   bodyIncludes?: string
-  /** JSON body returned on match. */
-  response: object
+  /** JSON body returned on match, or a function computing it per request. */
+  response: MockResponse
   /** HTTP status returned on match. Defaults to 200. */
   status?: number
   /** Higher wins when multiple mocks match. Defaults to 0. */


### PR DESCRIPTION
This PR adds browser E2E coverage for SRA and updates the qa-lab to use the same mocks for manual testing.

#### Test Cases added:
- drives one deposit from detected through routing to received
- shows a deposit that fails after bridging as Failed
- arrives as whichever token is selected to send
- offers every network the token claims to support
- shows the create-failure card and recovers on retry
- shows the no-routes card when creation returns no estimates
- shows the polling-failure card only once a poll has succeeded
- opens a past deposit and shows the route it was made on
- checks all quote details are being displayed

#### QA Lab demo
Success deposit simulation:

https://github.com/user-attachments/assets/1f7b0f2e-fe1c-4745-971f-250974441877

Failed deposit simulation:

https://github.com/user-attachments/assets/a919b89f-1734-4534-a018-2ac5541dccef

Other mocks:

https://github.com/user-attachments/assets/8bedea9f-2466-4038-b9f1-5aba152abe3b

