### PR TITLE
feat(wallet-ui): fix local wc expiry handling

### DIFF
--- a/packages/wallet-react-ui/src/auth/hooks/useWalletConnectPairing.test.tsx
+++ b/packages/wallet-react-ui/src/auth/hooks/useWalletConnectPairing.test.tsx
@@ -22,20 +22,24 @@ vi.mock('../utils/isMobile', () => ({
 const connect = vi.fn()
 let connectors: unknown[] = []
 let connections: unknown[] = []
+let reconnecting = false
 vi.mock('wagmi', () => ({
   useConnectors: () => connectors,
   useConnect: () => ({ mutate: connect }),
   useConnections: () => connections,
+  useAccount: () => ({ isReconnecting: reconnecting }),
 }))
 
 type MessageHandler = (event: { type: string; data?: unknown }) => void
 
-/** Connector double with a working `message` emitter and a provider whose
- * sign-client emits `proposal_expire`. Stamped like the zeroDevWalletConnect
- * factory's output unless `stamped: false`. */
+/** Connector double with a working `message` emitter and a provider that
+ * emits `connect` on fresh session settles and whose sign-client emits
+ * `proposal_expire`. Stamped like the zeroDevWalletConnect factory's output
+ * unless `stamped: false`. */
 function fakeWcConnector({ stamped = true } = {}) {
   const handlers = new Set<MessageHandler>()
   const expireHandlers = new Set<() => void>()
+  const connectHandlers = new Set<() => void>()
   const expiryEvents = {
     on: vi.fn((_event: string, handler: () => void) => {
       expireHandlers.add(handler)
@@ -43,6 +47,15 @@ function fakeWcConnector({ stamped = true } = {}) {
     off: vi.fn((_event: string, handler: () => void) => {
       expireHandlers.delete(handler)
     }),
+  }
+  const provider = {
+    on: vi.fn((_event: string, handler: () => void) => {
+      connectHandlers.add(handler)
+    }),
+    off: vi.fn((_event: string, handler: () => void) => {
+      connectHandlers.delete(handler)
+    }),
+    signer: { client: { events: expiryEvents } },
   }
   return {
     uid: crypto.randomUUID(),
@@ -60,12 +73,14 @@ function fakeWcConnector({ stamped = true } = {}) {
     emit: (event: { type: string; data?: unknown }) => {
       for (const handler of handlers) handler(event)
     },
-    getProvider: vi.fn(async () => ({
-      signer: { client: { events: expiryEvents } },
-    })),
+    getProvider: vi.fn(async () => provider),
+    provider,
     expiryEvents,
     expireProposal: () => {
       for (const handler of expireHandlers) handler()
+    },
+    settleSession: () => {
+      for (const handler of connectHandlers) handler()
     },
   }
 }
@@ -74,6 +89,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   connectors = []
   connections = []
+  reconnecting = false
   mobile.value = false
 })
 
@@ -120,15 +136,16 @@ describe('useWalletConnectPairing', () => {
     expect(connect).toHaveBeenCalledTimes(1)
   })
 
-  it('closes the auth flow when the pairing connects', () => {
+  it('closes the auth flow when a fresh session settles, surviving Strict Mode', async () => {
     const wc = fakeWcConnector()
     connectors = [wc]
-    const { rerender } = renderHook(() => useWalletConnectPairing())
+    renderHook(() => useWalletConnectPairing(), { wrapper: StrictMode })
+    // Let the async getProvider subscription settle.
+    await act(async () => {})
     expect(goToStep).not.toHaveBeenCalled()
 
-    // The approved pairing surfaces as a wagmi connection, not a callback.
-    connections = [{ connector: wc }]
-    rerender()
+    // The provider's `connect` event = the user approved OUR pairing.
+    act(() => wc.settleSession())
     expect(goToStep).toHaveBeenCalledWith(null)
   })
 
@@ -138,6 +155,42 @@ describe('useWalletConnectPairing', () => {
     connections = [{ connector: wc }]
     renderHook(() => useWalletConnectPairing())
     expect(goToStep).not.toHaveBeenCalled()
+  })
+
+  it('does not close the flow when a session restores after mount', async () => {
+    // The rehydration race: wagmi finishes restoring a persisted session
+    // AFTER the sign-up page mounted. A restored session emits no provider
+    // `connect` event, so the flow must stay open.
+    const wc = fakeWcConnector()
+    connectors = [wc]
+    const { rerender } = renderHook(() => useWalletConnectPairing())
+    await act(async () => {})
+
+    connections = [{ connector: wc }]
+    rerender()
+    expect(goToStep).not.toHaveBeenCalled()
+  })
+
+  it('defers the pairing kick while wagmi is reconnecting', () => {
+    const wc = fakeWcConnector()
+    connectors = [wc]
+    reconnecting = true
+    const { rerender } = renderHook(() => useWalletConnectPairing())
+    expect(connect).not.toHaveBeenCalled()
+
+    // Rehydration settled without a connection — now the kick runs.
+    reconnecting = false
+    rerender()
+    expect(connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces provider init failure through the error state', async () => {
+    const wc = fakeWcConnector()
+    wc.getProvider.mockRejectedValueOnce(new Error('relay unreachable'))
+    connectors = [wc]
+    const { result } = renderHook(() => useWalletConnectPairing())
+    await act(async () => {})
+    expect(result.current.error).toBe('relay unreachable')
   })
 
   it('errors on proposal expiry via the sign-client event, surviving Strict Mode', async () => {
@@ -216,6 +269,10 @@ describe('useWalletConnectPairing', () => {
     expect(wc.expiryEvents.off).toHaveBeenCalledWith(
       'proposal_expire',
       expireHandler,
+    )
+    expect(wc.provider.off).toHaveBeenCalledWith(
+      'connect',
+      wc.provider.on.mock.calls[0][1],
     )
   })
 

--- a/packages/wallet-react-ui/src/auth/hooks/useWalletConnectPairing.test.tsx
+++ b/packages/wallet-react-ui/src/auth/hooks/useWalletConnectPairing.test.tsx
@@ -30,10 +30,20 @@ vi.mock('wagmi', () => ({
 
 type MessageHandler = (event: { type: string; data?: unknown }) => void
 
-/** Connector double with a working `message` emitter. Stamped like the
- * zeroDevWalletConnect factory's output unless `stamped: false`. */
+/** Connector double with a working `message` emitter and a provider whose
+ * sign-client emits `proposal_expire`. Stamped like the zeroDevWalletConnect
+ * factory's output unless `stamped: false`. */
 function fakeWcConnector({ stamped = true } = {}) {
   const handlers = new Set<MessageHandler>()
+  const expireHandlers = new Set<() => void>()
+  const expiryEvents = {
+    on: vi.fn((_event: string, handler: () => void) => {
+      expireHandlers.add(handler)
+    }),
+    off: vi.fn((_event: string, handler: () => void) => {
+      expireHandlers.delete(handler)
+    }),
+  }
   return {
     uid: crypto.randomUUID(),
     id: 'walletConnect',
@@ -49,6 +59,13 @@ function fakeWcConnector({ stamped = true } = {}) {
     },
     emit: (event: { type: string; data?: unknown }) => {
       for (const handler of handlers) handler(event)
+    },
+    getProvider: vi.fn(async () => ({
+      signer: { client: { events: expiryEvents } },
+    })),
+    expiryEvents,
+    expireProposal: () => {
+      for (const handler of expireHandlers) handler()
     },
   }
 }
@@ -106,9 +123,40 @@ describe('useWalletConnectPairing', () => {
   it('closes the auth flow when the pairing connects', () => {
     const wc = fakeWcConnector()
     connectors = [wc]
-    renderHook(() => useWalletConnectPairing())
-    act(() => connect.mock.calls[0][1].onSuccess())
+    const { rerender } = renderHook(() => useWalletConnectPairing())
+    expect(goToStep).not.toHaveBeenCalled()
+
+    // The approved pairing surfaces as a wagmi connection, not a callback.
+    connections = [{ connector: wc }]
+    rerender()
     expect(goToStep).toHaveBeenCalledWith(null)
+  })
+
+  it('does not close the flow for a session restored before mount', () => {
+    const wc = fakeWcConnector()
+    connectors = [wc]
+    connections = [{ connector: wc }]
+    renderHook(() => useWalletConnectPairing())
+    expect(goToStep).not.toHaveBeenCalled()
+  })
+
+  it('errors on proposal expiry via the sign-client event, surviving Strict Mode', async () => {
+    const wc = fakeWcConnector()
+    connectors = [wc]
+    const { result } = renderHook(() => useWalletConnectPairing(), {
+      wrapper: StrictMode,
+    })
+    // Let the async getProvider subscription settle.
+    await act(async () => {})
+    act(() => wc.emit({ type: 'display_uri', data: 'wc:t@2?relay' }))
+
+    act(() => wc.expireProposal())
+    expect(result.current.error).toBe('Proposal expired')
+
+    const metamask = WALLET_GUIDE.find((w) => w.id === 'metamask')
+    if (!metamask) throw new Error('metamask missing from WALLET_GUIDE')
+    mobile.value = true
+    expect(result.current.deepLinkFor(metamask)).toBeNull()
   })
 
   it('surfaces connect errors and retry resets state and reconnects', () => {
@@ -156,13 +204,19 @@ describe('useWalletConnectPairing', () => {
     expect(connect).not.toHaveBeenCalled()
   })
 
-  it('unsubscribes its message handler on unmount', () => {
+  it('unsubscribes its message and expiry handlers on unmount', async () => {
     const wc = fakeWcConnector()
     connectors = [wc]
     const { unmount } = renderHook(() => useWalletConnectPairing())
+    await act(async () => {})
     const handler = wc.emitter.on.mock.calls[0][1]
+    const expireHandler = wc.expiryEvents.on.mock.calls[0][1]
     unmount()
     expect(wc.emitter.off).toHaveBeenCalledWith('message', handler)
+    expect(wc.expiryEvents.off).toHaveBeenCalledWith(
+      'proposal_expire',
+      expireHandler,
+    )
   })
 
   it('deepLinkFor wraps the URI on mobile and stays null on desktop', () => {

--- a/packages/wallet-react-ui/src/auth/hooks/useWalletConnectPairing.ts
+++ b/packages/wallet-react-ui/src/auth/hooks/useWalletConnectPairing.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import {
   type Connector,
+  useAccount,
   useConnect,
   useConnections,
   useConnectors,
@@ -15,7 +16,14 @@ type WcExpiryEvents = {
   on: (event: 'proposal_expire', listener: () => void) => unknown
   off: (event: 'proposal_expire', listener: () => void) => unknown
 }
-type WcExpiryProvider = {
+/** The slice of `@walletconnect/ethereum-provider` this hook touches: the
+ * provider emits `connect` only when a session settles fresh (a pairing the
+ * user just approved) — never for a session restored from storage — and the
+ * sign-client's emitter fires `proposal_expire` when the pairing offer's TTL
+ * runs out. */
+type WcPairingProvider = {
+  on: (event: 'connect', listener: () => void) => unknown
+  off: (event: 'connect', listener: () => void) => unknown
   signer?: { client?: { events?: WcExpiryEvents } }
 }
 
@@ -47,6 +55,9 @@ export function useWalletConnectPairing(): WalletConnectPairing {
   const wcConnected = connections.some(
     (c) => c.connector.uid === wcConnector?.uid,
   )
+  // While wagmi is still rehydrating persisted sessions, hold the pairing
+  // kick — a connector mid-restore may be about to come back as connected.
+  const { isReconnecting } = useAccount()
 
   const [uri, setUri] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -57,13 +68,6 @@ export function useWalletConnectPairing(): WalletConnectPairing {
     setUri(null)
     connect({ connector: target }, { onError: (err) => setError(err.message) })
   }
-  const wasConnectedRef = useRef(wcConnected)
-  useEffect(() => {
-    // trigger on actual connection
-    if (wcConnected && !wasConnectedRef.current) goToStep(null)
-    wasConnectedRef.current = wcConnected
-  }, [wcConnected, goToStep])
-
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only pairing setup — startConnect closes over kick-time callbacks (connect, goToStep), which must not retrigger the subscription
   useEffect(() => {
     if (!wcConnector || wcConnected) return
@@ -72,27 +76,46 @@ export function useWalletConnectPairing(): WalletConnectPairing {
     }
     // Subscribe before the connect kick — `display_uri` fires mid-connect.
     wcConnector.emitter.on('message', onMessage)
+
     // Expiry comes from the sign-client's own event, not the connect
     // mutation — this subscription is re-established every effect run, so it
     // survives Strict Mode where the mutation's `onError` does not.
     const onExpire = () => setError('Proposal expired')
-    let expiryEvents: WcExpiryEvents | undefined
+    // Success is the provider's `connect` event — emitted only when a session
+    // settles fresh (the user approved a pairing), never when wagmi restores
+    // a persisted session, so rehydration can't close a flow the user is
+    // looking at. Whether an already-connected user should see sign-up at
+    // all stays the host's `isConnected` decision.
+    const onConnect = () => goToStep(null)
+
+    let wcProvider: WcPairingProvider | undefined
     let disposed = false
-    wcConnector.getProvider().then((provider) => {
-      expiryEvents = (provider as WcExpiryProvider).signer?.client?.events
-      if (disposed || !expiryEvents) return
-      expiryEvents.on('proposal_expire', onExpire)
-    })
-    if (!startedRef.current) {
+
+    wcConnector
+      .getProvider()
+      .then((provider) => {
+        if (disposed) return
+        wcProvider = provider as WcPairingProvider
+        wcProvider.signer?.client?.events?.on('proposal_expire', onExpire)
+        wcProvider.on('connect', onConnect)
+      })
+      .catch((err) => {
+        // Provider init failed — surface through the pairing's error state
+        // instead of an unhandled rejection.
+        if (!disposed)
+          setError(err instanceof Error ? err.message : String(err))
+      })
+    if (!startedRef.current && !isReconnecting) {
       startedRef.current = true
       startConnect(wcConnector)
     }
     return () => {
       disposed = true
-      expiryEvents?.off('proposal_expire', onExpire)
+      wcProvider?.signer?.client?.events?.off('proposal_expire', onExpire)
+      wcProvider?.off('connect', onConnect)
       wcConnector.emitter.off('message', onMessage)
     }
-  }, [wcConnector, wcConnected])
+  }, [wcConnector, wcConnected, isReconnecting])
 
   return {
     uri,

--- a/packages/wallet-react-ui/src/auth/hooks/useWalletConnectPairing.ts
+++ b/packages/wallet-react-ui/src/auth/hooks/useWalletConnectPairing.ts
@@ -11,6 +11,14 @@ import { walletDeepLink } from '../utils/walletDeepLink'
 import type { WalletGuideEntry } from '../walletGuide'
 import { useAuth } from './useAuth'
 
+type WcExpiryEvents = {
+  on: (event: 'proposal_expire', listener: () => void) => unknown
+  off: (event: 'proposal_expire', listener: () => void) => unknown
+}
+type WcExpiryProvider = {
+  signer?: { client?: { events?: WcExpiryEvents } }
+}
+
 export type WalletConnectPairing = {
   /** Pairing URI from the connector's `display_uri` event; null until it
    * arrives (or after a retry reset). */
@@ -47,14 +55,14 @@ export function useWalletConnectPairing(): WalletConnectPairing {
   const startConnect = (target: Connector) => {
     setError(null)
     setUri(null)
-    connect(
-      { connector: target },
-      {
-        onSuccess: () => goToStep(null),
-        onError: (err) => setError(err.message),
-      },
-    )
+    connect({ connector: target }, { onError: (err) => setError(err.message) })
   }
+  const wasConnectedRef = useRef(wcConnected)
+  useEffect(() => {
+    // trigger on actual connection
+    if (wcConnected && !wasConnectedRef.current) goToStep(null)
+    wasConnectedRef.current = wcConnected
+  }, [wcConnected, goToStep])
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only pairing setup — startConnect closes over kick-time callbacks (connect, goToStep), which must not retrigger the subscription
   useEffect(() => {
@@ -64,11 +72,26 @@ export function useWalletConnectPairing(): WalletConnectPairing {
     }
     // Subscribe before the connect kick — `display_uri` fires mid-connect.
     wcConnector.emitter.on('message', onMessage)
+    // Expiry comes from the sign-client's own event, not the connect
+    // mutation — this subscription is re-established every effect run, so it
+    // survives Strict Mode where the mutation's `onError` does not.
+    const onExpire = () => setError('Proposal expired')
+    let expiryEvents: WcExpiryEvents | undefined
+    let disposed = false
+    wcConnector.getProvider().then((provider) => {
+      expiryEvents = (provider as WcExpiryProvider).signer?.client?.events
+      if (disposed || !expiryEvents) return
+      expiryEvents.on('proposal_expire', onExpire)
+    })
     if (!startedRef.current) {
       startedRef.current = true
       startConnect(wcConnector)
     }
-    return () => wcConnector.emitter.off('message', onMessage)
+    return () => {
+      disposed = true
+      expiryEvents?.off('proposal_expire', onExpire)
+      wcConnector.emitter.off('message', onMessage)
+    }
   }, [wcConnector, wcConnected])
 
   return {


### PR DESCRIPTION
When WalletConnect connection link expires locally, an error is throw because of strict mode. It works fine in prod, this only fixes local issue.

Because of it error doesn't show on expiration and user (dev in this case since only local) can send request e.g. to MetaMask mobile with an expired link, so the connection hangs.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>