### PR TITLE
feat(wallet-ui): add wc signing redirect for external wallets

### DIFF
--- a/packages/wallet-react-ui/src/zeroDevWalletConnect.test.ts
+++ b/packages/wallet-react-ui/src/zeroDevWalletConnect.test.ts
@@ -1,13 +1,63 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { zeroDevWalletConnect } from './zeroDevWalletConnect'
 
-const { walletConnect } = vi.hoisted(() => ({
-  walletConnect: vi.fn(() => () => ({ id: 'walletConnect' })),
-}))
+type FakeProvider = {
+  session?: unknown
+  on: ReturnType<typeof vi.fn>
+  emit: (event: string) => void
+}
+
+/** Provider double with a working on/emit pair and an optional session. */
+function fakeProvider(session?: unknown): FakeProvider {
+  const handlers: Record<string, Array<() => void>> = {}
+  return {
+    session,
+    on: vi.fn((event: string, cb: () => void) => {
+      ;(handlers[event] ??= []).push(cb)
+    }),
+    emit: (event: string) => {
+      for (const cb of handlers[event] ?? []) cb()
+    },
+  }
+}
+
+const { walletConnect, providerBox } = vi.hoisted(() => {
+  const providerBox = { value: undefined as unknown }
+  return {
+    providerBox,
+    walletConnect: vi.fn(() => () => ({
+      id: 'walletConnect',
+      getProvider: async () => providerBox.value,
+    })),
+  }
+})
 vi.mock('wagmi/connectors', () => ({ walletConnect }))
