### PR TITLE
feat(wallet-ui): WalletConnect support - QA changes

### DIFF
--- a/packages/wallet-react-ui/README.md
+++ b/packages/wallet-react-ui/README.md
@@ -172,10 +172,10 @@ import { ConnectWallet, SignUp } from '@zerodev/wallet-react-ui'
   and `maxWallets` caps the list (default 4, known wallets ranked first).
 - `SignUp.WalletConnect` renders a "WalletConnect" row that opens a pairing
   sheet: a QR code any mobile wallet can scan, plus a copy-link fallback. The
-  pairing preloads when the sign-up page mounts so the QR is ready on open,
-  and re-pairs automatically when the link expires. On phones, tapping a
-  known wallet's row deep-links straight into its app; the sheet opens behind
-  it as the fallback. The row renders nothing unless a `zeroDevWalletConnect`
+  pairing preloads when the sign-up page mounts so the QR is ready on open;
+  when it expires, WalletConnect's own error shows in the sheet with a
+  one-tap Try again. On phones, tapping a known wallet's row deep-links
+  straight into its app; the sheet opens behind it as the fallback. The row renders nothing unless a `zeroDevWalletConnect`
   connector is in your wagmi config.
 - `SignUp.MoreWallets` renders a row that opens an overlay sheet with the full
   wallet grid — every known wallet plus any other live connector; installed

--- a/packages/wallet-react-ui/README.md
+++ b/packages/wallet-react-ui/README.md
@@ -172,9 +172,11 @@ import { ConnectWallet, SignUp } from '@zerodev/wallet-react-ui'
   and `maxWallets` caps the list (default 4, known wallets ranked first).
 - `SignUp.WalletConnect` renders a "WalletConnect" row that opens a pairing
   sheet: a QR code any mobile wallet can scan, plus a copy-link fallback. The
-  pairing starts when the sheet opens and a fresh link is generated per open.
-  The row renders nothing unless a `zeroDevWalletConnect` connector is in
-  your wagmi config.
+  pairing preloads when the sign-up page mounts so the QR is ready on open,
+  and re-pairs automatically when the link expires. On phones, tapping a
+  known wallet's row deep-links straight into its app; the sheet opens behind
+  it as the fallback. The row renders nothing unless a `zeroDevWalletConnect`
+  connector is in your wagmi config.
 - `SignUp.MoreWallets` renders a row that opens an overlay sheet with the full
   wallet grid — every known wallet plus any other live connector; installed
   ones connect, the rest link to the vendor's download page. With

--- a/packages/wallet-react-ui/src/auth/components/WalletSheet/WalletSheet.test.tsx
+++ b/packages/wallet-react-ui/src/auth/components/WalletSheet/WalletSheet.test.tsx
@@ -53,7 +53,6 @@ function fakePairing(
 ): WalletConnectPairing {
   return {
     uri: null,
-    expiresAt: null,
     error: null,
     retry: vi.fn(),
     deepLinkFor: () => null,
@@ -164,31 +163,5 @@ describe('WalletSheet', () => {
     })
     expect(writeText).toHaveBeenCalledWith('wc:copy@2')
     expect(screen.getByText('Copied')).toBeDefined()
-  })
-
-  it('re-pairs immediately when opened onto a stale URI', () => {
-    const pairing = fakePairing({
-      uri: 'wc:old@2',
-      expiresAt: Date.now() - 1,
-    })
-    render(<WalletSheet open onOpenChange={() => {}} pairing={pairing} />)
-    expect(pairing.retry).toHaveBeenCalledTimes(1)
-  })
-
-  it('re-pairs when the URI expires while the sheet is open', () => {
-    vi.useFakeTimers()
-    try {
-      const pairing = fakePairing({
-        uri: 'wc:live@2',
-        expiresAt: Date.now() + 30_000,
-      })
-      render(<WalletSheet open onOpenChange={() => {}} pairing={pairing} />)
-      expect(pairing.retry).not.toHaveBeenCalled()
-
-      act(() => vi.advanceTimersByTime(30_000))
-      expect(pairing.retry).toHaveBeenCalledTimes(1)
-    } finally {
-      vi.useRealTimers()
-    }
   })
 })

--- a/packages/wallet-react-ui/src/auth/components/WalletSheet/WalletSheet.test.tsx
+++ b/packages/wallet-react-ui/src/auth/components/WalletSheet/WalletSheet.test.tsx
@@ -4,6 +4,7 @@
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WalletConnectPairing } from '../../hooks/useWalletConnectPairing'
 import { WALLET_GUIDE } from '../../walletGuide'
 import { WalletSheet } from './index'
 
@@ -39,41 +40,24 @@ vi.mock('../../hooks/useAuth', () => ({
   useAuth: () => ({ goToStep }),
 }))
 
-// Not a mobile device unless a test overrides it — keeps the auto-deeplink
-// effect quiet.
-const mobile = vi.hoisted(() => ({ value: false }))
-vi.mock('../../utils/isMobile', () => ({
-  isMobile: () => mobile.value,
-}))
-
 const connect = vi.fn()
 let connectors: unknown[] = []
 vi.mock('wagmi', () => ({
   useConnectors: () => connectors,
   useConnect: () => ({ mutate: connect }),
-  useConnections: () => [],
 }))
 
