### PR TITLE
test(e2e): report why a tx run failed instead of just that it did

### DIFF
--- a/apps/qa-lab-testing/src/app/components/testing-lab/txRuns.tsx
+++ b/apps/qa-lab-testing/src/app/components/testing-lab/txRuns.tsx
@@ -16,15 +16,44 @@ export interface TxRun {
 
 const shortHex = (hex: string) => `${hex.slice(0, 8)}…${hex.slice(-6)}`;
 
-const errorMessage = (err: unknown): string => {
-  if (
-    err &&
-    typeof err === "object" &&
-    "shortMessage" in err &&
-    typeof (err as { shortMessage: unknown }).shortMessage === "string"
-  ) {
-    return (err as { shortMessage: string }).shortMessage;
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+const asText = (value: unknown): string | undefined =>
+  typeof value === "string" && value.length > 0 ? value : undefined;
+
+/**
+ * HTTP status from anywhere in viem's cause chain. It sits on the innermost
+ * `HttpRequestError`, so the outer `ContractFunctionExecutionError` alone never
+ * tells you a request was throttled rather than rejected.
+ */
+const httpStatus = (err: unknown): number | undefined => {
+  let current = asRecord(err);
+  for (let depth = 0; current && depth < 10; depth++) {
+    if (typeof current.status === "number") return current.status;
+    current = asRecord(current.cause);
   }
+  return undefined;
+};
+
+/**
+ * viem's `shortMessage` collapses a throttled paymaster into "An unknown RPC
+ * error occurred", which is indistinguishable from a real revert in a CI log.
+ * `details` carries the server's own explanation and the status says whether it
+ * was the transport, so both are kept.
+ */
+const errorMessage = (err: unknown): string => {
+  const error = asRecord(err);
+  const status = httpStatus(err);
+  const parts = [
+    asText(error?.shortMessage),
+    asText(error?.details),
+    status ? `HTTP ${status}` : undefined,
+  ].filter(Boolean);
+
+  if (parts.length > 0) return parts.join(" · ");
   return err instanceof Error ? err.message : "Transaction failed";
 };
 
@@ -86,6 +115,7 @@ export function TxRunList({ runs }: { runs: TxRun[] }) {
             key={run.id}
             data-testid={`tx-run-${run.id}`}
             data-status={run.status}
+            data-error={run.error}
             className="flex items-center gap-2.5 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2"
           >
             <span className="shrink-0">

--- a/e2e/browser/passkey.spec.ts
+++ b/e2e/browser/passkey.spec.ts
@@ -14,6 +14,7 @@
 
 import type { Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
+import { expectTxRunSucceeded } from '../helpers/tx-runs.js'
 import { expectLabReady } from '../helpers/ui-login.js'
 import {
   getVirtualCredentials,
@@ -123,12 +124,7 @@ test.describe('Passkey Flow', () => {
       await expect(mint.getByTestId('demo-nft-address')).not.toHaveText('—')
       await mint.getByTestId('demo-nft-mint-submit').click()
 
-      await expect(mint.getByTestId('tx-run-1')).toHaveAttribute(
-        'data-status',
-        'success',
-        { timeout: 60_000 },
-      )
-      console.log('Mint NFT (send transaction) successful')
+      await expectTxRunSucceeded(mint.getByTestId('tx-run-1'))
     } finally {
       await teardownVirtualAuthenticator(virtualAuth)
     }

--- a/e2e/browser/post-auth.spec.ts
+++ b/e2e/browser/post-auth.spec.ts
@@ -12,6 +12,7 @@
 import { expect, type Page } from '@playwright/test'
 import { test } from '../fixtures/authed-session.js'
 import { createNewAccount, ping } from '../helpers/temp-email.js'
+import { expectTxRunSucceeded } from '../helpers/tx-runs.js'
 import { expectLabReady, loginWithMagicLink } from '../helpers/ui-login.js'
 
 /**
@@ -142,13 +143,6 @@ test.describe('Post-Auth Operations', () => {
     await expect(mint.getByTestId('demo-nft-address')).not.toHaveText('—')
     await mint.getByTestId('demo-nft-mint-submit').click()
 
-    const run = mint.getByTestId('tx-run-1')
-    await expect(run).toHaveAttribute('data-status', 'success', {
-      timeout: 60_000,
-    })
-    await expect(run.getByTestId('tx-run-hash')).toHaveAttribute(
-      'data-hash',
-      /^0x[0-9a-fA-F]{64}$/,
-    )
+    await expectTxRunSucceeded(mint.getByTestId('tx-run-1'))
   })
 })

--- a/e2e/helpers/tx-runs.ts
+++ b/e2e/helpers/tx-runs.ts
@@ -1,0 +1,44 @@
+import { expect, type Locator, test } from '@playwright/test'
+
+/** A sponsored userOp on staging can take a while; the run itself settles fast. */
+const TX_SETTLE_TIMEOUT_MS = 60_000
+
+/**
+ * Staging's RPC and paymaster sit behind a shared per-project rate limit, and
+ * `pm_getPaymasterData` is not retried (`@zerodev/sdk` forces `retryCount: 0` on
+ * the paymaster transport), so one throttled burst fails the transaction for
+ * good. Matched on the server's own wording plus the status the lab now renders,
+ * only to label the failure — a throttle still fails the test.
+ */
+const RATE_LIMITED = /rate limit|HTTP 429/i
+
+/**
+ * Waits for a tx run to reach a terminal state and asserts it succeeded.
+ *
+ * Waits for `success` *or* `error` rather than `success` alone: a failed run is
+ * already final within seconds, so waiting only for success spends the whole
+ * timeout and then reports a timeout instead of the reason. On error the run's
+ * `data-error` is read back and attached as an annotation before failing, so the
+ * report says whether staging throttled us or the SDK actually broke — the two
+ * belong to different owners, and the bare status assertion said neither.
+ */
+export async function expectTxRunSucceeded(run: Locator): Promise<void> {
+  await expect(run).toHaveAttribute('data-status', /^(success|error)$/, {
+    timeout: TX_SETTLE_TIMEOUT_MS,
+  })
+
+  if ((await run.getAttribute('data-status')) === 'error') {
+    const detail =
+      (await run.getAttribute('data-error')) ?? 'no error text rendered'
+    test.info().annotations.push({
+      type: RATE_LIMITED.test(detail) ? 'staging-rate-limit' : 'tx-failure',
+      description: detail,
+    })
+    throw new Error(`Transaction run failed: ${detail}`)
+  }
+
+  await expect(run.getByTestId('tx-run-hash')).toHaveAttribute(
+    'data-hash',
+    /^0x[0-9a-fA-F]{64}$/,
+  )
+}

--- a/e2e/mocks/README.md
+++ b/e2e/mocks/README.md
@@ -107,7 +107,7 @@ await routeMocks(page, userWallet, { unmatched: 'block' })
 
 `routeMocks` can be called more than once. Playwright runs handlers
 newest-first, and an install that matches nothing defers to the one before it,
-so definitions compose which results in a clash:
+so definitions compose without clashing:
 
 ```ts
 await routeMocks(page, userWallet)


### PR DESCRIPTION
The NFT-mint e2e went red on a staging rate limit, not a product defect. From the trace on [run 32216185307](https://github.com/zerodevapp/zerodev-wallet-sdk/actions/runs/32216185307): `pm_getPaymasterData` returned **HTTP 429** (`"You have exceeded the rate limit for this endpoint"`)

## Main changes
- **`txRuns.tsx`** — keep viem's `details` and the HTTP status, not just `shortMessage` (which collapsed a throttle into "unknown RPC error"). Exposed as `data-error`.
- **`e2e/helpers/tx-runs.ts`** (new) — `expectTxRunSucceeded` waits for `success|error` instead of `success` alone, so an already-failed run reports its cause rather than a 60s timeout. Failures are annotated `staging-rate-limit` or `tx-failure`, and still fail.
- Used at both mint sites; the passkey one now also asserts the tx hash.
- **`e2e/mocks/README.md`** — definitions compose *without* clashing (#410 review comment).