+
+const mobile = vi.hoisted(() => ({ value: true }))
+vi.mock('./auth/utils/isMobile', () => ({
+  isMobile: () => mobile.value,
+}))
+
+const KEY = 'WALLETCONNECT_DEEPLINK_CHOICE'
+const metamaskSession = {
+  peer: {
+    metadata: { name: 'MetaMask', redirect: { native: 'metamask://' } },
+  },
+}
+
+/** Create a connector through the factory and hand back its provider. */
+async function connectorProvider(provider: FakeProvider) {
+  providerBox.value = provider
+  const connector = zeroDevWalletConnect({ projectId: 'pid' })({} as never)
+  await connector.getProvider()
+  return provider
+}
 
 beforeEach(() => {
   vi.clearAllMocks()
+  localStorage.clear()
+  mobile.value = true
+  providerBox.value = undefined
 })
 
 describe('zeroDevWalletConnect', () => {
@@ -37,11 +87,71 @@ describe('zeroDevWalletConnect', () => {
   it('stamps the connector instance for the kit discovery', () => {
     const create = zeroDevWalletConnect({ projectId: 'pid' })
     const connector = create({} as never)
-    expect(connector).toEqual({ id: 'walletConnect', zdWalletConnect: true })
+    expect(connector).toMatchObject({
+      id: 'walletConnect',
+      zdWalletConnect: true,
+    })
   })
 
   it('throws early without a projectId', () => {
     expect(() => zeroDevWalletConnect({ projectId: '' })).toThrow(/projectId/)
     expect(walletConnect).not.toHaveBeenCalled()
+  })
+
+  it('stores the wallet deep-link choice when the session connects on mobile', async () => {
+    const provider = await connectorProvider(fakeProvider())
+    provider.session = metamaskSession
+    provider.emit('connect')
+
+    expect(JSON.parse(localStorage.getItem(KEY) ?? 'null')).toEqual({
+      href: 'metamask://',
+      name: 'MetaMask',
+    })
+  })
+
+  it('stays unarmed on desktop sessions', async () => {
+    mobile.value = false
+    const provider = await connectorProvider(fakeProvider())
+    provider.session = metamaskSession
+    provider.emit('connect')
+
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('stays unarmed when the wallet registers no native redirect', async () => {
+    const provider = await connectorProvider(fakeProvider())
+    provider.session = { peer: { metadata: { name: 'NoRedirect' } } }
+    provider.emit('connect')
+
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('clears the choice on disconnect', async () => {
+    const provider = await connectorProvider(fakeProvider())
+    provider.session = metamaskSession
+    provider.emit('connect')
+    expect(localStorage.getItem(KEY)).not.toBeNull()
+
+    provider.emit('disconnect')
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('re-arms a session restored from storage without an event', async () => {
+    await connectorProvider(fakeProvider(metamaskSession))
+    expect(JSON.parse(localStorage.getItem(KEY) ?? 'null')).toEqual({
+      href: 'metamask://',
+      name: 'MetaMask',
+    })
+  })
+
+  it('subscribes once across repeated getProvider calls', async () => {
+    const provider = fakeProvider()
+    providerBox.value = provider
+    const connector = zeroDevWalletConnect({ projectId: 'pid' })({} as never)
+    await connector.getProvider()
+    await connector.getProvider()
+
+    const events = provider.on.mock.calls.map((c) => c[0])
+    expect(events).toEqual(['connect', 'disconnect'])
   })
 })

--- a/packages/wallet-react-ui/src/zeroDevWalletConnect.test.ts
+++ b/packages/wallet-react-ui/src/zeroDevWalletConnect.test.ts
@@ -126,6 +126,42 @@ describe('zeroDevWalletConnect', () => {
     expect(localStorage.getItem(KEY)).toBeNull()
   })
 
+  it('clears a stale choice when the new session is ineligible', async () => {
+    // Seeded by a previous mobile session — a desktop session must not leave
+    // it armed, or signing requests deep-link into the previous wallet.
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({ href: 'rabby://', name: 'Rabby' }),
+    )
+    mobile.value = false
+    const provider = await connectorProvider(fakeProvider(metamaskSession))
+    provider.emit('connect')
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('clears a stale choice when the wallet registers no native redirect', async () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({ href: 'rabby://', name: 'Rabby' }),
+    )
+    const provider = await connectorProvider(
+      fakeProvider({ peer: { metadata: { name: 'NoRedirect' } } }),
+    )
+    provider.emit('connect')
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('clears a stale choice for an ineligible restored session', async () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({ href: 'rabby://', name: 'Rabby' }),
+    )
+    mobile.value = false
+    // Restored session present at provider creation — no events fire.
+    await connectorProvider(fakeProvider(metamaskSession))
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
   it('clears the choice on disconnect', async () => {
     const provider = await connectorProvider(fakeProvider())
     provider.session = metamaskSession

--- a/packages/wallet-react-ui/src/zeroDevWalletConnect.ts
+++ b/packages/wallet-react-ui/src/zeroDevWalletConnect.ts
@@ -1,5 +1,64 @@
 import type { CreateConnectorFn } from 'wagmi'
 import { type WalletConnectParameters, walletConnect } from 'wagmi/connectors'
+import { isMobile } from './auth/utils/isMobile'
+
+/**
+ * localStorage key `@walletconnect/sign-client` reads before publishing each
+ * session request — when set, the SDK deep-links back into the chosen wallet
+ * app (`{href}/wc?requestId=…&sessionTopic=…`) so the approval prompt is in
+ * front of the user. Same key AppKit writes; the SDK no-ops when it's absent.
+ */
+const DEEPLINK_CHOICE_KEY = 'WALLETCONNECT_DEEPLINK_CHOICE'
+
+/** The slice of `@walletconnect/ethereum-provider` this module touches. */
+type WcSessionProvider = {
+  on: (event: 'connect' | 'disconnect', listener: () => void) => unknown
+  session?: {
+    peer?: {
+      metadata?: { name?: string; redirect?: { native?: string } }
+    }
+  }
+}
+
+const watched = new WeakSet<object>()
+
+/**
+ * Arm the SDK's redirect-on-request with the connected wallet's own
+ * registered scheme (`session.peer.metadata.redirect.native`) — authoritative
+ * for whichever wallet actually claimed the pairing. Desktop sessions and
+ * wallets that register no native redirect stay unarmed.
+ */
+function storeDeepLinkChoice(provider: WcSessionProvider) {
+  const metadata = provider.session?.peer?.metadata
+  const href = metadata?.redirect?.native
+  if (!href || !isMobile()) return
+  try {
+    localStorage.setItem(
+      DEEPLINK_CHOICE_KEY,
+      JSON.stringify({ href, name: metadata?.name ?? '' }),
+    )
+  } catch {
+    // Storage unavailable — requests still work, minus the app hop.
+  }
+}
+
+function clearDeepLinkChoice() {
+  try {
+    localStorage.removeItem(DEEPLINK_CHOICE_KEY)
+  } catch {
+    // Nothing to clear if storage is unavailable.
+  }
+}
+
+function watchSession(provider: WcSessionProvider) {
+  if (watched.has(provider)) return
+  watched.add(provider)
+  provider.on('connect', () => storeDeepLinkChoice(provider))
+  // A stale choice would deep-link a future session to the wrong app.
+  provider.on('disconnect', clearDeepLinkChoice)
+  // Session restored from storage (page reload) — re-arm without an event.
+  if (provider.session) storeDeepLinkChoice(provider)
+}
 
 /**
  * WalletConnect connector preconfigured for the kit. `showQrModal: false` is
@@ -17,8 +76,17 @@ export function zeroDevWalletConnect(
     throw new Error('zeroDevWalletConnect requires a WalletConnect projectId')
   }
   const create = walletConnect({ ...params, showQrModal: false })
-  // Stamp the connector instance so the kit's discovery can tell a
-  // correctly-configured connector from a raw walletConnect(), where
-  // showQrModal defaults to true.
-  return (config) => Object.assign(create(config), { zdWalletConnect: true })
+  return (config) => {
+    // Stamp the connector instance so the kit's discovery can tell a
+    // correctly-configured connector from a raw walletConnect(), where
+    // showQrModal defaults to true.
+    const connector = Object.assign(create(config), { zdWalletConnect: true })
+    const getProvider = connector.getProvider.bind(connector)
+    connector.getProvider = async (...args: Parameters<typeof getProvider>) => {
+      const provider = await getProvider(...args)
+      watchSession(provider as WcSessionProvider)
+      return provider
+    }
+    return connector
+  }
 }

--- a/packages/wallet-react-ui/src/zeroDevWalletConnect.ts
+++ b/packages/wallet-react-ui/src/zeroDevWalletConnect.ts
@@ -31,7 +31,10 @@ const watched = new WeakSet<object>()
 function storeDeepLinkChoice(provider: WcSessionProvider) {
   const metadata = provider.session?.peer?.metadata
   const href = metadata?.redirect?.native
-  if (!href || !isMobile()) return
+  if (!href || !isMobile()) {
+    clearDeepLinkChoice()
+    return
+  }
   try {
     localStorage.setItem(
       DEEPLINK_CHOICE_KEY,


### PR DESCRIPTION
Currently our wallet wouldn't prompt opening a mobile wallet when signing a transaction. WalletConnect does that for us, but we need subscribe to their local storage key `WALLETCONNECT_DEEPLINK_CHOICE`.

This PR does that + some clean ups on disconnect etc.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>