-type MessageHandler = (event: { type: string; data?: unknown }) => void
-
-function fakeWcConnector() {
-  const handlers = new Set<MessageHandler>()
+/** Prop double for the page-level pairing the SignUp root provides. */
+function fakePairing(
+  over: Partial<WalletConnectPairing> = {},
+): WalletConnectPairing {
   return {
-    uid: crypto.randomUUID(),
-    id: 'walletConnect',
-    type: 'walletConnect',
-    zdWalletConnect: true,
-    emitter: {
-      on: (_event: string, handler: MessageHandler) => {
-        handlers.add(handler)
-      },
-      off: (_event: string, handler: MessageHandler) => {
-        handlers.delete(handler)
-      },
-    },
-    emit: (event: { type: string; data?: unknown }) => {
-      for (const handler of handlers) handler(event)
-    },
+    uri: null,
+    expiresAt: null,
+    error: null,
+    retry: vi.fn(),
+    deepLinkFor: () => null,
+    ...over,
   }
 }
 
@@ -86,41 +70,35 @@ beforeEach(() => {
 })
 
 describe('WalletSheet', () => {
-  it('starts a fresh pairing per open and none while closed', () => {
-    const wc = fakeWcConnector()
-    connectors = [wc]
+  it('generic mode: no tabs, spinner until the URI lands, then a raw-URI QR', () => {
     const { rerender } = render(
-      <WalletSheet open={false} onOpenChange={() => {}} />,
+      <WalletSheet open onOpenChange={() => {}} pairing={fakePairing()} />,
     )
-    expect(connect).not.toHaveBeenCalled()
-
-    rerender(<WalletSheet open onOpenChange={() => {}} />)
-    expect(connect).toHaveBeenCalledTimes(1)
-
-    rerender(<WalletSheet open={false} onOpenChange={() => {}} />)
-    rerender(<WalletSheet open onOpenChange={() => {}} />)
-    expect(connect).toHaveBeenCalledTimes(2)
-  })
-
-  it('generic mode: no tabs, raw-URI QR once the link arrives', () => {
-    const wc = fakeWcConnector()
-    connectors = [wc]
-    render(<WalletSheet open onOpenChange={() => {}} />)
+    expect(screen.queryByText('Mobile')).toBeNull()
     // Pending state: no QR yet, copy stays disabled until the URI arrives.
     expect(screen.queryByTestId('qr')).toBeNull()
     expect(screen.getByText('Copy link').closest('button')?.disabled).toBe(true)
-    expect(screen.queryByText('Mobile')).toBeNull()
 
-    act(() => wc.emit({ type: 'display_uri', data: 'wc:raw@2' }))
+    rerender(
+      <WalletSheet
+        open
+        onOpenChange={() => {}}
+        pairing={fakePairing({ uri: 'wc:raw@2' })}
+      />,
+    )
     expect(screen.getByTestId('qr').getAttribute('data-value')).toBe('wc:raw@2')
   })
 
   it('per-wallet mobile tab wraps the URI in the wallet deep link', () => {
-    const wc = fakeWcConnector()
-    connectors = [wc]
-    render(<WalletSheet open onOpenChange={() => {}} wallet={metamask} />)
+    render(
+      <WalletSheet
+        open
+        onOpenChange={() => {}}
+        wallet={metamask}
+        pairing={fakePairing({ uri: 'wc:abc@2' })}
+      />,
+    )
     // Not installed → Mobile preselected.
-    act(() => wc.emit({ type: 'display_uri', data: 'wc:abc@2' }))
     expect(screen.getByTestId('qr').getAttribute('data-value')).toBe(
       `${metamask.mobileLink}${encodeURIComponent('wc:abc@2')}`,
     )
@@ -128,10 +106,16 @@ describe('WalletSheet', () => {
   })
 
   it('defaults to the Browser tab when a connector claims the wallet', () => {
-    const wc = fakeWcConnector()
     const announced = { id: 'io.metamask', uid: crypto.randomUUID() }
-    connectors = [wc, announced]
-    render(<WalletSheet open onOpenChange={() => {}} wallet={metamask} />)
+    connectors = [announced]
+    render(
+      <WalletSheet
+        open
+        onOpenChange={() => {}}
+        wallet={metamask}
+        pairing={fakePairing()}
+      />,
+    )
 
     const button = screen.getByText(`Open in ${metamask.name}`)
     fireEvent.click(button)
@@ -141,38 +125,70 @@ describe('WalletSheet', () => {
   })
 
   it('Browser tab links to the download page when nothing claims the wallet', () => {
-    const wc = fakeWcConnector()
-    connectors = [wc]
-    render(<WalletSheet open onOpenChange={() => {}} wallet={metamask} />)
+    render(
+      <WalletSheet
+        open
+        onOpenChange={() => {}}
+        wallet={metamask}
+        pairing={fakePairing()}
+      />,
+    )
     fireEvent.click(screen.getByText('Browser'))
     const link = screen.getByText(`Get ${metamask.name}`)
     expect(link.getAttribute('href')).toBe(metamask.downloadUrl)
   })
 
-  it('shows pairing errors with a retry that reconnects', () => {
-    const wc = fakeWcConnector()
-    connectors = [wc]
-    render(<WalletSheet open onOpenChange={() => {}} />)
-    act(() => connect.mock.calls[0][1].onError(new Error('relay down')))
+  it('shows pairing errors with a retry', () => {
+    const pairing = fakePairing({ error: 'relay down' })
+    render(<WalletSheet open onOpenChange={() => {}} pairing={pairing} />)
     expect(screen.getByText('relay down')).toBeDefined()
 
     fireEvent.click(screen.getByText('Try again'))
-    expect(connect).toHaveBeenCalledTimes(2)
+    expect(pairing.retry).toHaveBeenCalledTimes(1)
   })
 
   it('copies the raw URI', async () => {
     const writeText = vi
       .spyOn(navigator.clipboard, 'writeText')
       .mockResolvedValue(undefined)
-    const wc = fakeWcConnector()
-    connectors = [wc]
-    render(<WalletSheet open onOpenChange={() => {}} />)
-    act(() => wc.emit({ type: 'display_uri', data: 'wc:copy@2' }))
+    render(
+      <WalletSheet
+        open
+        onOpenChange={() => {}}
+        pairing={fakePairing({ uri: 'wc:copy@2' })}
+      />,
+    )
 
     await act(async () => {
       fireEvent.click(screen.getByText('Copy link'))
     })
     expect(writeText).toHaveBeenCalledWith('wc:copy@2')
     expect(screen.getByText('Copied')).toBeDefined()
+  })
+
+  it('re-pairs immediately when opened onto a stale URI', () => {
+    const pairing = fakePairing({
+      uri: 'wc:old@2',
+      expiresAt: Date.now() - 1,
+    })
+    render(<WalletSheet open onOpenChange={() => {}} pairing={pairing} />)
+    expect(pairing.retry).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-pairs when the URI expires while the sheet is open', () => {
+    vi.useFakeTimers()
+    try {
+      const pairing = fakePairing({
+        uri: 'wc:live@2',
+        expiresAt: Date.now() + 30_000,
+      })
+      render(<WalletSheet open onOpenChange={() => {}} pairing={pairing} />)
+      expect(pairing.retry).not.toHaveBeenCalled()
+
+      act(() => vi.advanceTimersByTime(30_000))
+      expect(pairing.retry).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/wallet-react-ui/src/auth/components/WalletSheet/index.tsx
+++ b/packages/wallet-react-ui/src/auth/components/WalletSheet/index.tsx
@@ -7,13 +7,12 @@ import {
   QrCode,
   Text,
 } from '@zerodev/react-ui'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useConnect, useConnectors } from 'wagmi'
 import { walletConnectLogo } from '../../brandAssets'
 import { useAuth } from '../../hooks/useAuth'
-import { useWalletConnectPairing } from '../../hooks/useWalletConnectPairing'
+import type { WalletConnectPairing } from '../../hooks/useWalletConnectPairing'
 import { isCancellationError } from '../../utils/isCancellationError'
-import { isMobile } from '../../utils/isMobile'
 import { matchesWallet, type WalletGuideEntry } from '../../walletGuide'
 
 export type WalletSheetProps = {
@@ -21,30 +20,44 @@ export type WalletSheetProps = {
   onOpenChange: (open: boolean) => void
   /** Absent = generic WalletConnect mode (raw-URI QR, no tabs). */
   wallet?: WalletGuideEntry | undefined
+  /** Page-level pairing (preloaded by the SignUp root) shared by every wallet
+   * surface — the sheet renders it and re-pairs it on expiry. */
+  pairing: WalletConnectPairing
 }
 
 /**
  * Bottom sheet with the connection paths for one wallet (or the generic
- * WalletConnect pairing). The pairing lives in the sheet body, which Radix
- * mounts only while open — opening the sheet starts a fresh pairing,
- * closing it abandons it.
+ * WalletConnect pairing). The pairing is preloaded at page level so the QR is
+ * ready on open and mobile row taps can deep-link synchronously; while the
+ * sheet is open the body re-pairs whenever the URI expires.
  */
-export function WalletSheet({ open, onOpenChange, wallet }: WalletSheetProps) {
+export function WalletSheet({
+  open,
+  onOpenChange,
+  wallet,
+  pairing,
+}: WalletSheetProps) {
   return (
     <BottomSheet open={open} onOpenChange={onOpenChange}>
       <BottomSheetContent className="zd:p-4">
         <BottomSheetTitle>
           {wallet ? `Connect ${wallet.name}` : 'WalletConnect'}
         </BottomSheetTitle>
-        <SheetBody wallet={wallet} />
+        <SheetBody wallet={wallet} pairing={pairing} />
       </BottomSheetContent>
     </BottomSheet>
   )
 }
 
-function SheetBody({ wallet }: { wallet?: WalletGuideEntry | undefined }) {
+function SheetBody({
+  wallet,
+  pairing,
+}: {
+  wallet?: WalletGuideEntry | undefined
+  pairing: WalletConnectPairing
+}) {
   const { goToStep } = useAuth()
-  const { uri, error, retry } = useWalletConnectPairing()
+  const { uri, expiresAt, error, retry } = pairing
   const connectors = useConnectors()
   const { mutate: connect } = useConnect()
 
@@ -59,6 +72,20 @@ function SheetBody({ wallet }: { wallet?: WalletGuideEntry | undefined }) {
   const [connectError, setConnectError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
 
+  // Re-pair when the URI expires while the sheet is open so the QR never goes
+  // dead in front of the user; a stale-on-open URI hits the immediate branch.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: retry identity changes per render — the re-pair is keyed on expiry/error state only
+  useEffect(() => {
+    if (error || !expiresAt) return
+    const delay = expiresAt - Date.now()
+    if (delay <= 0) {
+      retry()
+      return
+    }
+    const id = setTimeout(retry, delay)
+    return () => clearTimeout(id)
+  }, [expiresAt, error])
+
   // Wallet-specific QR encodes the wallet's own deep link so phone cameras
   // route to THAT app (`wc:` is claimed by every wallet app). Generic mode
   // keeps the raw URI so any wallet's in-app scanner can claim the pairing.
@@ -66,15 +93,6 @@ function SheetBody({ wallet }: { wallet?: WalletGuideEntry | undefined }) {
     uri && wallet?.mobileLink
       ? `${wallet.mobileLink}${encodeURIComponent(uri)}`
       : uri
-
-  // Route the phone straight into the wallet's app once the URI lands.
-  const firedRef = useRef(false)
-  useEffect(() => {
-    if (!firedRef.current && wallet?.mobileLink && uri && isMobile()) {
-      firedRef.current = true
-      window.location.href = `${wallet.mobileLink}${encodeURIComponent(uri)}`
-    }
-  }, [wallet, uri])
 
   const copyUri = async () => {
     if (!uri) return

--- a/packages/wallet-react-ui/src/auth/components/WalletSheet/index.tsx
+++ b/packages/wallet-react-ui/src/auth/components/WalletSheet/index.tsx
@@ -7,7 +7,7 @@ import {
   QrCode,
   Text,
 } from '@zerodev/react-ui'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useConnect, useConnectors } from 'wagmi'
 import { walletConnectLogo } from '../../brandAssets'
 import { useAuth } from '../../hooks/useAuth'
@@ -21,15 +21,17 @@ export type WalletSheetProps = {
   /** Absent = generic WalletConnect mode (raw-URI QR, no tabs). */
   wallet?: WalletGuideEntry | undefined
   /** Page-level pairing (preloaded by the SignUp root) shared by every wallet
-   * surface — the sheet renders it and re-pairs it on expiry. */
+   * surface. Expiry is WalletConnect's own signal: the rejected connect()
+   * surfaces through `error` and the existing Try-again re-pairs. */
   pairing: WalletConnectPairing
 }
 
 /**
  * Bottom sheet with the connection paths for one wallet (or the generic
  * WalletConnect pairing). The pairing is preloaded at page level so the QR is
- * ready on open and mobile row taps can deep-link synchronously; while the
- * sheet is open the body re-pairs whenever the URI expires.
+ * ready on open and mobile row taps can deep-link synchronously; when the
+ * proposal expires, WalletConnect rejects the pending connect and the error
+ * branch offers Try again.
  */
 export function WalletSheet({
   open,
@@ -57,7 +59,7 @@ function SheetBody({
   pairing: WalletConnectPairing
 }) {
   const { goToStep } = useAuth()
-  const { uri, expiresAt, error, retry } = pairing
+  const { uri, error, retry } = pairing
   const connectors = useConnectors()
   const { mutate: connect } = useConnect()
 
@@ -71,20 +73,6 @@ function SheetBody({
   )
   const [connectError, setConnectError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
-
-  // Re-pair when the URI expires while the sheet is open so the QR never goes
-  // dead in front of the user; a stale-on-open URI hits the immediate branch.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: retry identity changes per render — the re-pair is keyed on expiry/error state only
-  useEffect(() => {
-    if (error || !expiresAt) return
-    const delay = expiresAt - Date.now()
-    if (delay <= 0) {
-      retry()
-      return
-    }
-    const id = setTimeout(retry, delay)
-    return () => clearTimeout(id)
-  }, [expiresAt, error])
 
   // Wallet-specific QR encodes the wallet's own deep link so phone cameras
   // route to THAT app (`wc:` is claimed by every wallet app). Generic mode

--- a/packages/wallet-react-ui/src/auth/components/WalletSheet/index.tsx
+++ b/packages/wallet-react-ui/src/auth/components/WalletSheet/index.tsx
@@ -21,8 +21,7 @@ export type WalletSheetProps = {
   /** Absent = generic WalletConnect mode (raw-URI QR, no tabs). */
   wallet?: WalletGuideEntry | undefined
   /** Page-level pairing (preloaded by the SignUp root) shared by every wallet
-   * surface. Expiry is WalletConnect's own signal: the rejected connect()
-   * surfaces through `error` and the existing Try-again re-pairs. */
+   * surface. */
   pairing: WalletConnectPairing
 }
 

--- a/packages/wallet-react-ui/src/auth/hooks/useWalletConnectPairing.test.tsx
+++ b/packages/wallet-react-ui/src/auth/hooks/useWalletConnectPairing.test.tsx
@@ -4,6 +4,7 @@
 import { act, cleanup, renderHook } from '@testing-library/react'
 import { StrictMode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WALLET_GUIDE } from '../walletGuide'
 import { useWalletConnectPairing } from './useWalletConnectPairing'
 
 afterEach(cleanup)
@@ -11,6 +12,11 @@ afterEach(cleanup)
 const goToStep = vi.fn()
 vi.mock('./useAuth', () => ({
   useAuth: () => ({ goToStep }),
+}))
+
+const mobile = vi.hoisted(() => ({ value: false }))
+vi.mock('../utils/isMobile', () => ({
+  isMobile: () => mobile.value,
 }))
 
 const connect = vi.fn()
@@ -51,6 +57,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   connectors = []
   connections = []
+  mobile.value = false
 })
 
 describe('useWalletConnectPairing', () => {
@@ -156,5 +163,45 @@ describe('useWalletConnectPairing', () => {
     const handler = wc.emitter.on.mock.calls[0][1]
     unmount()
     expect(wc.emitter.off).toHaveBeenCalledWith('message', handler)
+  })
+
+  it('parses the URI expiryTimestamp into expiresAt', () => {
+    const wc = fakeWcConnector()
+    connectors = [wc]
+    const { result } = renderHook(() => useWalletConnectPairing())
+    act(() =>
+      wc.emit({
+        type: 'display_uri',
+        data: 'wc:t@2?relay-protocol=irn&symKey=s&expiryTimestamp=1755500000',
+      }),
+    )
+    expect(result.current.expiresAt).toBe(1_755_500_000_000)
+  })
+
+  it('falls back to the 5-minute TTL when the URI carries no expiry', () => {
+    const wc = fakeWcConnector()
+    connectors = [wc]
+    const { result } = renderHook(() => useWalletConnectPairing())
+    const before = Date.now()
+    act(() => wc.emit({ type: 'display_uri', data: 'wc:t@2?relay' }))
+    const ttl = 5 * 60_000
+    expect(result.current.expiresAt).toBeGreaterThanOrEqual(before + ttl)
+    expect(result.current.expiresAt).toBeLessThanOrEqual(Date.now() + ttl)
+  })
+
+  it('deepLinkFor wraps the fresh URI on mobile and stays null on desktop', () => {
+    const metamask = WALLET_GUIDE.find((w) => w.id === 'metamask')
+    if (!metamask) throw new Error('metamask missing from WALLET_GUIDE')
+    const wc = fakeWcConnector()
+    connectors = [wc]
+    const { result } = renderHook(() => useWalletConnectPairing())
+    const uri = `wc:t@2?expiryTimestamp=${Math.floor((Date.now() + 60_000) / 1000)}`
+    act(() => wc.emit({ type: 'display_uri', data: uri }))
+
+    expect(result.current.deepLinkFor(metamask)).toBeNull() // desktop
+    mobile.value = true
+    expect(result.current.deepLinkFor(metamask)).toBe(
+      `${metamask.mobileLink}${encodeURIComponent(uri)}`,
+    )
   })
 })

--- a/packages/wallet-react-ui/src/auth/hooks/useWalletConnectPairing.test.tsx
+++ b/packages/wallet-react-ui/src/auth/hooks/useWalletConnectPairing.test.tsx
@@ -165,43 +165,32 @@ describe('useWalletConnectPairing', () => {
     expect(wc.emitter.off).toHaveBeenCalledWith('message', handler)
   })
 
-  it('parses the URI expiryTimestamp into expiresAt', () => {
-    const wc = fakeWcConnector()
-    connectors = [wc]
-    const { result } = renderHook(() => useWalletConnectPairing())
-    act(() =>
-      wc.emit({
-        type: 'display_uri',
-        data: 'wc:t@2?relay-protocol=irn&symKey=s&expiryTimestamp=1755500000',
-      }),
-    )
-    expect(result.current.expiresAt).toBe(1_755_500_000_000)
-  })
-
-  it('falls back to the 5-minute TTL when the URI carries no expiry', () => {
-    const wc = fakeWcConnector()
-    connectors = [wc]
-    const { result } = renderHook(() => useWalletConnectPairing())
-    const before = Date.now()
-    act(() => wc.emit({ type: 'display_uri', data: 'wc:t@2?relay' }))
-    const ttl = 5 * 60_000
-    expect(result.current.expiresAt).toBeGreaterThanOrEqual(before + ttl)
-    expect(result.current.expiresAt).toBeLessThanOrEqual(Date.now() + ttl)
-  })
-
-  it('deepLinkFor wraps the fresh URI on mobile and stays null on desktop', () => {
+  it('deepLinkFor wraps the URI on mobile and stays null on desktop', () => {
     const metamask = WALLET_GUIDE.find((w) => w.id === 'metamask')
     if (!metamask) throw new Error('metamask missing from WALLET_GUIDE')
     const wc = fakeWcConnector()
     connectors = [wc]
     const { result } = renderHook(() => useWalletConnectPairing())
-    const uri = `wc:t@2?expiryTimestamp=${Math.floor((Date.now() + 60_000) / 1000)}`
-    act(() => wc.emit({ type: 'display_uri', data: uri }))
+    act(() => wc.emit({ type: 'display_uri', data: 'wc:t@2?relay' }))
 
     expect(result.current.deepLinkFor(metamask)).toBeNull() // desktop
     mobile.value = true
     expect(result.current.deepLinkFor(metamask)).toBe(
-      `${metamask.mobileLink}${encodeURIComponent(uri)}`,
+      `${metamask.mobileLink}${encodeURIComponent('wc:t@2?relay')}`,
     )
+  })
+
+  it('deepLinkFor goes null once the pairing errors — e.g. proposal expiry', () => {
+    const metamask = WALLET_GUIDE.find((w) => w.id === 'metamask')
+    if (!metamask) throw new Error('metamask missing from WALLET_GUIDE')
+    mobile.value = true
+    const wc = fakeWcConnector()
+    connectors = [wc]
+    const { result } = renderHook(() => useWalletConnectPairing())
+    act(() => wc.emit({ type: 'display_uri', data: 'wc:t@2?relay' }))
+    expect(result.current.deepLinkFor(metamask)).not.toBeNull()
+
+    act(() => connect.mock.calls[0][1].onError(new Error('Proposal expired')))
+    expect(result.current.deepLinkFor(metamask)).toBeNull()
   })
 })

--- a/packages/wallet-react-ui/src/auth/hooks/useWalletConnectPairing.ts
+++ b/packages/wallet-react-ui/src/auth/hooks/useWalletConnectPairing.ts
@@ -5,15 +5,31 @@ import {
   useConnections,
   useConnectors,
 } from 'wagmi'
+import { isMobile } from '../utils/isMobile'
 import { isZeroDevWalletConnect } from '../utils/isZeroDevWalletConnect'
+import { walletDeepLink } from '../utils/walletDeepLink'
+import type { WalletGuideEntry } from '../walletGuide'
 import { useAuth } from './useAuth'
 
 export type WalletConnectPairing = {
   /** Pairing URI from the connector's `display_uri` event; null until it
    * arrives (or after a retry reset). */
   uri: string | null
+  /** Epoch ms when `uri` stops being claimable (WC pairing TTL). */
+  expiresAt: number | null
   error: string | null
   retry: () => void
+  /** Wrapped deep link for the one-tap mobile redirect into `wallet`'s app,
+   * or null when the tap should just open the sheet (desktop, claiming
+   * installed connector, missing/stale URI). Checks freshness at call time. */
+  deepLinkFor: (wallet: WalletGuideEntry) => string | null
+}
+
+/** WC v2 URIs carry `expiryTimestamp` (unix seconds); fall back to the
+ * protocol's 5-minute pairing TTL when absent. */
+function parseUriExpiry(uri: string): number {
+  const match = /[?&]expiryTimestamp=(\d+)/.exec(uri)
+  return match ? Number(match[1]) * 1000 : Date.now() + 5 * 60_000
 }
 
 /**
@@ -33,12 +49,14 @@ export function useWalletConnectPairing(): WalletConnectPairing {
   )
 
   const [uri, setUri] = useState<string | null>(null)
+  const [expiresAt, setExpiresAt] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
   const startedRef = useRef(false)
 
   const startConnect = (target: Connector) => {
     setError(null)
     setUri(null)
+    setExpiresAt(null)
     connect(
       { connector: target },
       {
@@ -52,7 +70,10 @@ export function useWalletConnectPairing(): WalletConnectPairing {
   useEffect(() => {
     if (!wcConnector || wcConnected) return
     const onMessage = ({ type, data }: { type: string; data?: unknown }) => {
-      if (type === 'display_uri' && typeof data === 'string') setUri(data)
+      if (type === 'display_uri' && typeof data === 'string') {
+        setUri(data)
+        setExpiresAt(parseUriExpiry(data))
+      }
     }
     // Subscribe before the connect kick — `display_uri` fires mid-connect.
     wcConnector.emitter.on('message', onMessage)
@@ -65,9 +86,18 @@ export function useWalletConnectPairing(): WalletConnectPairing {
 
   return {
     uri,
+    expiresAt,
     error,
     retry: () => {
       if (wcConnector) startConnect(wcConnector)
     },
+    deepLinkFor: (wallet) =>
+      walletDeepLink({
+        wallet,
+        connectors,
+        uri,
+        expiresAt,
+        mobile: isMobile(),
+      }),
   }
 }

--- a/packages/wallet-react-ui/src/auth/hooks/useWalletConnectPairing.ts
+++ b/packages/wallet-react-ui/src/auth/hooks/useWalletConnectPairing.ts
@@ -15,21 +15,13 @@ export type WalletConnectPairing = {
   /** Pairing URI from the connector's `display_uri` event; null until it
    * arrives (or after a retry reset). */
   uri: string | null
-  /** Epoch ms when `uri` stops being claimable (WC pairing TTL). */
-  expiresAt: number | null
   error: string | null
   retry: () => void
   /** Wrapped deep link for the one-tap mobile redirect into `wallet`'s app,
    * or null when the tap should just open the sheet (desktop, claiming
-   * installed connector, missing/stale URI). Checks freshness at call time. */
+   * installed connector, no usable URI). An errored pairing — including
+   * WalletConnect's own proposal expiry — never redirects. */
   deepLinkFor: (wallet: WalletGuideEntry) => string | null
-}
-
-/** WC v2 URIs carry `expiryTimestamp` (unix seconds); fall back to the
- * protocol's 5-minute pairing TTL when absent. */
-function parseUriExpiry(uri: string): number {
-  const match = /[?&]expiryTimestamp=(\d+)/.exec(uri)
-  return match ? Number(match[1]) * 1000 : Date.now() + 5 * 60_000
 }
 
 /**
@@ -49,14 +41,12 @@ export function useWalletConnectPairing(): WalletConnectPairing {
   )
 
   const [uri, setUri] = useState<string | null>(null)
-  const [expiresAt, setExpiresAt] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
   const startedRef = useRef(false)
 
   const startConnect = (target: Connector) => {
     setError(null)
     setUri(null)
-    setExpiresAt(null)
     connect(
       { connector: target },
       {
@@ -70,10 +60,7 @@ export function useWalletConnectPairing(): WalletConnectPairing {
   useEffect(() => {
     if (!wcConnector || wcConnected) return
     const onMessage = ({ type, data }: { type: string; data?: unknown }) => {
-      if (type === 'display_uri' && typeof data === 'string') {
-        setUri(data)
-        setExpiresAt(parseUriExpiry(data))
-      }
+      if (type === 'display_uri' && typeof data === 'string') setUri(data)
     }
     // Subscribe before the connect kick — `display_uri` fires mid-connect.
     wcConnector.emitter.on('message', onMessage)
@@ -86,7 +73,6 @@ export function useWalletConnectPairing(): WalletConnectPairing {
 
   return {
     uri,
-    expiresAt,
     error,
     retry: () => {
       if (wcConnector) startConnect(wcConnector)
@@ -95,8 +81,7 @@ export function useWalletConnectPairing(): WalletConnectPairing {
       walletDeepLink({
         wallet,
         connectors,
-        uri,
-        expiresAt,
+        uri: error ? null : uri,
         mobile: isMobile(),
       }),
   }

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/Email.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/Email.test.tsx
@@ -11,7 +11,6 @@ afterEach(cleanup)
 vi.mock('../../hooks/useWalletConnectPairing', () => ({
   useWalletConnectPairing: () => ({
     uri: null,
-    expiresAt: null,
     error: null,
     retry: () => {},
     deepLinkFor: () => null,

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/Email.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/Email.test.tsx
@@ -7,6 +7,17 @@ import { SignUp } from './index'
 
 afterEach(cleanup)
 
+// The SignUp root preloads the page-level pairing — inert here.
+vi.mock('../../hooks/useWalletConnectPairing', () => ({
+  useWalletConnectPairing: () => ({
+    uri: null,
+    expiresAt: null,
+    error: null,
+    retry: () => {},
+    deepLinkFor: () => null,
+  }),
+}))
+
 const { sendMagicLink, sendOtp } = vi.hoisted(() => ({
   sendMagicLink: vi.fn().mockResolvedValue({
     otpId: 'otp-1',

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/Google.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/Google.test.tsx
@@ -11,7 +11,6 @@ afterEach(cleanup)
 vi.mock('../../hooks/useWalletConnectPairing', () => ({
   useWalletConnectPairing: () => ({
     uri: null,
-    expiresAt: null,
     error: null,
     retry: () => {},
     deepLinkFor: () => null,

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/Google.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/Google.test.tsx
@@ -7,6 +7,17 @@ import { SignUp } from './index'
 
 afterEach(cleanup)
 
+// The SignUp root preloads the page-level pairing — inert here.
+vi.mock('../../hooks/useWalletConnectPairing', () => ({
+  useWalletConnectPairing: () => ({
+    uri: null,
+    expiresAt: null,
+    error: null,
+    retry: () => {},
+    deepLinkFor: () => null,
+  }),
+}))
+
 const { authenticateOAuth } = vi.hoisted(() => ({
   authenticateOAuth: vi.fn().mockResolvedValue(undefined),
 }))

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/InstalledWallets.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/InstalledWallets.test.tsx
@@ -8,6 +8,17 @@ import { SignUp } from './index'
 
 afterEach(cleanup)
 
+// The SignUp root preloads the page-level pairing — inert here.
+vi.mock('../../hooks/useWalletConnectPairing', () => ({
+  useWalletConnectPairing: () => ({
+    uri: null,
+    expiresAt: null,
+    error: null,
+    retry: () => {},
+    deepLinkFor: () => null,
+  }),
+}))
+
 // Sibling units pull in wagmi/wallet-react hooks — replace them with stubs so
 // the tests exercise the InstalledWallets unit against the real root.
 vi.mock('./Passkey', () => ({ SignUpPasskey: () => null }))

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/InstalledWallets.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/InstalledWallets.test.tsx
@@ -12,7 +12,6 @@ afterEach(cleanup)
 vi.mock('../../hooks/useWalletConnectPairing', () => ({
   useWalletConnectPairing: () => ({
     uri: null,
-    expiresAt: null,
     error: null,
     retry: () => {},
     deepLinkFor: () => null,

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/MoreWallets.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/MoreWallets.test.tsx
@@ -13,7 +13,6 @@ afterEach(cleanup)
 vi.mock('../../hooks/useWalletConnectPairing', () => ({
   useWalletConnectPairing: () => ({
     uri: null,
-    expiresAt: null,
     error: null,
     retry: () => {},
     deepLinkFor: () => null,

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/MoreWallets.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/MoreWallets.test.tsx
@@ -9,6 +9,17 @@ import { SignUp } from './index'
 
 afterEach(cleanup)
 
+// The SignUp root preloads the page-level pairing — inert here.
+vi.mock('../../hooks/useWalletConnectPairing', () => ({
+  useWalletConnectPairing: () => ({
+    uri: null,
+    expiresAt: null,
+    error: null,
+    retry: () => {},
+    deepLinkFor: () => null,
+  }),
+}))
+
 // Sibling units pull in wallet-react hooks — replace them with stubs so the
 // tests exercise the MoreWallets unit against the real root (context, gate).
 vi.mock('./Passkey', () => ({ SignUpPasskey: () => null }))

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/Passkey.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/Passkey.test.tsx
@@ -11,7 +11,6 @@ afterEach(cleanup)
 vi.mock('../../hooks/useWalletConnectPairing', () => ({
   useWalletConnectPairing: () => ({
     uri: null,
-    expiresAt: null,
     error: null,
     retry: () => {},
     deepLinkFor: () => null,

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/Passkey.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/Passkey.test.tsx
@@ -7,6 +7,17 @@ import { SignUp } from './index'
 
 afterEach(cleanup)
 
+// The SignUp root preloads the page-level pairing — inert here.
+vi.mock('../../hooks/useWalletConnectPairing', () => ({
+  useWalletConnectPairing: () => ({
+    uri: null,
+    expiresAt: null,
+    error: null,
+    retry: () => {},
+    deepLinkFor: () => null,
+  }),
+}))
+
 const { registerPasskey, loginPasskey } = vi.hoisted(() => ({
   registerPasskey: vi.fn(),
   loginPasskey: vi.fn(),

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/Wallet.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/Wallet.test.tsx
@@ -9,6 +9,19 @@ import { SignUp } from './index'
 
 afterEach(cleanup)
 
+// The SignUp root preloads the page-level pairing; `deepLink` drives what the
+// root's tap-time redirect sees.
+const deepLink = vi.hoisted(() => ({ value: null as string | null }))
+vi.mock('../../hooks/useWalletConnectPairing', () => ({
+  useWalletConnectPairing: () => ({
+    uri: null,
+    expiresAt: null,
+    error: null,
+    retry: () => {},
+    deepLinkFor: () => deepLink.value,
+  }),
+}))
+
 // Sibling units pull in wagmi/wallet-react hooks — replace them with stubs so
 // the tests exercise the Wallet unit against the real root (context, gate).
 vi.mock('./Passkey', () => ({ SignUpPasskey: () => null }))
@@ -67,6 +80,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   connectors = []
   connectPending = false
+  deepLink.value = null
 })
 
 describe('SignUp.Wallet', () => {
@@ -224,5 +238,25 @@ describe('SignUp.Wallet', () => {
       /Unknown walletId "nope"/,
     )
     consoleError.mockRestore()
+  })
+
+  it('fires the mobile deep link on the row tap and still opens the sheet', () => {
+    connectors = [
+      { id: 'walletConnect', type: 'walletConnect', zdWalletConnect: true },
+    ]
+    deepLink.value = 'https://metamask.app.link/wc?uri=wc%3Aabc%402'
+    render(
+      <SignUp>
+        <SignUp.Wallet walletId="metamask" />
+      </SignUp>,
+    )
+
+    fireEvent.click(screen.getByText('MetaMask'))
+    expect(window.location.href).toBe(
+      'https://metamask.app.link/wc?uri=wc%3Aabc%402',
+    )
+    // The sheet still opens behind the redirect as the fallback surface.
+    const lastSheet = sheetProps.mock.calls.at(-1)?.[0]
+    expect(lastSheet.open).toBe(true)
   })
 })

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/Wallet.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/Wallet.test.tsx
@@ -15,7 +15,6 @@ const deepLink = vi.hoisted(() => ({ value: null as string | null }))
 vi.mock('../../hooks/useWalletConnectPairing', () => ({
   useWalletConnectPairing: () => ({
     uri: null,
-    expiresAt: null,
     error: null,
     retry: () => {},
     deepLinkFor: () => deepLink.value,

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/WalletConnect.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/WalletConnect.test.tsx
@@ -11,7 +11,6 @@ afterEach(cleanup)
 vi.mock('../../hooks/useWalletConnectPairing', () => ({
   useWalletConnectPairing: () => ({
     uri: null,
-    expiresAt: null,
     error: null,
     retry: () => {},
     deepLinkFor: () => null,

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/WalletConnect.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/WalletConnect.test.tsx
@@ -7,6 +7,17 @@ import { SignUp } from './index'
 
 afterEach(cleanup)
 
+// The SignUp root preloads the page-level pairing — inert here.
+vi.mock('../../hooks/useWalletConnectPairing', () => ({
+  useWalletConnectPairing: () => ({
+    uri: null,
+    expiresAt: null,
+    error: null,
+    retry: () => {},
+    deepLinkFor: () => null,
+  }),
+}))
+
 // Sibling units pull in wagmi/wallet-react hooks — replace them with stubs so
 // the tests exercise the WalletConnect unit against the real root.
 vi.mock('./Passkey', () => ({ SignUpPasskey: () => null }))

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/index.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/index.test.tsx
@@ -12,7 +12,6 @@ afterEach(cleanup)
 vi.mock('../../hooks/useWalletConnectPairing', () => ({
   useWalletConnectPairing: () => ({
     uri: null,
-    expiresAt: null,
     error: null,
     retry: () => {},
     deepLinkFor: () => null,

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/index.test.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/index.test.tsx
@@ -8,6 +8,17 @@ import { SignUp } from './index'
 
 afterEach(cleanup)
 
+// The SignUp root preloads the page-level pairing — inert here.
+vi.mock('../../hooks/useWalletConnectPairing', () => ({
+  useWalletConnectPairing: () => ({
+    uri: null,
+    expiresAt: null,
+    error: null,
+    retry: () => {},
+    deepLinkFor: () => null,
+  }),
+}))
+
 // Units pull in wagmi/wallet-react hooks — replace them with markers so the
 // tests exercise only the page logic (composition, registry, guard).
 vi.mock('./Passkey', () => ({

--- a/packages/wallet-react-ui/src/auth/pages/SignUp/index.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/SignUp/index.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, useCallback, useState } from 'react'
 import { SignUpFooter } from '../../../shared/components/SignUpFooter'
 import { BlobAnimation } from '../../components/BlobAnimation'
 import { WalletSheet } from '../../components/WalletSheet'
+import { useWalletConnectPairing } from '../../hooks/useWalletConnectPairing'
 import type { EmailAuthMethod } from '../../types'
 import type { WalletGuideEntry } from '../../walletGuide'
 import { SignUpContext } from './context'
@@ -60,6 +61,10 @@ function SignUpRoot({
   const [walletSheet, setWalletSheet] = useState<{
     wallet?: WalletGuideEntry | undefined
   } | null>(null)
+  // Pairing preloads at page mount so the sheet's QR is ready on open and the
+  // mobile deep link below fires synchronously inside the tap — iOS only
+  // hands a universal link to the app for gesture-qualified navigations.
+  const pairing = useWalletConnectPairing()
 
   const requiresAgreement = !!(termsAndConditionsUrl || privacyPolicyUrl)
   const needsAgreement = requiresAgreement && !agreedToTerms
@@ -81,7 +86,13 @@ function SignUpRoot({
         setError,
         registeredWallets,
         registerWallet,
-        openWalletSheet: (wallet) => setWalletSheet({ wallet }),
+        openWalletSheet: (wallet) => {
+          const deepLink = wallet && pairing.deepLinkFor(wallet)
+          if (deepLink) window.location.href = deepLink
+          // Sheet opens either way — it's the fallback surface when the
+          // redirect doesn't take (and the only surface on desktop).
+          setWalletSheet({ wallet })
+        },
       }}
     >
       {error !== null && (
@@ -136,6 +147,7 @@ function SignUpRoot({
         </div>
       </div>
       <WalletSheet
+        pairing={pairing}
         open={walletSheet !== null}
         onOpenChange={(open) => {
           if (!open) setWalletSheet(null)

--- a/packages/wallet-react-ui/src/auth/utils/walletDeepLink.test.ts
+++ b/packages/wallet-react-ui/src/auth/utils/walletDeepLink.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { WALLET_GUIDE, type WalletGuideEntry } from '../walletGuide'
+import { walletDeepLink } from './walletDeepLink'
+
+const metamask = WALLET_GUIDE.find((w) => w.id === 'metamask')
+if (!metamask) throw new Error('metamask missing from WALLET_GUIDE')
+
+/** Params for the happy path — each test overrides one dimension. */
+const fresh = () => ({
+  wallet: metamask,
+  connectors: [],
+  uri: 'wc:abc@2',
+  expiresAt: Date.now() + 60_000,
+  mobile: true,
+})
+
+describe('walletDeepLink', () => {
+  it('wraps the URI in the wallet deep link for a fresh mobile tap', () => {
+    expect(walletDeepLink(fresh())).toBe(
+      `${metamask.mobileLink}${encodeURIComponent('wc:abc@2')}`,
+    )
+  })
+
+  it('is null on desktop', () => {
+    expect(walletDeepLink({ ...fresh(), mobile: false })).toBeNull()
+  })
+
+  it('is null before the URI arrives', () => {
+    expect(walletDeepLink({ ...fresh(), uri: null })).toBeNull()
+  })
+
+  it('is null when the URI is stale or inside the freshness margin', () => {
+    expect(walletDeepLink({ ...fresh(), expiresAt: Date.now() - 1 })).toBeNull()
+    expect(
+      walletDeepLink({ ...fresh(), expiresAt: Date.now() + 5_000 }),
+    ).toBeNull()
+  })
+
+  it('is null when an installed connector claims the wallet', () => {
+    expect(
+      walletDeepLink({ ...fresh(), connectors: [{ id: 'io.metamask' }] }),
+    ).toBeNull()
+  })
+
+  it('is null for a wallet without a mobile link', () => {
+    const wallet: WalletGuideEntry = {
+      id: 'nolink',
+      name: 'NoLink',
+      icon: '',
+      downloadUrl: 'https://example.com',
+    }
+    expect(walletDeepLink({ ...fresh(), wallet })).toBeNull()
+  })
+})

--- a/packages/wallet-react-ui/src/auth/utils/walletDeepLink.test.ts
+++ b/packages/wallet-react-ui/src/auth/utils/walletDeepLink.test.ts
@@ -10,12 +10,11 @@ const fresh = () => ({
   wallet: metamask,
   connectors: [],
   uri: 'wc:abc@2',
-  expiresAt: Date.now() + 60_000,
   mobile: true,
 })
 
 describe('walletDeepLink', () => {
-  it('wraps the URI in the wallet deep link for a fresh mobile tap', () => {
+  it('wraps the URI in the wallet deep link for a mobile tap', () => {
     expect(walletDeepLink(fresh())).toBe(
       `${metamask.mobileLink}${encodeURIComponent('wc:abc@2')}`,
     )
@@ -27,13 +26,6 @@ describe('walletDeepLink', () => {
 
   it('is null before the URI arrives', () => {
     expect(walletDeepLink({ ...fresh(), uri: null })).toBeNull()
-  })
-
-  it('is null when the URI is stale or inside the freshness margin', () => {
-    expect(walletDeepLink({ ...fresh(), expiresAt: Date.now() - 1 })).toBeNull()
-    expect(
-      walletDeepLink({ ...fresh(), expiresAt: Date.now() + 5_000 }),
-    ).toBeNull()
   })
 
   it('is null when an installed connector claims the wallet', () => {

--- a/packages/wallet-react-ui/src/auth/utils/walletDeepLink.ts
+++ b/packages/wallet-react-ui/src/auth/utils/walletDeepLink.ts
@@ -1,0 +1,27 @@
+import { matchesWallet, type WalletGuideEntry } from '../walletGuide'
+
+/** Don't redirect into a link about to expire — the app would open on a dead
+ * pairing. Tap falls back to the sheet, which re-pairs. */
+const FRESH_MARGIN_MS = 10_000
+
+/**
+ * Wrapped deep link for the one-tap mobile redirect into `wallet`'s app, or
+ * null when the tap should just open the sheet: desktop, a claiming installed
+ * connector (direct connect wins), or a missing/stale pairing URI.
+ */
+export function walletDeepLink(params: {
+  wallet: WalletGuideEntry
+  connectors: readonly {
+    id: string
+    rdns?: string | readonly string[] | undefined
+  }[]
+  uri: string | null
+  expiresAt: number | null
+  mobile: boolean
+}): string | null {
+  const { wallet, connectors, uri, expiresAt, mobile } = params
+  if (!wallet.mobileLink || !mobile || !uri) return null
+  if (!expiresAt || Date.now() >= expiresAt - FRESH_MARGIN_MS) return null
+  if (connectors.some((c) => matchesWallet(c, wallet))) return null
+  return `${wallet.mobileLink}${encodeURIComponent(uri)}`
+}

--- a/packages/wallet-react-ui/src/auth/utils/walletDeepLink.ts
+++ b/packages/wallet-react-ui/src/auth/utils/walletDeepLink.ts
@@ -1,13 +1,9 @@
 import { matchesWallet, type WalletGuideEntry } from '../walletGuide'
 
-/** Don't redirect into a link about to expire — the app would open on a dead
- * pairing. Tap falls back to the sheet, which re-pairs. */
-const FRESH_MARGIN_MS = 10_000
-
 /**
  * Wrapped deep link for the one-tap mobile redirect into `wallet`'s app, or
  * null when the tap should just open the sheet: desktop, a claiming installed
- * connector (direct connect wins), or a missing/stale pairing URI.
+ * connector (direct connect wins), or no pairing URI.
  */
 export function walletDeepLink(params: {
   wallet: WalletGuideEntry
@@ -16,12 +12,10 @@ export function walletDeepLink(params: {
     rdns?: string | readonly string[] | undefined
   }[]
   uri: string | null
-  expiresAt: number | null
   mobile: boolean
 }): string | null {
-  const { wallet, connectors, uri, expiresAt, mobile } = params
+  const { wallet, connectors, uri, mobile } = params
   if (!wallet.mobileLink || !mobile || !uri) return null
-  if (!expiresAt || Date.now() >= expiresAt - FRESH_MARGIN_MS) return null
   if (connectors.some((c) => matchesWallet(c, wallet))) return null
   return `${wallet.mobileLink}${encodeURIComponent(uri)}`
 }


### PR DESCRIPTION
QA found an issue where wallets wouldn't deeplink on mobile automatically. The problem is iOS doesn't allow you to navigate to an app on your phone from browser programmatically - there has to be user action such as click.

This PR moves WalletConnect connection fetching up in the tree, so that it's established before the mobile wallet button is clicked, and users can be navigated to their mobile wallet with the WC connection.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>