### PR TITLE
refactor(sra): set slippage to required

### DIFF
--- a/.changeset/firm-slippage-required.md
+++ b/.changeset/firm-slippage-required.md
@@ -1,0 +1,12 @@
+---
+'@zerodev/smart-routing-address-react-ui': patch
+---
+
+feat: require `slippage` in `SmartRoutingAddressConfig`
+
+`@zerodev/smart-routing-address` 0.2.6 makes `slippage` a required
+`createSmartRoutingAddress` param (the SRA server no longer supplies a
+default), so the config field is now required too. The widget's
+"Max slippage" row always renders as a result. Pick values with care:
+tight slippage inflates `minDeposit`, which the server computes as
+~fee / slippage.

--- a/apps/qa-lab-testing/src/app/components/sra/SraDepositPanel.tsx
+++ b/apps/qa-lab-testing/src/app/components/sra/SraDepositPanel.tsx
@@ -16,6 +16,8 @@ const TARGET_CHAIN = arbitrum;
 
 const SRA_CONFIG: SmartRoutingAddressConfig = {
   targetChainId: TARGET_CHAIN.id,
+  // Required since @zerodev/smart-routing-address 0.2.6 (no server default).
+  slippage: 100,
 };
 
 export function SraDepositPanel() {

--- a/apps/qa-lab-testing/src/app/components/sra/SraDepositPanel.tsx
+++ b/apps/qa-lab-testing/src/app/components/sra/SraDepositPanel.tsx
@@ -16,7 +16,6 @@ const TARGET_CHAIN = arbitrum;
 
 const SRA_CONFIG: SmartRoutingAddressConfig = {
   targetChainId: TARGET_CHAIN.id,
-  // Required since @zerodev/smart-routing-address 0.2.6 (no server default).
   slippage: 100,
 };
 

--- a/apps/sra-demo/src/app/page.tsx
+++ b/apps/sra-demo/src/app/page.tsx
@@ -63,10 +63,11 @@ export default function Home() {
   const [lastMainnetRecipient, setLastMainnetRecipient] =
     useState<Address | null>(null)
   const [targetChainId, setTargetChainId] = useState<number>(arbitrum.id)
-  // `undefined` = don't send `slippage` to the widget/SDK, so the SRA server
-  // uses its own default. Tight client-set values (e.g. 50 bps) massively
-  // inflate `minDeposit` since the server computes it as ~fee / slippage.
-  const [slippage, setSlippage] = useState<number | undefined>(undefined)
+  // Required since @zerodev/smart-routing-address 0.2.6 — the server no
+  // longer supplies a default. 100 bps (1%) keeps `minDeposit` reasonable:
+  // tight values (e.g. 50 bps) massively inflate it since the server
+  // computes it as ~fee / slippage.
+  const [slippage, setSlippage] = useState<number>(100)
   // Bumped by `MockControls` after inserting/clearing mock deposits or
   // toggling error/sponsored modes — re-mounts the widget so freshly-added
   // deposits re-baseline as past and new mock state takes effect.
@@ -84,9 +85,7 @@ export default function Home() {
     SIMULATED_DEFAULT_RECIPIENT,
   )
   const [draftChain, setDraftChain] = useState<number>(targetChainId)
-  const [draftSlippage, setDraftSlippage] = useState<number | undefined>(
-    slippage,
-  )
+  const [draftSlippage, setDraftSlippage] = useState<number>(slippage)
 
   // Mock lifecycle owned at page level so the toggle can flip it cleanly.
   // Simulated → install the fetch interceptor + seed past-deposits from
@@ -158,12 +157,7 @@ export default function Home() {
   }
 
   const config = useMemo<SmartRoutingAddressConfig>(
-    // Omit `slippage` when unset so the server picks its default — sending
-    // a tight value (e.g. 50 bps) blows up `minDeposit`.
-    () => ({
-      targetChainId,
-      ...(slippage !== undefined && { slippage }),
-    }),
+    () => ({ targetChainId, slippage }),
     [targetChainId, slippage],
   )
 
@@ -367,39 +361,22 @@ export default function Home() {
                   <span className="flex items-baseline justify-between text-sm font-semibold">
                     Max slippage
                     <span className="text-muted tabular-nums">
-                      {draftSlippage === undefined
-                        ? 'Server default'
-                        : `${(draftSlippage / 100).toFixed(2)}%`}
+                      {`${(draftSlippage / 100).toFixed(2)}%`}
                     </span>
                   </span>
-                  <span className="flex items-center gap-2 text-[13px] text-muted">
-                    <input
-                      type="checkbox"
-                      checked={draftSlippage !== undefined}
-                      onChange={(e) =>
-                        setDraftSlippage(e.target.checked ? 100 : undefined)
-                      }
-                      className="accent-ink"
-                    />
-                    Override server default
-                  </span>
-                  {draftSlippage !== undefined && (
-                    <input
-                      type="range"
-                      min={50}
-                      max={500}
-                      step={10}
-                      value={draftSlippage}
-                      onChange={(e) => setDraftSlippage(Number(e.target.value))}
-                      className="w-full accent-ink"
-                    />
-                  )}
+                  <input
+                    type="range"
+                    min={50}
+                    max={500}
+                    step={10}
+                    value={draftSlippage}
+                    onChange={(e) => setDraftSlippage(Number(e.target.value))}
+                    className="w-full accent-ink"
+                  />
                   <span className="text-[13px] text-muted">
                     Max price movement tolerated while swapping. A tighter value
                     protects the price but raises the minimum deposit, and can
-                    make it fluctuate significantly with gas. Leaving it on{' '}
-                    <b>Server default</b> keeps the minimum deposit at the
-                    lowest.
+                    make it fluctuate significantly with gas.
                   </span>
                 </label>
 

--- a/apps/sra-demo/src/app/page.tsx
+++ b/apps/sra-demo/src/app/page.tsx
@@ -63,10 +63,6 @@ export default function Home() {
   const [lastMainnetRecipient, setLastMainnetRecipient] =
     useState<Address | null>(null)
   const [targetChainId, setTargetChainId] = useState<number>(arbitrum.id)
-  // Required since @zerodev/smart-routing-address 0.2.6 — the server no
-  // longer supplies a default. 100 bps (1%) keeps `minDeposit` reasonable:
-  // tight values (e.g. 50 bps) massively inflate it since the server
-  // computes it as ~fee / slippage.
   const [slippage, setSlippage] = useState<number>(100)
   // Bumped by `MockControls` after inserting/clearing mock deposits or
   // toggling error/sponsored modes — re-mounts the widget so freshly-added

--- a/packages/smart-routing-address-react-ui/README.md
+++ b/packages/smart-routing-address-react-ui/README.md
@@ -47,6 +47,7 @@ function Funding({ recipient }: { recipient: `0x${string}` }) {
       config={{
         projectId: 'your-project-id', // from https://dashboard.zerodev.app
         targetChainId: arbitrum.id,
+        slippage: 100, // max slippage in basis points (100 = 1%)
       }}
     >
       <SmartRoutingAddress recipient={recipient} onClose={() => {}} />
@@ -88,7 +89,7 @@ Everything the widget needs is on the config passed to the provider.
 | `targetChainId` | `number` | Chain id where funds settle. **Required.** |
 | `version` | `SmartRoutingAddressVersion?` | SRA manager version. Defaults to the latest stable. |
 | `actions` | `CreateSmartRoutingAddressParams['actions']?` | Destination actions per token type. When omitted, deposits are simply transferred to the recipient. |
-| `slippage` | `number?` | Max slippage in basis points (50 = 0.5%). When omitted, the SRA server picks its default. |
+| `slippage` | `number` | Max slippage in basis points (50 = 0.5%). **Required.** Tight values inflate `minDeposit` (server computes it as ~fee / slippage). |
 | `baseUrl` | `string?` | Override the SRA server root URL; the `projectId` is appended. |
 
 ## API

--- a/packages/smart-routing-address-react-ui/package.json
+++ b/packages/smart-routing-address-react-ui/package.json
@@ -57,7 +57,7 @@
   ],
   "dependencies": {
     "@zerodev/react-ui": "workspace:*",
-    "@zerodev/smart-routing-address": "^0.2.5",
+    "@zerodev/smart-routing-address": "^0.2.6",
     "uqr": "^0.1.2",
     "zod": "^4.4.3"
   },

--- a/packages/smart-routing-address-react-ui/src/context/SmartRoutingAddressProvider.tsx
+++ b/packages/smart-routing-address-react-ui/src/context/SmartRoutingAddressProvider.tsx
@@ -68,9 +68,7 @@ export function SmartRoutingAddressProvider({
           const result = await createSmartRoutingAddress({
             owner: nextRecipient,
             destChain: resolveDestChain(config),
-            ...(config.slippage !== undefined && {
-              slippage: config.slippage,
-            }),
+            slippage: config.slippage,
             srcTokens: resolveSourceTokens(config),
             ...(resolveActions(config, nextRecipient) && {
               actions: resolveActions(config, nextRecipient),

--- a/packages/smart-routing-address-react-ui/src/pages/Deposit.tsx
+++ b/packages/smart-routing-address-react-ui/src/pages/Deposit.tsx
@@ -221,10 +221,9 @@ export function Deposit({
     return out
   }, [srcTokens, selectedTokenType])
 
-  // Only formatted when the consumer explicitly sets a slippage — otherwise
-  // the server picks its own default and there is no meaningful value to show.
-  const slippage =
-    typeof config.slippage === 'number' ? formatSlippage(config.slippage) : null
+  // Always present: config.slippage is required now that the SRA server no
+  // longer supplies a default.
+  const slippage = formatSlippage(config.slippage)
 
   const minDepositAmount =
     feeData && tokenSymbol
@@ -378,38 +377,36 @@ export function Deposit({
                 }
               />
               <div className="zd:flex zd:w-full zd:flex-col zd:items-start zd:gap-2 zd:px-2 zd:py-4">
-                {slippage && (
-                  <DataRow
-                    label="Max slippage"
-                    value={slippage}
-                    info
-                    infoTooltip={FEE_INFO.maxSlippage}
-                    trailing={
-                      breakdown?.provider &&
-                      PROVIDER_ICONS[breakdown.provider] ? (
-                        <LiveValue
-                          loading={providerFees.loading}
-                          flashKey={breakdown.provider}
-                        >
-                          <Tooltip content={`Quoted via ${breakdown.provider}`}>
-                            <button
-                              type="button"
-                              aria-label={`Quoted via ${breakdown.provider}`}
-                              className="zd:inline-flex zd:items-center zd:justify-center zd:cursor-help zd:outline-none zd:bg-transparent"
-                            >
-                              <img
-                                src={PROVIDER_ICONS[breakdown.provider]}
-                                alt=""
-                                aria-hidden
-                                className="zd:size-4 zd:shrink-0 zd:rounded-[4px] zd:object-cover"
-                              />
-                            </button>
-                          </Tooltip>
-                        </LiveValue>
-                      ) : null
-                    }
-                  />
-                )}
+                <DataRow
+                  label="Max slippage"
+                  value={slippage}
+                  info
+                  infoTooltip={FEE_INFO.maxSlippage}
+                  trailing={
+                    breakdown?.provider &&
+                    PROVIDER_ICONS[breakdown.provider] ? (
+                      <LiveValue
+                        loading={providerFees.loading}
+                        flashKey={breakdown.provider}
+                      >
+                        <Tooltip content={`Quoted via ${breakdown.provider}`}>
+                          <button
+                            type="button"
+                            aria-label={`Quoted via ${breakdown.provider}`}
+                            className="zd:inline-flex zd:items-center zd:justify-center zd:cursor-help zd:outline-none zd:bg-transparent"
+                          >
+                            <img
+                              src={PROVIDER_ICONS[breakdown.provider]}
+                              alt=""
+                              aria-hidden
+                              className="zd:size-4 zd:shrink-0 zd:rounded-[4px] zd:object-cover"
+                            />
+                          </button>
+                        </Tooltip>
+                      </LiveValue>
+                    ) : null
+                  }
+                />
                 <DataRow
                   label="Estimated fee"
                   value={

--- a/packages/smart-routing-address-react-ui/src/test/fixtures.ts
+++ b/packages/smart-routing-address-react-ui/src/test/fixtures.ts
@@ -19,7 +19,6 @@ export const TEST_CONFIG: SmartRoutingAddressConfig = {
   projectId: TEST_PROJECT_ID,
   targetChainId: base.id,
   slippage: 50,
-  pollingInterval: 25,
 }
 
 export const TEST_ESTIMATED_FEES: EstimatedFee[] = [

--- a/packages/smart-routing-address-react-ui/src/types.ts
+++ b/packages/smart-routing-address-react-ui/src/types.ts
@@ -41,10 +41,7 @@ export type SmartRoutingAddressConfig = {
    */
   actions?: CreateSmartRoutingAddressParams['actions']
   /**
-   * Max slippage in basis points (50 = 0.5%). Required — the SRA server no
-   * longer supplies a default (@zerodev/smart-routing-address ≥ 0.2.6).
-   * Note: tight values inflate `minDeposit`, which the server computes as
-   * ~fee / slippage.
+   * Max slippage in basis points (50 = 0.5%).
    */
   slippage: number
   /**

--- a/packages/smart-routing-address-react-ui/src/types.ts
+++ b/packages/smart-routing-address-react-ui/src/types.ts
@@ -40,8 +40,13 @@ export type SmartRoutingAddressConfig = {
    * transferred to the owner.
    */
   actions?: CreateSmartRoutingAddressParams['actions']
-  /** Max slippage in basis points (50 = 0.5%) */
-  slippage?: number
+  /**
+   * Max slippage in basis points (50 = 0.5%). Required — the SRA server no
+   * longer supplies a default (@zerodev/smart-routing-address ≥ 0.2.6).
+   * Note: tight values inflate `minDeposit`, which the server computes as
+   * ~fee / slippage.
+   */
+  slippage: number
   /**
    * Override the smart routing address server root URL; the projectId is
    * appended to it

--- a/packages/smart-routing-address-react-ui/src/utils/config.test.ts
+++ b/packages/smart-routing-address-react-ui/src/utils/config.test.ts
@@ -22,6 +22,7 @@ import {
 /** Minimal config without routes, exercising the defaults */
 const BARE_CONFIG: SmartRoutingAddressConfig = {
   targetChainId: base.id,
+  slippage: 100,
 }
 
 describe('resolveVersion', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -611,8 +611,8 @@ importers:
         specifier: workspace:*
         version: link:../react-ui
       '@zerodev/smart-routing-address':
-        specifier: ^0.2.5
-        version: 0.2.5(typescript@5.9.3)(viem@2.47.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+        specifier: ^0.2.6
+        version: 0.2.6(typescript@5.9.3)(viem@2.47.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       uqr:
         specifier: ^0.1.2
         version: 0.1.3
@@ -4473,7 +4473,6 @@ packages:
   '@safe-global/safe-gateway-typescript-sdk@3.23.1':
     resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
     engines: {node: '>=16'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
@@ -5753,8 +5752,8 @@ packages:
     peerDependencies:
       viem: ^2.28.0
 
-  '@zerodev/smart-routing-address@0.2.5':
-    resolution: {integrity: sha512-LtHwb7trl/4huwbbP590Rb58vHoeBFsEanwwyqVu1TaB1VvDI4NUSnLyNnPYt5g0i7+yF1yPSmfHsU1vAQD80g==}
+  '@zerodev/smart-routing-address@0.2.6':
+    resolution: {integrity: sha512-mGb3Bx+YDrCafuaIXeNMXfQ9XEheV8USaKWn5IyH4HLmA0RBzsO4DyKPoH8KG65IHu7bTWuUC91//uStVbyYdA==}
     peerDependencies:
       typescript: ^5.0.0
       viem: ^2.47.18
@@ -18212,7 +18211,7 @@ snapshots:
       semver: 7.8.5
       viem: 2.54.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
 
-  '@zerodev/smart-routing-address@0.2.5(typescript@5.9.3)(viem@2.47.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))':
+  '@zerodev/smart-routing-address@0.2.6(typescript@5.9.3)(viem@2.47.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))':
     dependencies:
       typescript: 5.9.3
       viem: 2.47.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
@@ -23794,7 +23793,7 @@ snapshots:
       ox: 0.9.17(typescript@5.9.3)(zod@4.4.3)
       viem: 2.54.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       zod: 4.4.3
-      zustand: 5.0.14(@types/react@19.2.17)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+      zustand: 5.0.3(@types/react@19.2.17)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     optionalDependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.3)
       expo-web-browser: 56.0.5(expo@56.0.15)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))


### PR DESCRIPTION
### Summary

This PR updates `@zerodev/smart-routing-address` to `v0.2.6` which sets `slippage` to required

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
