### PR TITLE
test(core-integration-boundary): adds initial Core Boundary Integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,3 +232,87 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 14
+
+  integration-test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    # No `if:` guard and no `env:` secrets, deliberately: the integration layer
+    # is in-process and must never need a live service. If a test here ever
+    # needs a secret, it belongs in e2e/backend instead.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run integration tests
+        run: pnpm test:integration
+
+  ci-gate:
+    name: All checks passed
+    runs-on: ubuntu-latest
+    needs:
+      - lint-and-format
+      - typecheck
+      - build
+      - test
+      - integration-test
+      - backend-e2e-test
+      - e2e-test
+    if: always()
+    steps:
+      - name: Verify every job succeeded
+        env:
+          # Every job in `needs:` and its result, so this script never has to
+          # name them. Adding or removing a gated job is a one-line edit to
+          # `needs:` above and nothing else.
+          NEEDS: ${{ toJSON(needs) }}
+          # The ONLY per-job policy: jobs allowed to report `skipped`. Both are
+          # guarded off for PRs from forks, so a fork PR could never merge otherwise.
+          # Any other job that reports `skipped` fails the gate — a skip there
+          # means it silently did not run.
+          SKIPPABLE: backend-e2e-test e2e-test
+        run: |
+          fail=0
+
+          # `jq` is preinstalled on GitHub-hosted ubuntu runners.
+          while read -r job result; do
+            case "$result" in
+              success)
+                echo "ok       $job"
+                ;;
+              skipped)
+                case " $SKIPPABLE " in
+                  *" $job "*)
+                    echo "skipped  $job (allowed: guarded off for fork PRs)"
+                    ;;
+                  *)
+                    echo "::error::$job was skipped but is not allowed to skip"
+                    fail=1
+                    ;;
+                esac
+                ;;
+              *)
+                echo "::error::$job did not succeed (got '$result')"
+                fail=1
+                ;;
+            esac
+          done <<EOF
+          $(echo "$NEEDS" | jq -r 'to_entries[] | "\(.key) \(.value.result)"')
+          EOF
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::CI gate failed — see the job results above."
+            exit 1
+          fi
+          echo "All gated jobs passed."

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "build:e2e": "pnpm --filter '@zerodev/qa-lab-testing^...' build",
     "test:e2e:browser": "pnpm build:e2e && playwright test --config e2e/playwright.config.ts",
     "test:e2e:browser:headed": "pnpm build:e2e && playwright test --config e2e/playwright.config.ts --headed",

--- a/packages/core/src/actions/wallet/userOperationPayload.integration.test.ts
+++ b/packages/core/src/actions/wallet/userOperationPayload.integration.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Boundary between Wallet Core and KMS.
+ *
+ * Nothing in Core or the viem adapter calls `sign/user-operation`. Only an app
+ * using the client gets there, so the test calls the action directly.
+ * `computeDataPayloadHash` is specific to this endpoint. `sendSigningRequest`
+ * and `buildTurnkeyPayload`'s address guard are shared with the other signing
+ * paths.
+ */
+import { type Hex, keccak256, recoverAddress, toHex } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { rest } from '../../client/transports/rest.js'
+import type { Client } from '../../client/types.js'
+import type { Stamper } from '../../stampers/types.js'
+import { signUserOperation } from './signUserOperation.js'
+
+const BASE = 'https://kms.example.invalid/api/v1'
+const SIGN_URL = `${BASE}/proj/sign/user-operation`
+
+/** Publicly known test keys. OWNER is the wallet; IMPOSTOR is anyone else. */
+const OWNER = privateKeyToAccount(`0x${'11'.repeat(32)}` as Hex)
+const IMPOSTOR = privateKeyToAccount(`0x${'33'.repeat(32)}` as Hex)
+
+/** A plausible packed user operation. Content is opaque to Core. */
+const USER_OP = '0xdeadbeef'
+
+const stamper: Stamper = {
+  stamp: async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  }),
+  clear: async () => {},
+}
+
+type SigningRequest = {
+  unsignedUserOperation: string
+  chainId: number
+  encoding: string
+  turnkeyPayload: { parameters: { signWith: string; payload: string } }
+}
+
+function driven(
+  answer?: (correct: Hex) => unknown,
+  signer = OWNER,
+): { client: Client; sent: SigningRequest[]; urls: string[] } {
+  const sent: SigningRequest[] = []
+  const urls: string[] = []
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      urls.push(String(url))
+      const body = JSON.parse(String(init?.body)) as SigningRequest
+      sent.push(body)
+      const correct = await signer.sign({
+        hash: `0x${body.turnkeyPayload.parameters.payload}` as Hex,
+      })
+      return new Response(
+        JSON.stringify(answer ? answer(correct) : { signature: correct }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )
+    }),
+  )
+  const client = {
+    request: rest(BASE, {
+      apiKeyStamper: stamper,
+      passkeyStamper: stamper,
+    }).request,
+    apiKeyStamper: stamper,
+  } as unknown as Client
+
+  return { client, sent, urls }
+}
+
+const PARAMS = {
+  organizationId: 'suborg-1',
+  projectId: 'proj',
+  token: 'tok',
+  address: OWNER.address,
+  chainId: 1,
+  encoding: 'hex' as const,
+  unsignedUserOperation: USER_OP,
+}
+
+const outcomeOf = (p: Promise<unknown>) =>
+  p.then(
+    (value) => ({ ok: true, value }) as const,
+    (error: unknown) => ({ ok: false, error }) as const,
+  )
+
+/** 65 bytes exactly. Asserted alongside recovery, never instead of it. */
+const SIGNATURE = /^0x[0-9a-f]{130}$/i
+
+/** Attributable = an Error that is not a raw deref and names the signature. */
+const blamesTheSignature = (error: unknown) =>
+  error instanceof Error &&
+  !(error instanceof TypeError) &&
+  /signature|signing|owner/i.test(error.message)
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('user operation: a signature the caller can broadcast', () => {
+  const encodings: ['hex' | 'utf8', string, Hex][] = [
+    ['hex', 'the bytes the hex decodes to', keccak256(USER_OP)],
+    ['utf8', 'the bytes of the string itself', keccak256(toHex(USER_OP))],
+  ]
+
+  for (const [encoding, what, expected] of encodings) {
+    it(`signs ${what} when the encoding is ${encoding}`, async () => {
+      const { client } = driven()
+
+      const signature = await signUserOperation(client, { ...PARAMS, encoding })
+
+      expect(signature).toMatch(SIGNATURE)
+      await expect(recoverAddress({ hash: expected, signature })).resolves.toBe(
+        OWNER.address,
+      )
+    })
+  }
+
+  it('hashes the user operation the caller passed, not something else', async () => {
+    const { client, sent } = driven()
+
+    await signUserOperation(client, { ...PARAMS, encoding: 'hex' })
+
+    expect(`0x${sent[0].turnkeyPayload.parameters.payload}`).toBe(
+      keccak256(USER_OP),
+    )
+  })
+
+  it('hashes the raw string when the encoding is utf8', async () => {
+    const { client, sent } = driven()
+
+    await signUserOperation(client, { ...PARAMS, encoding: 'utf8' })
+
+    expect(`0x${sent[0].turnkeyPayload.parameters.payload}`).toBe(
+      keccak256(toHex(USER_OP)),
+    )
+  })
+
+  it('sends the operation, chain and encoding on to the backend', async () => {
+    const { client, sent, urls } = driven()
+
+    await signUserOperation(client, { ...PARAMS, chainId: 8453 })
+
+    expect(urls).toEqual([SIGN_URL])
+    expect(sent[0]).toMatchObject({
+      unsignedUserOperation: USER_OP,
+      chainId: 8453,
+      encoding: 'hex',
+    })
+    expect(sent[0].turnkeyPayload.parameters.signWith).toBe(OWNER.address)
+  })
+})
+
+describe('user operation: refusing before a round trip is spent', () => {
+  const badAddresses: [string, Hex][] = [
+    ['the zero address', `0x${'00'.repeat(20)}` as Hex],
+    ['a malformed address', '0xdead' as Hex],
+  ]
+
+  for (const [label, address] of badAddresses) {
+    it(`refuses ${label} without asking KMS`, async () => {
+      const { client, urls } = driven()
+
+      const outcome = await outcomeOf(
+        signUserOperation(client, { ...PARAMS, address }),
+      )
+
+      expect(outcome.ok).toBe(false)
+      expect(urls).toHaveLength(0)
+    })
+  }
+})
+
+describe('user operation: the signing response is unusable', () => {
+  const unusable: [string, (correct: Hex) => unknown][] = [
+    ['the field is absent', () => ({})],
+    ['it is an empty string', () => ({ signature: '' })],
+    ['it is null', () => ({ signature: null })],
+    ['it is not a string', () => ({ signature: 42 })],
+    ['it is truncated', (correct) => ({ signature: correct.slice(0, 40) })],
+  ]
+
+  for (const [label, answer] of unusable) {
+    it(`returns no signature when ${label}`, async () => {
+      const { client } = driven(answer)
+
+      const outcome = await outcomeOf(signUserOperation(client, PARAMS))
+
+      expect(outcome.ok).toBe(false)
+      expect(blamesTheSignature((outcome as { error: unknown }).error)).toBe(
+        true,
+      )
+    })
+  }
+
+  it('refuses a signature from a key that is not the wallet', async () => {
+    const { client } = driven(undefined, IMPOSTOR)
+
+    const outcome = await outcomeOf(signUserOperation(client, PARAMS))
+
+    expect(outcome.ok).toBe(false)
+    expect(blamesTheSignature((outcome as { error: unknown }).error)).toBe(true)
+  })
+
+  it('accepts a signature the backend sent without an 0x prefix', async () => {
+    const { client } = driven((correct) => ({ signature: correct.slice(2) }))
+
+    const signature = await signUserOperation(client, PARAMS)
+
+    expect(signature).toMatch(SIGNATURE)
+  })
+})

--- a/packages/core/src/adapters/authorizationPayload.integration.test.ts
+++ b/packages/core/src/adapters/authorizationPayload.integration.test.ts
@@ -137,7 +137,7 @@ async function loggedIn(
       if (path.includes('/auth/login/stamp')) {
         return json({ session: token(body.targetPublicKey) })
       }
-      if (path.includes('/user-wallet')) {
+      if (path.includes('/wallets')) {
         return json({ walletAddresses: [OWNER.address] })
       }
       if (path.includes('/sign/')) {

--- a/packages/core/src/adapters/authorizationPayload.integration.test.ts
+++ b/packages/core/src/adapters/authorizationPayload.integration.test.ts
@@ -1,15 +1,13 @@
 /**
- * Boundary: Wallet Core <-> KMS, at `sign/7702-authorization` — the fourth
+ * Boundary: Wallet Core <-> KMS, at `sign/7702-authorization` - the fourth
  * signing method on the account.
  *
  * `signAuthorization` builds the EIP-7702 pre-image by hand while hashing the
  * same authorization with viem's `hashAuthorization`, then returns a tuple
- * assembled from `parameters` rather than from what the signature covered — so
- * what Core signs can drift from what it reports, and the caller broadcasts the
- * report. `recoverAuthorizationAddress` recomputes the hash from the returned
+ * assembled from `parameters` rather than from what the signature covered and
+ * what Core signs can drift from what it reports, and the caller broadcasts
+ * the report. `recoverAuthorizationAddress` recomputes the hash from the returned
  * tuple, which is why it is the assertion this file leans on.
- *
- * Seam is HEALTHY as probed; no `it.fails` here.
  */
 import { type Hex, keccak256 } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'

--- a/packages/core/src/adapters/authorizationPayload.integration.test.ts
+++ b/packages/core/src/adapters/authorizationPayload.integration.test.ts
@@ -1,0 +1,452 @@
+/**
+ * Boundary: Wallet Core <-> KMS, at `sign/7702-authorization` — the fourth
+ * signing method on the account.
+ *
+ * `signAuthorization` builds the EIP-7702 pre-image by hand while hashing the
+ * same authorization with viem's `hashAuthorization`, then returns a tuple
+ * assembled from `parameters` rather than from what the signature covered — so
+ * what Core signs can drift from what it reports, and the caller broadcasts the
+ * report. `recoverAuthorizationAddress` recomputes the hash from the returned
+ * tuple, which is why it is the assertion this file leans on.
+ *
+ * Seam is HEALTHY as probed; no `it.fails` here.
+ */
+import { type Hex, keccak256 } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { recoverAuthorizationAddress } from 'viem/utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createZeroDevWalletCore } from '../core/createZeroDevWalletCore.js'
+import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'
+import type { StorageAdapter } from '../storage/manager.js'
+import { SessionType } from '../types/session.js'
+
+/** Publicly known test keys; OWNER is the wallet's signer so recovery succeeds. */
+const OWNER = privateKeyToAccount(`0x${'11'.repeat(32)}` as Hex)
+const IMPOSTOR = privateKeyToAccount(`0x${'33'.repeat(32)}` as Hex)
+
+/** The contract being delegated to — NOT the wallet. */
+const DELEGATE = '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e' as Hex
+const ZERO = '0x0000000000000000000000000000000000000000' as Hex
+
+const sessionKey = (nth: number) => `02${String(nth).padStart(64, '0')}`
+
+function keyStore(): ApiKeyStamper {
+  let active: string | null = null
+  let pending: string | null = null
+  let minted = 0
+  const stamp = async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  })
+  return {
+    stamp,
+    clear: async () => {
+      active = null
+      pending = null
+    },
+    getPublicKey: async () => active,
+    resetKeyPair: async () => {
+      active = sessionKey(++minted)
+    },
+    prepareKeyRotation: async () => {
+      pending = sessionKey(++minted)
+      return pending
+    },
+    stampPending: stamp,
+    signPending: async () => 'sig',
+    commitKeyRotation: async () => {
+      if (pending) active = pending
+      pending = null
+    },
+    discardKeyRotation: async () => {
+      pending = null
+    },
+    sign: async () => 'sig',
+  }
+}
+
+const passkeyStamper: PasskeyStamper = {
+  stamp: async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  }),
+  clear: async () => {},
+  register: async () => ({
+    attestation: {
+      attestationObject: 'ao',
+      clientDataJson: 'cdj',
+      credentialId: 'cred-1',
+    },
+    encodedChallenge: 'challenge',
+  }),
+}
+
+function token(publicKey: string) {
+  return `hdr.${btoa(
+    JSON.stringify({
+      exp: Date.now() + 3_600_000,
+      public_key: publicKey,
+      session_type: SessionType.READ_WRITE,
+      user_id: 'user-1',
+      organization_id: 'suborg-1',
+    }),
+  )}.sig`
+}
+
+/** What a `/sign/*` request is answered with. */
+type Answer =
+  | { signature: unknown }
+  | { raw: string; contentType: string }
+  | { status: number }
+
+/** Body of a `sign/7702-authorization` request, as it went on the wire. */
+type SigningRequest = {
+  unsignedTransaction: string
+  turnkeyPayload: { parameters: { signWith: string; payload: string } }
+}
+
+/**
+ * The double signs whatever hash it is handed with `signer` rather than deciding
+ * anything, so a degenerate case differs from the control only in `answer`.
+ * `sent` collects the `/sign/` bodies so assertions can read what Core asked
+ * for, not only what it returned.
+ */
+async function loggedIn(
+  answer: (correct: Hex) => Answer,
+  signer = OWNER,
+): Promise<{
+  signAuthorization: NonNullable<
+    Awaited<ReturnType<typeof buildAccount>>['signAuthorization']
+  >
+  sent: SigningRequest[]
+}> {
+  const sent: SigningRequest[] = []
+  const api = keyStore()
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const path = String(url)
+      const body = init?.body ? JSON.parse(String(init.body)) : {}
+      const json = (payload: unknown, status = 200) =>
+        new Response(JSON.stringify(payload), {
+          status,
+          headers: { 'content-type': 'application/json' },
+        })
+
+      if (path.includes('parent-org-id')) {
+        return json({ parentOrgId: 'parent-org' })
+      }
+      if (path.includes('/auth/login/stamp')) {
+        return json({ session: token(body.targetPublicKey) })
+      }
+      if (path.includes('/user-wallet')) {
+        return json({ walletAddresses: [OWNER.address] })
+      }
+      if (path.includes('/sign/')) {
+        sent.push(body as SigningRequest)
+        const correct = await signer.sign({
+          hash: `0x${body.turnkeyPayload.parameters.payload}` as Hex,
+        })
+        const chosen = answer(correct)
+        if ('status' in chosen) {
+          return json({ error: 'bad_token', message: 'expired' }, chosen.status)
+        }
+        if ('raw' in chosen) {
+          return new Response(chosen.raw, {
+            status: 200,
+            headers: { 'content-type': chosen.contentType },
+          })
+        }
+        return json(chosen)
+      }
+      return json({}, 404)
+    }),
+  )
+
+  const account = await buildAccount(api)
+  const signAuthorization = account.signAuthorization
+  if (!signAuthorization) {
+    throw new Error('account does not expose signAuthorization')
+  }
+  return { signAuthorization, sent }
+}
+
+async function buildAccount(api: ApiKeyStamper) {
+  const store = new Map<string, string>()
+  const adapter: StorageAdapter = {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value)
+    },
+    removeItem: (key) => {
+      store.delete(key)
+    },
+  }
+  const core = await createZeroDevWalletCore({
+    projectId: 'proj',
+    rpId: 'localhost',
+    sessionStorage: adapter,
+    apiKeyStamper: api,
+    passkeyStamper,
+    proxyBaseUrl: 'https://kms.test.invalid/api/v1',
+  })
+  await core.auth({ type: 'passkey', mode: 'login' })
+  return core.toAccount()
+}
+
+const correctly = (correct: Hex) => ({ signature: correct })
+
+/** A genuine OWNER signature, but over something Core never asked to have signed. */
+const elsewhere = await OWNER.sign({ hash: keccak256('0xdeadbeef') })
+
+/**
+ * Attributable = the caller can tell the signing response was at fault. Rejects
+ * a `TypeError` and a message that names nothing, so neither a raw deref nor a
+ * bare `Error('failed')` can pass for a guard.
+ */
+function blamesTheSignature(error: unknown) {
+  return (
+    error instanceof Error &&
+    !(error instanceof TypeError) &&
+    /signature|signing/i.test(error.message)
+  )
+}
+
+const caught = (p: Promise<unknown>) =>
+  p.then(
+    () => 'AUTHORIZED' as const,
+    (error: unknown) => error,
+  )
+
+/**
+ * Shape of the signature halves in the returned tuple, asserted alongside the
+ * recovery rather than instead of it. `serializeAuthorizationList` RLP-encodes
+ * `r`/`s`/`yParity` straight into the transaction, so a short or missing half
+ * becomes a silently wrong authorization on the wire.
+ */
+function expectWellFormedSignature(authorization: {
+  r?: Hex | undefined
+  s?: Hex | undefined
+  yParity?: number | undefined
+}) {
+  expect(authorization.r).toMatch(/^0x[0-9a-f]{64}$/i)
+  expect(authorization.s).toMatch(/^0x[0-9a-f]{64}$/i)
+  expect([0, 1]).toContain(authorization.yParity)
+}
+
+/** The pre-image Core told KMS it was hashing, and the hash it asked to be signed. */
+const preimageOf = (request: SigningRequest) =>
+  keccak256(`0x${request.unsignedTransaction}` as Hex)
+const signedHashOf = (request: SigningRequest) =>
+  `0x${request.turnkeyPayload.parameters.payload}`
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('7702: the authorization returned is the one that was signed', () => {
+  // chainId and nonce each pass through a `x ? numberToHex(x) : '0x'` ternary,
+  // so 0 takes the other branch. chainId 0 is not degenerate input — EIP-7702
+  // defines it as valid on any chain, so signing 0 while reporting 1 hands out
+  // a replayable delegation.
+  const authorizations: [string, number, number][] = [
+    ['a real chain and nonce', 1, 7],
+    ['chain 0 — valid on any chain', 0, 7],
+    ['nonce 0 — a never-delegated account', 1, 0],
+    ['both zero', 0, 0],
+  ]
+
+  for (const [label, chainId, nonce] of authorizations) {
+    it(`recovers to the wallet owner for ${label}`, async () => {
+      const { signAuthorization } = await loggedIn(correctly)
+
+      const authorization = await signAuthorization({
+        address: DELEGATE,
+        chainId,
+        nonce,
+      })
+
+      // Recomputed from the returned tuple, so this fails if the delegate,
+      // chain or nonce Core reports differs from the one it signed.
+      await expect(
+        recoverAuthorizationAddress({ authorization }),
+      ).resolves.toBe(OWNER.address)
+      expect(authorization).toMatchObject({ address: DELEGATE, chainId, nonce })
+      expectWellFormedSignature(authorization)
+    })
+
+    it(`asks KMS to sign the pre-image it sends for ${label}`, async () => {
+      const { signAuthorization, sent } = await loggedIn(correctly)
+
+      await signAuthorization({ address: DELEGATE, chainId, nonce })
+
+      // Nothing downstream compares the two, so this is the only guard against
+      // the hand-built pre-image drifting from viem's `hashAuthorization`. The
+      // `both zero` case cannot see a chainId/nonce transposition (identical at
+      // 0); the other three can, hence the whole table.
+      expect(preimageOf(sent[0])).toBe(signedHashOf(sent[0]))
+    })
+  }
+
+  it('signs with the wallet address, not the delegation target', async () => {
+    // Only one of the two addresses is the signer; swapping them would sign
+    // with the delegation target.
+    const { signAuthorization, sent } = await loggedIn(correctly)
+
+    await signAuthorization({ address: DELEGATE, chainId: 1, nonce: 7 })
+
+    expect(sent[0].turnkeyPayload.parameters.signWith).toBe(OWNER.address)
+  })
+
+  it('normalizes the contractAddress alias onto address', async () => {
+    // `AuthorizationRequest` accepts either key, but
+    // `serializeAuthorizationList` reads only `address` — so keeping the
+    // caller's key verbatim would RLP-encode `undefined` as the delegate.
+    const { signAuthorization } = await loggedIn(correctly)
+
+    const authorization = await signAuthorization({
+      contractAddress: DELEGATE,
+      chainId: 1,
+      nonce: 7,
+    })
+
+    expect(authorization.address).toBe(DELEGATE)
+    await expect(recoverAuthorizationAddress({ authorization })).resolves.toBe(
+      OWNER.address,
+    )
+    expectWellFormedSignature(authorization)
+  })
+})
+
+describe('7702: authorizations Core must not refuse', () => {
+  it('authorizes the zero address, which revokes a delegation', async () => {
+    // The zero address clears a delegation, so this is how a user un-delegates.
+    // `buildTurnkeyPayload` and `toViemAccount` both reject zero addresses for
+    // the *wallet* — extending that to the delegation target would strand every
+    // delegated user, so this test is here to stop it.
+    const { signAuthorization } = await loggedIn(correctly)
+
+    const authorization = await signAuthorization({
+      address: ZERO,
+      chainId: 1,
+      nonce: 3,
+    })
+
+    expect(authorization.address).toBe(ZERO)
+    await expect(recoverAuthorizationAddress({ authorization })).resolves.toBe(
+      OWNER.address,
+    )
+    expectWellFormedSignature(authorization)
+  })
+
+  it('accepts a signature the backend sent without an 0x prefix', async () => {
+    // `sendSigningRequest` normalizes it; dropping that would reject perfectly
+    // good responses.
+    const { signAuthorization } = await loggedIn((correct) => ({
+      signature: correct.slice(2),
+    }))
+
+    const authorization = await signAuthorization({
+      address: DELEGATE,
+      chainId: 1,
+      nonce: 7,
+    })
+
+    await expect(recoverAuthorizationAddress({ authorization })).resolves.toBe(
+      OWNER.address,
+    )
+    expectWellFormedSignature(authorization)
+  })
+})
+
+describe('7702: nothing to authorize', () => {
+  it('refuses before spending a KMS round trip when no address was given', async () => {
+    // Reachable only from untyped callers, but the observable is outbound: no
+    // KMS round trip is spent signing an `undefined` delegation target.
+    const { signAuthorization, sent } = await loggedIn(correctly)
+
+    const error = await caught(
+      signAuthorization({ chainId: 1, nonce: 7 } as never),
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toMatch(/address is undefined/i)
+    expect(sent).toHaveLength(0)
+  })
+})
+
+describe('7702: the signing response is unusable', () => {
+  // These share `sendSigningRequest` with `signingResponse.integration.test.ts`,
+  // so no mutation kills them uniquely; they keep the 7702 endpoint covered if
+  // the message path moves. Three guards hold the line, measured: the
+  // `signature` field check (absent/null/non-string/non-JSON), the
+  // `recoverAddress` call itself (malformed and truncated hex), and the two
+  // ownership comparisons — which only the wrong-signer test needs, and needs
+  // BOTH gone to fail. Do not "fix" either surviving mutation.
+
+  const unusable: [string, (correct: Hex) => Answer][] = [
+    ['the field is absent', () => ({}) as Answer],
+    ['it is an empty string', () => ({ signature: '' })],
+    ['it is null', () => ({ signature: null })],
+    ['it is not a string', () => ({ signature: 42 })],
+    ['it is not hex', () => ({ signature: `0x${'zz'.repeat(32)}` })],
+    ['it is truncated', (correct) => ({ signature: correct.slice(0, 40) })],
+    [
+      'the body is not JSON at all',
+      () => ({ raw: '<html>gateway timeout</html>', contentType: 'text/html' }),
+    ],
+  ]
+
+  for (const [label, answer] of unusable) {
+    it(`returns no authorization when ${label}`, async () => {
+      const { signAuthorization } = await loggedIn(answer)
+
+      const error = await caught(
+        signAuthorization({ address: DELEGATE, chainId: 1, nonce: 7 }),
+      )
+
+      // Must reject, not resolve with the tuple minus its signature: viem
+      // serializes a missing r/s as zeroes and the caller cannot tell.
+      expect(blamesTheSignature(error)).toBe(true)
+    })
+  }
+
+  it('refuses a valid signature made over a different authorization', async () => {
+    // Right key, right length, wrong bytes signed — KMS returning a signature
+    // over an authorization Core never asked for. For 7702 that is a delegation
+    // to a contract the user did not choose, so no shape check is any use here.
+    const { signAuthorization } = await loggedIn(() => ({
+      signature: elsewhere,
+    }))
+
+    const error = await caught(
+      signAuthorization({ address: DELEGATE, chainId: 1, nonce: 7 }),
+    )
+
+    expect(blamesTheSignature(error)).toBe(true)
+  })
+
+  it('refuses an authorization signed by someone other than the wallet', async () => {
+    // Well-formed, over the right hash, wrong key. Broadcast, it delegates the
+    // signer's account instead of the user's.
+    const { signAuthorization } = await loggedIn(correctly, IMPOSTOR)
+
+    const error = await caught(
+      signAuthorization({ address: DELEGATE, chainId: 1, nonce: 7 }),
+    )
+
+    expect(blamesTheSignature(error)).toBe(true)
+    expect((error as Error).message).toContain(OWNER.address)
+  })
+
+  it('surfaces a rejected token as a request failure, not a signature fault', async () => {
+    const { signAuthorization } = await loggedIn(() => ({ status: 401 }))
+
+    const error = await caught(
+      signAuthorization({ address: DELEGATE, chainId: 1, nonce: 7 }),
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toContain('401')
+  })
+})

--- a/packages/core/src/adapters/signingResponse.integration.test.ts
+++ b/packages/core/src/adapters/signingResponse.integration.test.ts
@@ -123,7 +123,7 @@ async function loggedIn(answer: (correct: Hex) => Answer) {
       if (path.includes('/auth/login/stamp')) {
         return json({ session: token(body.targetPublicKey) })
       }
-      if (path.includes('/user-wallet')) {
+      if (path.includes('/wallets')) {
         return json({ walletAddresses: [OWNER.address] })
       }
       if (path.includes('/sign/')) {

--- a/packages/core/src/adapters/signingResponse.integration.test.ts
+++ b/packages/core/src/adapters/signingResponse.integration.test.ts
@@ -8,8 +8,6 @@
  * `assertOwner` recovers a second time, so the owner check is redundant by
  * design. `loginWalletIdentity` covers a well-formed signature from the wrong
  * wallet, so this file covers responses carrying no usable signature at all.
- *
- * Seam is HEALTHY as probed; no `it.fails` here.
  */
 import {
   type Hex,

--- a/packages/core/src/adapters/signingResponse.integration.test.ts
+++ b/packages/core/src/adapters/signingResponse.integration.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Boundary: Wallet Core <-> KMS, at the point a signing response becomes a
+ * signature the caller will broadcast.
+ *
+ * Three endpoints share `sendSigningRequest`, which requires a non-empty
+ * `signature` string, prefixes `0x` when the backend omits it, and recovers the
+ * signer against the payload it asked to have signed; `toViemAccount`'s
+ * `assertOwner` recovers a second time, so the owner check is redundant by
+ * design. `loginWalletIdentity` covers a well-formed signature from the wrong
+ * wallet, so this file covers responses carrying no usable signature at all.
+ *
+ * Seam is HEALTHY as probed; no `it.fails` here.
+ */
+import {
+  type Hex,
+  keccak256,
+  parseGwei,
+  recoverMessageAddress,
+  recoverTransactionAddress,
+  recoverTypedDataAddress,
+} from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createZeroDevWalletCore } from '../core/createZeroDevWalletCore.js'
+import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'
+import type { StorageAdapter } from '../storage/manager.js'
+import { SessionType } from '../types/session.js'
+
+/** Publicly known test keys; the wallet's signer, so recovery can succeed. */
+const OWNER = privateKeyToAccount(`0x${'11'.repeat(32)}` as Hex)
+const PAYEE = privateKeyToAccount(`0x${'22'.repeat(32)}` as Hex)
+
+const sessionKey = (nth: number) => `02${String(nth).padStart(64, '0')}`
+
+function keyStore(): ApiKeyStamper {
+  let active: string | null = null
+  let pending: string | null = null
+  let minted = 0
+  const stamp = async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  })
+  return {
+    stamp,
+    clear: async () => {
+      active = null
+      pending = null
+    },
+    getPublicKey: async () => active,
+    resetKeyPair: async () => {
+      active = sessionKey(++minted)
+    },
+    prepareKeyRotation: async () => {
+      pending = sessionKey(++minted)
+      return pending
+    },
+    stampPending: stamp,
+    signPending: async () => 'sig',
+    commitKeyRotation: async () => {
+      if (pending) active = pending
+      pending = null
+    },
+    discardKeyRotation: async () => {
+      pending = null
+    },
+    sign: async () => 'sig',
+  }
+}
+
+const passkeyStamper: PasskeyStamper = {
+  stamp: async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  }),
+  clear: async () => {},
+  register: async () => ({
+    attestation: {
+      attestationObject: 'ao',
+      clientDataJson: 'cdj',
+      credentialId: 'cred-1',
+    },
+    encodedChallenge: 'challenge',
+  }),
+}
+
+function token(publicKey: string) {
+  return `hdr.${btoa(
+    JSON.stringify({
+      exp: Date.now() + 3_600_000,
+      public_key: publicKey,
+      session_type: SessionType.READ_WRITE,
+      user_id: 'user-1',
+      organization_id: 'suborg-1',
+    }),
+  )}.sig`
+}
+
+/** What a `/sign/*` request is answered with. */
+type Answer =
+  | { signature: unknown }
+  | { raw: string; contentType: string }
+  | { status: number }
+
+/**
+ * The double signs whatever hash it is handed with the wallet's key rather than
+ * deciding anything, so a degenerate case differs from the control only in
+ * `answer`.
+ */
+async function loggedIn(answer: (correct: Hex) => Answer) {
+  const api = keyStore()
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const path = String(url)
+      const body = init?.body ? JSON.parse(String(init.body)) : {}
+      const json = (payload: unknown, status = 200) =>
+        new Response(JSON.stringify(payload), {
+          status,
+          headers: { 'content-type': 'application/json' },
+        })
+
+      if (path.includes('parent-org-id')) {
+        return json({ parentOrgId: 'parent-org' })
+      }
+      if (path.includes('/auth/login/stamp')) {
+        return json({ session: token(body.targetPublicKey) })
+      }
+      if (path.includes('/user-wallet')) {
+        return json({ walletAddresses: [OWNER.address] })
+      }
+      if (path.includes('/sign/')) {
+        const correct = await OWNER.sign({
+          hash: `0x${body.turnkeyPayload.parameters.payload}` as Hex,
+        })
+        const chosen = answer(correct)
+        if ('status' in chosen) {
+          return json({ error: 'bad_token', message: 'expired' }, chosen.status)
+        }
+        if ('raw' in chosen) {
+          return new Response(chosen.raw, {
+            status: 200,
+            headers: { 'content-type': chosen.contentType },
+          })
+        }
+        return json(chosen)
+      }
+      return json({}, 404)
+    }),
+  )
+
+  const store = new Map<string, string>()
+  const adapter: StorageAdapter = {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value)
+    },
+    removeItem: (key) => {
+      store.delete(key)
+    },
+  }
+  const core = await createZeroDevWalletCore({
+    projectId: 'proj',
+    rpId: 'localhost',
+    sessionStorage: adapter,
+    apiKeyStamper: api,
+    passkeyStamper,
+    proxyBaseUrl: 'https://kms.test.invalid/api/v1',
+  })
+  await core.auth({ type: 'passkey', mode: 'login' })
+  return core.toAccount()
+}
+
+const correctly = (correct: Hex) => ({ signature: correct })
+
+/**
+ * Attributable = the caller can tell the signing response was at fault. Rejects
+ * a `TypeError` and a message that names nothing, so neither a raw deref nor a
+ * bare `Error('failed')` can pass for a guard.
+ */
+function blamesTheSignature(error: unknown) {
+  return (
+    error instanceof Error &&
+    !(error instanceof TypeError) &&
+    /signature|signing/i.test(error.message)
+  )
+}
+
+const caught = (p: Promise<unknown>) =>
+  p.then(
+    () => 'SIGNED' as const,
+    (error: unknown) => error,
+  )
+
+/** 65 bytes exactly. Asserted alongside every recovery, never instead of one. */
+const SIGNATURE = /^0x[0-9a-f]{130}$/i
+
+const TYPED_DATA = {
+  domain: { name: 'Test', version: '1', chainId: 1 },
+  types: { Msg: [{ name: 'x', type: 'uint256' }] },
+  primaryType: 'Msg',
+  message: { x: 1n },
+} as const
+
+const TRANSACTION = {
+  chainId: 1,
+  to: PAYEE.address,
+  value: 0n,
+  nonce: 0,
+  gas: 21_000n,
+  maxFeePerGas: parseGwei('1'),
+  maxPriorityFeePerGas: parseGwei('1'),
+  type: 'eip1559',
+} as never
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('signing: all three endpoints return a usable signature', () => {
+  // Shape AND recovery, on the value the CALLER received. Recovery is what
+  // catches 130 zeroes, a different payload, or a signature mangled after
+  // `assertOwner` already ran; shape localises the failure. Keep both.
+  it('signs a message', async () => {
+    const account = await loggedIn(correctly)
+
+    const signature = await account.signMessage({ message: 'hello' })
+
+    expect(signature).toMatch(SIGNATURE)
+    await expect(
+      recoverMessageAddress({ message: 'hello', signature }),
+    ).resolves.toBe(OWNER.address)
+  })
+
+  it('signs typed data', async () => {
+    const account = await loggedIn(correctly)
+
+    const signature = await account.signTypedData(TYPED_DATA as never)
+
+    expect(signature).toMatch(SIGNATURE)
+    await expect(
+      recoverTypedDataAddress({ ...TYPED_DATA, signature } as never),
+    ).resolves.toBe(OWNER.address)
+  })
+
+  it('signs a transaction', async () => {
+    // Returns a serialized transaction, not a raw signature — the adapter
+    // re-serializes with the recovered r/s/v. Prefix asserts it is still
+    // eip1559; recovery asserts the signature survived that round trip.
+    const account = await loggedIn(correctly)
+
+    const serializedTransaction = await account.signTransaction(TRANSACTION)
+
+    expect(serializedTransaction).toMatch(/^0x02[0-9a-f]+$/i)
+    await expect(
+      recoverTransactionAddress({
+        serializedTransaction: serializedTransaction as `0x02${string}`,
+      }),
+    ).resolves.toBe(OWNER.address)
+  })
+})
+
+describe('signing: the response carries no usable signature', () => {
+  const shapes: [string, Answer][] = [
+    ['the field is absent', {} as Answer],
+    ['it is an empty string', { signature: '' }],
+    ['it is null', { signature: null }],
+    ['it is not a string', { signature: 42 }],
+  ]
+
+  for (const [label, response] of shapes) {
+    it(`refuses to return a signature when ${label}`, async () => {
+      const account = await loggedIn(() => response)
+
+      const error = await caught(account.signMessage({ message: 'hello' }))
+
+      expect(blamesTheSignature(error)).toBe(true)
+    })
+  }
+
+  it('guards the non-JSON body that the oauth branch does not', async () => {
+    // `rest.ts` hands a non-JSON 200 back as `data`. Here the `signature` field
+    // check catches it; `auth({type:'oauth'})` reports the same body as a
+    // legitimate sessionless login. That asymmetry is the oauth defect's case.
+    const account = await loggedIn(() => ({
+      raw: '<html>gateway timeout</html>',
+      contentType: 'text/html',
+    }))
+
+    const error = await caught(account.signMessage({ message: 'hello' }))
+
+    expect(blamesTheSignature(error)).toBe(true)
+  })
+})
+
+describe('signing: the signature is present but unusable', () => {
+  // Measured, so nobody prunes the wrong thing: malformed and truncated hex are
+  // caught by the `recoverAddress` CALL itself and stay green even with both
+  // ownership comparisons deleted. Only the different-payload test below needs
+  // those comparisons, and needs BOTH gone to fail. Do not "fix" either
+  // surviving mutation.
+
+  const shapes: [string, (correct: Hex) => Answer][] = [
+    ['it is not hex', () => ({ signature: `0x${'zz'.repeat(32)}` })],
+    ['it is truncated', (correct) => ({ signature: correct.slice(0, 40) })],
+  ]
+
+  for (const [label, response] of shapes) {
+    it(`refuses to return a signature when ${label}`, async () => {
+      const account = await loggedIn(response)
+
+      const error = await caught(account.signMessage({ message: 'hello' }))
+
+      // Message comes from viem's recovery, not Core, but still names the
+      // signature — enough for a caller to place the blame.
+      expect(blamesTheSignature(error)).toBe(true)
+    })
+  }
+
+  it('refuses a valid signature made over a different payload', async () => {
+    // Right key, right length, right hex, wrong thing signed — no shape check
+    // can see it, so this is the one test the ownership comparisons exist for.
+    const elsewhere = await OWNER.sign({ hash: keccak256('0xdeadbeef') })
+    const account = await loggedIn(() => ({ signature: elsewhere }))
+
+    const error = await caught(account.signMessage({ message: 'hello' }))
+
+    expect(blamesTheSignature(error)).toBe(true)
+  })
+})
+
+describe('signing: shapes that must NOT be treated as failures', () => {
+  it('accepts a signature the backend sent without an 0x prefix', async () => {
+    // `sendSigningRequest` normalizes it; dropping that would reject perfectly
+    // good responses.
+    const account = await loggedIn((correct) => ({
+      signature: correct.slice(2),
+    }))
+
+    const signature = await account.signMessage({ message: 'hello' })
+
+    expect(signature).toMatch(SIGNATURE)
+    await expect(
+      recoverMessageAddress({ message: 'hello', signature }),
+    ).resolves.toBe(OWNER.address)
+  })
+
+  it('surfaces a rejected token as a request failure, not a signature fault', async () => {
+    // Two stamps precede the request here, so a transport error has further to
+    // travel than on a bare action.
+    const account = await loggedIn(() => ({ status: 401 }))
+
+    const error = await caught(account.signMessage({ message: 'hello' }))
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toContain('401')
+  })
+})

--- a/packages/core/src/adapters/walletAddressResolution.integration.test.ts
+++ b/packages/core/src/adapters/walletAddressResolution.integration.test.ts
@@ -1,14 +1,15 @@
 /**
- * Boundary: Wallet Core <-> KMS, at the point where a KMS response becomes the
+ * Boundary: Wallet Core to KMS, at the point where a KMS response becomes the
  * address a user's funds go to (`toViemAccount` in `adapters/viem.ts`).
  *
- * The highest-consequence boundary in the SDK, and the same shape as the pre-#365
- * defect: a degenerate KMS answer became a wrong address and the SDK used it
- * without complaint. #365's zero/malformed/missing guards are asserted here as
- * regression cover; the rest of the file looks for what they do NOT catch.
+ * The boundary with the most at stake in the SDK. The failure shape it guards
+ * against is a degenerate KMS answer becoming a wrong address that the SDK then
+ * uses without complaint. The zero, malformed and missing address guards are
+ * asserted here as regression cover, and the rest of the file looks for what
+ * those guards do NOT catch.
  *
- * `walletAddresses` is a plural `Hex[]` — `getUserWallet`'s own docstring shows
- * two entries — but `toViemAccount` takes `[0]` and nothing disambiguates.
+ * `walletAddresses` is a plural `Hex[]`, and `getUserWallet`'s own docstring
+ * shows two entries, but `toViemAccount` takes `[0]`.
  */
 import type { Hex } from 'viem'
 import { describe, expect, it, vi } from 'vitest'

--- a/packages/core/src/adapters/walletAddressResolution.integration.test.ts
+++ b/packages/core/src/adapters/walletAddressResolution.integration.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Boundary: Wallet Core <-> KMS, at the point where a KMS response becomes the
+ * address a user's funds go to (`toViemAccount` in `adapters/viem.ts`).
+ *
+ * The highest-consequence boundary in the SDK, and the same shape as the pre-#365
+ * defect: a degenerate KMS answer became a wrong address and the SDK used it
+ * without complaint. #365's zero/malformed/missing guards are asserted here as
+ * regression cover; the rest of the file looks for what they do NOT catch.
+ *
+ * `walletAddresses` is a plural `Hex[]` — `getUserWallet`'s own docstring shows
+ * two entries — but `toViemAccount` takes `[0]` and nothing disambiguates.
+ */
+import type { Hex } from 'viem'
+import { describe, expect, it, vi } from 'vitest'
+import type { ZeroDevWalletClient } from '../client/index.js'
+import { toViemAccount } from './viem.js'
+
+const ADDR_A = '0x1111111111111111111111111111111111111111' as Hex
+const ADDR_B = '0x2222222222222222222222222222222222222222' as Hex
+const ZERO = '0x0000000000000000000000000000000000000000' as Hex
+
+/** A client whose only job is to answer `getUserWallet` however we want. */
+function clientReturning(...responses: { walletAddresses: Hex[] }[]) {
+  const getUserWallet = vi.fn(async () => {
+    const next = responses.length > 1 ? responses.shift() : responses[0]
+    return next as { walletAddresses: Hex[] }
+  })
+  return {
+    client: { getUserWallet } as unknown as ZeroDevWalletClient,
+    getUserWallet,
+  }
+}
+
+function buildAccount(client: ZeroDevWalletClient) {
+  return toViemAccount({
+    client,
+    organizationId: 'org-1',
+    projectId: 'project-1',
+    getToken: () => 'session-token',
+  })
+}
+
+describe('wallet address resolution: guards that must hold (#365 regression)', () => {
+  it('builds an account on the address KMS returns', async () => {
+    const { client } = clientReturning({ walletAddresses: [ADDR_A] })
+
+    const account = await buildAccount(client)
+
+    expect(account.address).toBe(ADDR_A)
+  })
+
+  it('refuses to build an account when KMS returns no address', async () => {
+    const { client } = clientReturning({ walletAddresses: [] })
+
+    await expect(buildAccount(client)).rejects.toThrow(
+      /missing, malformed, or zero/,
+    )
+  })
+
+  it('refuses the zero address', async () => {
+    const { client } = clientReturning({ walletAddresses: [ZERO] })
+
+    await expect(buildAccount(client)).rejects.toThrow(
+      /missing, malformed, or zero/,
+    )
+  })
+
+  it('refuses a malformed address rather than passing it downstream', async () => {
+    const { client } = clientReturning({
+      walletAddresses: ['0xdeadbeef' as Hex],
+    })
+
+    await expect(buildAccount(client)).rejects.toThrow(
+      /missing, malformed, or zero/,
+    )
+  })
+
+  it("refuses the backend's wallet-fallback placeholder", async () => {
+    // Not a hypothetical value: doorway-kms answers a failed `/user-wallet`
+    // with HTTP 200 and this exact placeholder (40 Z's), which it publishes for
+    // tests to assert against.
+    const { client } = clientReturning({
+      walletAddresses: ['0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ' as Hex],
+    })
+
+    await expect(buildAccount(client)).rejects.toThrow(
+      /missing, malformed, or zero/,
+    )
+  })
+})
+
+describe('wallet address resolution: the response shape itself', () => {
+  // The transport hands back `data as any` with no schema validation, so these
+  // point wrong shapes at the seam. Each asserts the invariant every remedy
+  // shares — the rejection must be attributable to the wallet response — rather
+  // than a specific error type or message.
+
+  const shapeViolation = (response: unknown) =>
+    toViemAccount({
+      client: {
+        getUserWallet: vi.fn(async () => response),
+      } as unknown as ZeroDevWalletClient,
+      organizationId: 'org-1',
+      projectId: 'project-1',
+      getToken: () => 'session-token',
+    })
+
+  it('rejects a non-array `walletAddresses` with a diagnosable error', async () => {
+    // A string slips through indexing (`"0x…"[0]` is `"0"`) and lands on the
+    // address guard, so this already behaves.
+    await expect(shapeViolation({ walletAddresses: ADDR_A })).rejects.toThrow(
+      /missing, malformed, or zero/,
+    )
+  })
+
+  it('rejects entries that are not strings with a diagnosable error', async () => {
+    await expect(shapeViolation({ walletAddresses: [42] })).rejects.toThrow(
+      /missing, malformed, or zero/,
+    )
+  })
+
+  it.fails(
+    'rejects a missing `walletAddresses` field with a diagnosable error, not a TypeError',
+    async () => {
+      // Today: `TypeError: Cannot read properties of undefined (reading '0')`.
+      const error = await shapeViolation({}).catch((e: unknown) => e)
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error).not.toBeInstanceOf(TypeError)
+      expect((error as Error).message).toMatch(/wallet/i)
+    },
+  )
+
+  it.fails(
+    'rejects a null `walletAddresses` with a diagnosable error, not a TypeError',
+    async () => {
+      // Today: `TypeError: Cannot read properties of null (reading '0')`.
+      const error = await shapeViolation({ walletAddresses: null }).catch(
+        (e: unknown) => e,
+      )
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error).not.toBeInstanceOf(TypeError)
+      expect((error as Error).message).toMatch(/wallet/i)
+    },
+  )
+
+  it.fails(
+    'rejects an empty response body with a diagnosable error, not a TypeError',
+    async () => {
+      // Today: `TypeError: … of null (reading 'walletAddresses')`. Reachable on
+      // any 200 with no body — the transport parses that to `null`.
+      const error = await shapeViolation(null).catch((e: unknown) => e)
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error).not.toBeInstanceOf(TypeError)
+      expect((error as Error).message).toMatch(/wallet/i)
+    },
+  )
+})
+
+describe('wallet address resolution: ambiguity a user can actually hit', () => {
+  it('builds a fully usable account for EITHER address, so a dropped entry is a real wallet', async () => {
+    const accountA = await buildAccount(
+      clientReturning({ walletAddresses: [ADDR_A] }).client,
+    )
+    const accountB = await buildAccount(
+      clientReturning({ walletAddresses: [ADDR_B] }).client,
+    )
+
+    expect(accountA.address).toBe(ADDR_A)
+    expect(accountB.address).toBe(ADDR_B)
+    expect(accountA.address).not.toBe(accountB.address)
+    for (const account of [accountA, accountB]) {
+      expect(account.type).toBe('local')
+      expect(typeof account.signMessage).toBe('function')
+      expect(typeof account.signTransaction).toBe('function')
+      expect(typeof account.signTypedData).toBe('function')
+    }
+  })
+
+  it.fails(
+    'refuses to build an account when KMS returns more than one address',
+    async () => {
+      // Today `walletAddresses[0]` wins silently — a well-formed address, so the
+      // validity guards above cannot catch it. Nothing here pins WHICH entry is
+      // chosen: mutating the adapter to take the last element leaves the suite
+      // green, deliberately.
+      const { client } = clientReturning({
+        walletAddresses: [ADDR_A, ADDR_B],
+      })
+
+      await expect(buildAccount(client)).rejects.toThrow()
+    },
+  )
+
+  it('reflects a changed wallet address rather than reusing the first answer', async () => {
+    // The double answers with a DIFFERENT address on the second call, so a
+    // cache that still calls and ignores the answer fails here too.
+    const { client, getUserWallet } = clientReturning(
+      { walletAddresses: [ADDR_A] },
+      { walletAddresses: [ADDR_B] },
+    )
+
+    const before = await buildAccount(client)
+    const after = await buildAccount(client)
+
+    expect(before.address).toBe(ADDR_A)
+    expect(after.address).toBe(ADDR_B)
+    expect(getUserWallet).toHaveBeenCalledTimes(2)
+  })
+
+  it('propagates a KMS failure instead of producing an account', async () => {
+    const client = {
+      getUserWallet: vi.fn(async () => {
+        throw new Error('KMS unavailable')
+      }),
+    } as unknown as ZeroDevWalletClient
+
+    await expect(buildAccount(client)).rejects.toThrow(/KMS unavailable/)
+  })
+})

--- a/packages/core/src/client/authProxyConfigId.integration.test.ts
+++ b/packages/core/src/client/authProxyConfigId.integration.test.ts
@@ -3,15 +3,9 @@
  *
  * Two units in one file because the id passes through both:
  * `getAuthProxyConfigId` fetches it and `createAuthProxyClient` sends it as an
- * `X-Auth-Proxy-Config-Id` header.
- * `authProxyFailureFidelity` covers the proxy's responses using a valid id, so
- * this file covers the id itself.
- *
- * Both are driven directly because `auth()` cannot reach them. In the
- * `verifyOtp` branch `encryptOtpAttempt` runs first, pinned to the production
- * enclave key. That leaves one behaviour unasserted: `cachedAuthProxyConfigId`
- * is only assigned when truthy, so a degenerate id stays uncached and the next
- * attempt refetches.
+ * `X-Auth-Proxy-Config-Id` header. Both are driven directly, since `auth()`
+ * reaches them only through the `verifyOtp` branch, where `encryptOtpAttempt`
+ * runs first against a pinned enclave key.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { getAuthProxyConfigId } from '../actions/auth/getAuthProxyConfigId.js'
@@ -155,13 +149,6 @@ describe('auth proxy config id: a 200 that carries no usable id', () => {
 })
 
 describe('auth proxy config id: addressing the proxy with a bad one', () => {
-  // The call site passes the fetched value straight into
-  // `createAuthProxyClient`, so these are the inputs it would hand over.
-  //
-  // Asserted on the raw `init.headers` object Core built, not on a `Headers`
-  // instance. `Headers` normalises so under happy-dom `undefined`, `null`
-  // and `''` all flatten to `''` so reading it back that way measures the
-  // runtime's coercion instead of the value Core produced.
   const badIds: [string, unknown][] = [
     ['undefined', undefined],
     ['null', null],

--- a/packages/core/src/client/authProxyConfigId.integration.test.ts
+++ b/packages/core/src/client/authProxyConfigId.integration.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Boundary between Wallet Core and KMS at `server-info/auth-proxy-id`.
+ *
+ * Two units in one file because the id passes through both:
+ * `getAuthProxyConfigId` fetches it and `createAuthProxyClient` sends it as an
+ * `X-Auth-Proxy-Config-Id` header.
+ * `authProxyFailureFidelity` covers the proxy's responses using a valid id, so
+ * this file covers the id itself.
+ *
+ * Both are driven directly because `auth()` cannot reach them. In the
+ * `verifyOtp` branch `encryptOtpAttempt` runs first, pinned to the production
+ * enclave key. That leaves one behaviour unasserted: `cachedAuthProxyConfigId`
+ * is only assigned when truthy, so a degenerate id stays uncached and the next
+ * attempt refetches.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getAuthProxyConfigId } from '../actions/auth/getAuthProxyConfigId.js'
+import type { Stamper } from '../stampers/types.js'
+import { createAuthProxyClient } from './authProxy.js'
+import { rest } from './transports/rest.js'
+import type { Client } from './types.js'
+
+const BASE = 'https://kms.example.invalid/api/v1'
+const CONFIG_ID_URL = `${BASE}/server-info/auth-proxy-id`
+const VERIFY_URL = 'https://authproxy.turnkey.com/v1/otp_verify_v2'
+
+const noopStamper: Stamper = {
+  stamp: async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  }),
+  clear: async () => {},
+}
+
+const transport = () =>
+  rest(BASE, {
+    apiKeyStamper: noopStamper,
+    passkeyStamper: noopStamper,
+  }) as unknown as Client
+
+/** Answers the config-id request once with the given status, body, type. */
+function respondWith(
+  status: number,
+  body: unknown,
+  contentType = 'application/json',
+) {
+  const calls: { url: string; init?: RequestInit }[] = []
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), ...(init && { init }) })
+      return new Response(
+        typeof body === 'string' ? body : JSON.stringify(body),
+        { status, headers: { 'content-type': contentType } },
+      )
+    }),
+  )
+  return calls
+}
+
+const outcomeOf = (p: Promise<unknown>) =>
+  p.then(
+    (value) => ({ ok: true, value }) as const,
+    (error: unknown) => ({ ok: false, error }) as const,
+  )
+
+/** Rejects `''` so a `?? ''` coercion cannot pass for a repair. */
+const usable = (v: unknown) => typeof v === 'string' && v.length > 0
+
+/** Attributable = an Error that is not a raw deref and names the thing. */
+const blamesTheConfigId = (error: unknown) =>
+  error instanceof Error &&
+  !(error instanceof TypeError) &&
+  /config|proxy|auth/i.test(error.message)
+
+/** Refuse attributably, or return an id the proxy can be addressed with. */
+const endsUsably = (outcome: Awaited<ReturnType<typeof outcomeOf>>) =>
+  outcome.ok
+    ? typeof outcome.value === 'object' &&
+      outcome.value !== null &&
+      usable(
+        (outcome.value as { authProxyConfigId?: unknown }).authProxyConfigId,
+      )
+    : blamesTheConfigId(outcome.error)
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('auth proxy config id: fetching it', () => {
+  it('returns an id the proxy can be addressed with', async () => {
+    respondWith(200, { authProxyConfigId: 'cfg-1' })
+
+    const outcome = await outcomeOf(getAuthProxyConfigId(transport()))
+
+    expect(endsUsably(outcome)).toBe(true)
+  })
+
+  it('asks for it with a bare GET and no credentials', async () => {
+    const calls = respondWith(200, { authProxyConfigId: 'cfg-1' })
+
+    await getAuthProxyConfigId(transport())
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe(CONFIG_ID_URL)
+    expect(calls[0].init?.method).toBe('GET')
+    const headers = (calls[0].init?.headers ?? {}) as Record<string, unknown>
+    expect(headers.Authorization).toBeUndefined()
+  })
+
+  const failures: [string, number][] = [
+    ['a rejected caller', 401],
+    ['a missing endpoint', 404],
+    ['a throttle', 429],
+    ['a server fault', 500],
+  ]
+
+  for (const [label, status] of failures) {
+    it(`propagates ${label} with the status intact`, async () => {
+      respondWith(status, { error: 'nope', message: 'try later' })
+
+      const outcome = await outcomeOf(getAuthProxyConfigId(transport()))
+
+      expect(outcome.ok).toBe(false)
+      expect((outcome as { error: Error }).error.message).toContain(
+        String(status),
+      )
+    })
+  }
+})
+
+describe('auth proxy config id: a 200 that carries no usable id', () => {
+  // DEFECT. `rest.ts` returns `data as any`, so every shape below resolves and
+  // the declared `{ authProxyConfigId: string }` is not respected. The `null`
+  // case is the worst as the caller destructures the result, so it gets a TypeError
+  const hollow: [string, unknown, string?][] = [
+    ['the field is absent', {}],
+    ['it is null', { authProxyConfigId: null }],
+    ['it is an empty string', { authProxyConfigId: '' }],
+    ['it is not a string', { authProxyConfigId: 42 }],
+    ['the field is misspelled', { configId: 'cfg-1' }],
+    ['the body is null', null],
+    ['the body is a gateway interstitial', '<html>timeout</html>', 'text/html'],
+  ]
+
+  for (const [label, body, contentType] of hollow) {
+    it.fails(`returns an unusable id when ${label}`, async () => {
+      respondWith(200, body, contentType)
+
+      const outcome = await outcomeOf(getAuthProxyConfigId(transport()))
+
+      expect(endsUsably(outcome)).toBe(true)
+    })
+  }
+})
+
+describe('auth proxy config id: addressing the proxy with a bad one', () => {
+  // The call site passes the fetched value straight into
+  // `createAuthProxyClient`, so these are the inputs it would hand over.
+  //
+  // Asserted on the raw `init.headers` object Core built, not on a `Headers`
+  // instance. `Headers` normalises so under happy-dom `undefined`, `null`
+  // and `''` all flatten to `''` so reading it back that way measures the
+  // runtime's coercion instead of the value Core produced.
+  const badIds: [string, unknown][] = [
+    ['undefined', undefined],
+    ['null', null],
+    ['an empty string', ''],
+  ]
+
+  for (const [label, id] of badIds) {
+    it(`still spends a proxy round trip when the id is ${label}`, async () => {
+      const calls = respondWith(200, { verificationToken: 'vt' })
+      const proxy = createAuthProxyClient({ authProxyConfigId: id as string })
+
+      await outcomeOf(
+        proxy.verifyOtp({ otpId: 'otp-1', encryptedOtpBundle: 'sealed' }),
+      )
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0].url).toBe(VERIFY_URL)
+      const headers = (calls[0].init?.headers ?? {}) as Record<string, unknown>
+      expect(usable(headers['X-Auth-Proxy-Config-Id'])).toBe(false)
+    })
+  }
+
+  it('sends a usable id through unchanged', async () => {
+    const calls = respondWith(200, { verificationToken: 'vt' })
+    const proxy = createAuthProxyClient({ authProxyConfigId: 'cfg-1' })
+
+    await proxy.verifyOtp({ otpId: 'otp-1', encryptedOtpBundle: 'sealed' })
+
+    const headers = (calls[0].init?.headers ?? {}) as Record<string, unknown>
+    expect(headers['X-Auth-Proxy-Config-Id']).toBe('cfg-1')
+  })
+})

--- a/packages/core/src/client/authProxyFailureFidelity.integration.test.ts
+++ b/packages/core/src/client/authProxyFailureFidelity.integration.test.ts
@@ -1,10 +1,9 @@
 /**
- * Boundary: Wallet Core <-> Turnkey's Auth Proxy.
+ * Boundary between Wallet Core and Turnkey's Auth Proxy.
  *
- * `createAuthProxyClient` talks to a hardcoded `https://authproxy.turnkey.com`,
- * with its own request function that shares none of `rest.ts`'s behaviour
- *
- * The unit under test is the client itself rather than `auth()`
+ * `createAuthProxyClient` talks to a hardcoded `https://authproxy.turnkey.com`
+ * through its own request function, sharing none of `rest.ts`'s behaviour, so
+ * the unit under test is that client rather than `auth()`.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createAuthProxyClient } from './authProxy.js'
@@ -89,10 +88,11 @@ describe('auth proxy: the contract that must keep holding', () => {
 })
 
 describe('auth proxy: what a caller is left with when the response is wrong', () => {
-  // The assertions below are shaped to hold under ANY remedy — rejecting is one,
-  // returning something actionable is another — so they check "did I end up with
-  // a usable token" rather than "did it throw". Asserting rejection would turn a
-  // legitimate fix red.
+  // The two token tests are shaped to hold under any remedy, rejecting or
+  // returning something actionable, so they check "did I end up with a usable
+  // token" rather than "did it throw". The non-JSON test is a narrower bet on
+  // purpose: it requires an attributable rejection, since a 200 carrying HTML is
+  // a transport failure wearing the shape of success.
 
   it.fails(
     'does not report success when the response carries no verification token',
@@ -143,12 +143,23 @@ describe('auth proxy: what a caller is left with when the response is wrong', ()
   })
 
   it.fails('does not wait forever on a proxy that never answers', async () => {
-    // A fetch that never settles, with fake timers so the clock is advanced
-    // rather than waited on. Today nothing aborts it, so `settled` stays false.
+    // A fetch that never settles on its own; it rejects only once the caller's
+    // own abort signal fires, so a timeout is the only thing that can end it.
+    // A stub ignoring the signal would stay pending under an AbortController
+    // remedy too, leaving this expected-fail forever.
     vi.useFakeTimers()
     vi.stubGlobal(
       'fetch',
-      vi.fn(() => new Promise<Response>(() => {})),
+      vi.fn(
+        (_url: string | URL | Request, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => {
+              const error = new Error('The operation was aborted')
+              error.name = 'AbortError'
+              reject(error)
+            })
+          }),
+      ),
     )
 
     let settled = false
@@ -163,7 +174,9 @@ describe('auth proxy: what a caller is left with when the response is wrong', ()
         },
       )
 
-    await vi.advanceTimersByTimeAsync(60_000)
+    // Ten minutes, well past any sane timeout, so the number is not itself a
+    // ceiling a slower remedy could fall outside.
+    await vi.advanceTimersByTimeAsync(600_000)
     // Deliberately not awaited — awaiting a request with no timeout IS the hang
     // under test.
     expect(pending).toBeInstanceOf(Promise)

--- a/packages/core/src/client/authProxyFailureFidelity.integration.test.ts
+++ b/packages/core/src/client/authProxyFailureFidelity.integration.test.ts
@@ -19,6 +19,14 @@ function client() {
   return createAuthProxyClient({ authProxyConfigId: 'cfg-1' })
 }
 
+/**
+ * `typeof t === 'string'` alone would accept `''`, so a `?? ''` in the client
+ * would flip the hollow-token tests red as though the defect were fixed.
+ */
+function isUsableToken(token: unknown) {
+  return typeof token === 'string' && token.length > 0
+}
+
 /** Stubs `fetch` to answer once with the given status, body and content type. */
 function respondWith(
   status: number,
@@ -96,7 +104,7 @@ describe('auth proxy: what a caller is left with when the response is wrong', ()
       const usable = await client()
         .verifyOtp(ATTEMPT)
         .then(
-          (r) => typeof r.verificationToken === 'string',
+          (r) => isUsableToken(r.verificationToken),
           () => true, // rejecting is a perfectly good remedy
         )
 
@@ -112,7 +120,7 @@ describe('auth proxy: what a caller is left with when the response is wrong', ()
       const usable = await client()
         .verifyOtp(ATTEMPT)
         .then(
-          (r) => typeof r.verificationToken === 'string',
+          (r) => isUsableToken(r.verificationToken),
           () => true,
         )
 

--- a/packages/core/src/client/authProxyFailureFidelity.integration.test.ts
+++ b/packages/core/src/client/authProxyFailureFidelity.integration.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Boundary: Wallet Core <-> Turnkey's Auth Proxy.
+ *
+ * `createAuthProxyClient` talks to a hardcoded `https://authproxy.turnkey.com`,
+ * with its own request function that shares none of `rest.ts`'s behaviour
+ *
+ * The unit under test is the client itself rather than `auth()`
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createAuthProxyClient } from './authProxy.js'
+
+const VERIFY_URL = 'https://authproxy.turnkey.com/v1/otp_verify_v2'
+const ATTEMPT = { otpId: 'otp-1', encryptedOtpBundle: 'sealed-bundle' }
+
+/** A well-formed verification token: three segments, `id` in the payload. */
+const TOKEN = `hdr.${btoa(JSON.stringify({ id: 'token-1' }))}.sig`
+
+function client() {
+  return createAuthProxyClient({ authProxyConfigId: 'cfg-1' })
+}
+
+/** Stubs `fetch` to answer once with the given status, body and content type. */
+function respondWith(
+  status: number,
+  body: string,
+  contentType = 'application/json',
+) {
+  const fetchMock = vi.fn(
+    async (_url: string | URL | Request, _init?: RequestInit) =>
+      new Response(body, { status, headers: { 'content-type': contentType } }),
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('auth proxy: the contract that must keep holding', () => {
+  it('returns the verification token the proxy issued', async () => {
+    respondWith(200, JSON.stringify({ verificationToken: TOKEN }))
+
+    const result = await client().verifyOtp(ATTEMPT)
+
+    expect(result.verificationToken).toBe(TOKEN)
+  })
+
+  it('sends the sealed attempt and the config id to the verification endpoint', async () => {
+    const fetchMock = respondWith(
+      200,
+      JSON.stringify({ verificationToken: TOKEN }),
+    )
+
+    await client().verifyOtp(ATTEMPT)
+
+    const [url, init] = fetchMock.mock.calls[0] ?? []
+    expect(String(url)).toBe(VERIFY_URL)
+    expect(new Headers(init?.headers).get('X-Auth-Proxy-Config-Id')).toBe(
+      'cfg-1',
+    )
+    expect(JSON.parse(String(init?.body))).toEqual(ATTEMPT)
+  })
+
+  it('reports a throttle as a throttle, with the status and the body', async () => {
+    respondWith(429, 'slow down', 'text/plain')
+
+    await expect(client().verifyOtp(ATTEMPT)).rejects.toThrow(
+      /Auth Proxy request failed: 429.*slow down/,
+    )
+  })
+
+  it('reports a server error as a server error, with the body intact', async () => {
+    respondWith(500, JSON.stringify({ error: 'enclave unavailable' }))
+
+    await expect(client().verifyOtp(ATTEMPT)).rejects.toThrow(
+      /Auth Proxy request failed: 500.*enclave unavailable/,
+    )
+  })
+})
+
+describe('auth proxy: what a caller is left with when the response is wrong', () => {
+  // The assertions below are shaped to hold under ANY remedy — rejecting is one,
+  // returning something actionable is another — so they check "did I end up with
+  // a usable token" rather than "did it throw". Asserting rejection would turn a
+  // legitimate fix red.
+
+  it.fails(
+    'does not report success when the response carries no verification token',
+    async () => {
+      // Today: resolves with `{}`, so `usable` is false. Downstream that becomes
+      // `jwt.split(undefined)` inside `buildClientSignature`.
+      respondWith(200, JSON.stringify({}))
+
+      const usable = await client()
+        .verifyOtp(ATTEMPT)
+        .then(
+          (r) => typeof r.verificationToken === 'string',
+          () => true, // rejecting is a perfectly good remedy
+        )
+
+      expect(usable).toBe(true)
+    },
+  )
+
+  it.fails(
+    'does not report success when the verification token is null',
+    async () => {
+      respondWith(200, JSON.stringify({ verificationToken: null }))
+
+      const usable = await client()
+        .verifyOtp(ATTEMPT)
+        .then(
+          (r) => typeof r.verificationToken === 'string',
+          () => true,
+        )
+
+      expect(usable).toBe(true)
+    },
+  )
+
+  it.fails('attributes a non-JSON success body to the auth proxy', async () => {
+    // A 200 carrying HTML, as a gateway or CDN interstitial would. Today
+    // `response.json()` throws `SyntaxError: Unexpected token '<'`.
+    respondWith(200, '<html>gateway timeout</html>', 'text/html')
+
+    const error = await client()
+      .verifyOtp(ATTEMPT)
+      .catch((e: unknown) => e)
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error).not.toBeInstanceOf(SyntaxError)
+    expect((error as Error).message).toMatch(/auth proxy/i)
+  })
+
+  it.fails('does not wait forever on a proxy that never answers', async () => {
+    // A fetch that never settles, with fake timers so the clock is advanced
+    // rather than waited on. Today nothing aborts it, so `settled` stays false.
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise<Response>(() => {})),
+    )
+
+    let settled = false
+    const pending = client()
+      .verifyOtp(ATTEMPT)
+      .then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        },
+      )
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    // Deliberately not awaited — awaiting a request with no timeout IS the hang
+    // under test.
+    expect(pending).toBeInstanceOf(Promise)
+
+    expect(settled).toBe(true)
+  })
+})

--- a/packages/core/src/client/kmsFailureFidelity.integration.test.ts
+++ b/packages/core/src/client/kmsFailureFidelity.integration.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Boundary: Wallet Core <-> KMS / doorway-kms (B1).
+ *
+ * `client/transports/rest.ts` is the entire KMS contract — all 14 auth and
+ * signing actions go through it. One `fetch`, no retry, a 10 s default timeout,
+ * and either `RestRequestError` (status + url + parsed body) or
+ * `RestTimeoutError`.
+ *
+ * What these protect is failure fidelity: a caller has to tell a throttle from a
+ * rejection from an outage, because the right response differs.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RestRequestError, RestTimeoutError } from '../errors/request.js'
+import type { Stamper } from '../stampers/types.js'
+import { rest } from './transports/rest.js'
+
+const BASE = 'https://kms.example.invalid/api/v1'
+
+const noopStamper: Stamper = {
+  stamp: async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  }),
+  clear: async () => {},
+}
+
+function transport(timeoutMs?: number) {
+  return rest(BASE, {
+    apiKeyStamper: noopStamper,
+    passkeyStamper: noopStamper,
+    ...(timeoutMs !== undefined && { timeoutMs }),
+  })
+}
+
+/** Stubs `fetch` to answer once with the given status and body. */
+function respondWith(
+  status: number,
+  body: unknown,
+  contentType = 'application/json',
+) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () =>
+        new Response(typeof body === 'string' ? body : JSON.stringify(body), {
+          status,
+          headers: { 'content-type': contentType },
+        }),
+    ),
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('KMS boundary: HTTP failures stay distinguishable', () => {
+  const cases = [
+    { status: 401, label: 'rejected credential — re-authenticate' },
+    { status: 403, label: 'forbidden — do not retry' },
+    { status: 429, label: 'throttled — back off and retry' },
+    { status: 500, label: 'server fault' },
+    { status: 503, label: 'outage — back off' },
+  ] as const
+
+  for (const { status, label } of cases) {
+    it(`preserves status ${status} on the thrown error (${label})`, async () => {
+      respondWith(status, { error: 'some_code', message: 'human readable' })
+
+      const err = await transport()
+        .request({ path: 'whoami', stamp: false })
+        .catch((e: unknown) => e)
+
+      expect(err).toBeInstanceOf(RestRequestError)
+      expect((err as RestRequestError).status).toBe(status)
+      expect((err as RestRequestError).url).toContain('whoami')
+    })
+  }
+
+  it('surfaces the backend error code and message, not just the status', async () => {
+    respondWith(400, {
+      error: 'otp_expired',
+      message: 'The OTP has expired, request a new one',
+    })
+
+    const err = (await transport()
+      .request({ path: 'login/otp', stamp: false })
+      .catch((e) => e)) as RestRequestError
+
+    expect(err.message).toContain('otp_expired')
+    expect(err.message).toContain('The OTP has expired, request a new one')
+    expect(err.body).toMatchObject({ error: 'otp_expired' })
+  })
+
+  it('still reports the status when the body is not JSON', async () => {
+    respondWith(502, '<html>Bad Gateway</html>', 'text/html')
+
+    const err = (await transport()
+      .request({ path: 'whoami', stamp: false })
+      .catch((e) => e)) as RestRequestError
+
+    expect(err).toBeInstanceOf(RestRequestError)
+    expect(err.status).toBe(502)
+  })
+
+  it('does not mistake a 2xx with an error-shaped body for a failure', async () => {
+    respondWith(200, { error: null, message: 'ok', userId: 'user-1' })
+
+    await expect(
+      transport().request({ path: 'whoami', stamp: false }),
+    ).resolves.toMatchObject({ userId: 'user-1' })
+  })
+})
+
+describe('KMS boundary: timeout is its own failure class', () => {
+  it('raises RestTimeoutError, not a generic abort, when KMS never answers', async () => {
+    // A fetch that never settles on its own — it only rejects once the
+    // transport's own abort signal fires, so the 10 ms timeout is what ends it.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (_url: string, init?: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => {
+              const err = new Error('The operation was aborted')
+              err.name = 'AbortError'
+              reject(err)
+            })
+          }),
+      ),
+    )
+
+    const err = await transport(10)
+      .request({ path: 'whoami', stamp: false })
+      .catch((e: unknown) => e)
+
+    expect(err).toBeInstanceOf(RestTimeoutError)
+    expect(err).not.toBeInstanceOf(RestRequestError)
+    expect((err as RestTimeoutError).url).toContain('whoami')
+  })
+
+  it('lets a network-level failure through as itself', async () => {
+    // `fetch` itself throws, as it does on DNS failure or connection refused.
+    const failure = new TypeError('fetch failed')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw failure
+      }),
+    )
+
+    const err = await transport()
+      .request({ path: 'whoami', stamp: false })
+      .catch((e: unknown) => e)
+
+    expect(err).toBe(failure)
+  })
+})

--- a/packages/core/src/client/kmsFailureFidelity.integration.test.ts
+++ b/packages/core/src/client/kmsFailureFidelity.integration.test.ts
@@ -5,9 +5,6 @@
  * signing actions go through it. One `fetch`, no retry, a 10 s default timeout,
  * and either `RestRequestError` (status + url + parsed body) or
  * `RestTimeoutError`.
- *
- * What these protect is failure fidelity: a caller has to tell a throttle from a
- * rejection from an outage, because the right response differs.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { RestRequestError, RestTimeoutError } from '../errors/request.js'

--- a/packages/core/src/client/kmsFailureFidelity.integration.test.ts
+++ b/packages/core/src/client/kmsFailureFidelity.integration.test.ts
@@ -110,6 +110,28 @@ describe('KMS boundary: HTTP failures stay distinguishable', () => {
       transport().request({ path: 'whoami', stamp: false }),
     ).resolves.toMatchObject({ userId: 'user-1' })
   })
+
+  it.fails(
+    'does not hand a non-JSON success body back as though it were the payload',
+    async () => {
+      // A gateway or CDN interstitial arriving with a 200. Today the text
+      // fallback returns the HTML string as `data`, so callers treat it as a
+      // response body: `auth({type:'oauth'})` reads `!data.session`, finds
+      // nothing, and reports a legitimate sessionless login. The sibling client
+      // `createAuthProxyClient` has the same gap, which is why neither checks
+      // content-type before trusting a 200.
+      respondWith(200, '<html>gateway timeout</html>', 'text/html')
+
+      const outcome = await transport()
+        .request({ path: 'whoami', stamp: false })
+        .then(
+          (data) => data,
+          () => 'REJECTED' as const,
+        )
+
+      expect(outcome).toBe('REJECTED')
+    },
+  )
 })
 
 describe('KMS boundary: timeout is its own failure class', () => {

--- a/packages/core/src/core/loginWalletIdentity.integration.test.ts
+++ b/packages/core/src/core/loginWalletIdentity.integration.test.ts
@@ -14,7 +14,7 @@
  * Each wallet in the double is backed by a real private key, so the SDK's two owner
  * checks run against real signatures rather than canned ones.
  */
-import { type Hex, hashMessage } from 'viem'
+import { type Hex, hashMessage, recoverMessageAddress } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'
@@ -282,9 +282,14 @@ describe('the wallet a login lands on', () => {
     const account = await core.toAccount()
 
     expect(account.address).toBe(WALLETS[0].signer.address)
-    await expect(account.signMessage({ message: 'hello' })).resolves.toMatch(
-      /^0x[0-9a-f]+$/i,
-    )
+    const signature = await account.signMessage({ message: 'hello' })
+
+    expect(signature).toMatch(/^0x[0-9a-f]{130}$/i)
+    // `account.address` alone only proves Core resolved the right address; this
+    // proves the wallet it resolved is the one that can actually sign for it.
+    await expect(
+      recoverMessageAddress({ message: 'hello', signature }),
+    ).resolves.toBe(WALLETS[0].signer.address)
   })
 
   it('signs under the sub-organization of the session, not the parent org it authenticated against', async () => {
@@ -376,6 +381,9 @@ describe('an account object that outlives the wallet it was built for', () => {
     expect(`0x${sign.body.turnkeyPayload.parameters.payload}`).toBe(
       hashMessage('hello'),
     )
-    expect(signature).toMatch(/^0x[0-9a-f]+$/i)
+    expect(signature).toMatch(/^0x[0-9a-f]{130}$/i)
+    await expect(
+      recoverMessageAddress({ message: 'hello', signature }),
+    ).resolves.toBe(WALLETS[1].signer.address)
   })
 })

--- a/packages/core/src/core/loginWalletIdentity.integration.test.ts
+++ b/packages/core/src/core/loginWalletIdentity.integration.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Boundary: Wallet Core <-> KMS on the LOGIN side (the `passkey`/`login` branch of
+ * `auth()` in `createZeroDevWalletCore`).
+ *
+ * A person holding two passkeys owns two wallets — one passkey, one wallet, working
+ * as designed. So this is not a duplication defect; the question is what follows
+ * from it: when a login lands on one of them, does Core resolve, scope and sign
+ * under exactly that one?
+ *
+ * Which one it lands on is not Core's choice today. No sub-org is sent (the endpoint
+ * resolves the user from the stamped credential) and no credential selector is
+ * passed, so the double models the landed wallet as an input it is TOLD (`picks()`).
+ *
+ * Each wallet in the double is backed by a real private key, so the SDK's two owner
+ * checks run against real signatures rather than canned ones.
+ */
+import { type Hex, hashMessage } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'
+import type { StorageAdapter } from '../storage/manager.js'
+import { SessionType } from '../types/session.js'
+import { createZeroDevWalletCore } from './createZeroDevWalletCore.js'
+
+/**
+ * Two independent identities, one wallet each, in two sub-orgs — which is all the
+ * backend holds. Nothing links them server-side; the fact that one person holds
+ * both credentials exists only on their device.
+ */
+const WALLETS = [
+  {
+    subOrgId: 'suborg-1',
+    userId: 'user-suborg-1',
+    signer: privateKeyToAccount(`0x${'11'.repeat(32)}` as Hex),
+  },
+  {
+    subOrgId: 'suborg-2',
+    userId: 'user-suborg-2',
+    signer: privateKeyToAccount(`0x${'22'.repeat(32)}` as Hex),
+  },
+] as const
+
+/** Tracks pending vs active the way a real key store does, so the rotation
+ *  sequencing in the flow under test is exercised rather than stubbed away. */
+function statefulStamper(): ApiKeyStamper {
+  let activeKey: string | null = null
+  let pending: string | null = null
+  let n = 0
+  const stamp = async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  })
+  return {
+    stamp,
+    clear: async () => {},
+    getPublicKey: async () => activeKey,
+    resetKeyPair: async () => {
+      activeKey = `02${String(++n).padStart(64, '0')}`
+    },
+    prepareKeyRotation: async () => {
+      pending = `02${String(++n).padStart(64, '0')}`
+      return pending
+    },
+    stampPending: stamp,
+    signPending: async () => 'sig',
+    commitKeyRotation: async () => {
+      if (pending) activeKey = pending
+      pending = null
+    },
+    discardKeyRotation: async () => {
+      pending = null
+    },
+    sign: async () => 'sig',
+  }
+}
+
+/** Login only stamps; the credential it stamps with is the authenticator's pick,
+ *  which is what `stubKms().picks()` stands in for. */
+function passkeyStamper(): PasskeyStamper {
+  return {
+    stamp: async () => ({
+      stampHeaderName: 'X-Stamp',
+      stampHeaderValue: 'stamp',
+    }),
+    clear: async () => {},
+    register: async () => ({
+      attestation: {
+        attestationObject: 'ao',
+        clientDataJson: 'cdj',
+        credentialId: 'credential-unused',
+      },
+      encodedChallenge: 'challenge',
+    }),
+  }
+}
+
+function sessionToken(publicKey: string, wallet: (typeof WALLETS)[number]) {
+  return `hdr.${btoa(
+    JSON.stringify({
+      exp: Date.now() + 3_600_000,
+      public_key: publicKey,
+      session_type: SessionType.READ_WRITE,
+      user_id: wallet.userId,
+      organization_id: wallet.subOrgId,
+    }),
+  )}.sig`
+}
+
+/**
+ * A KMS double that can answer as either identity, one at a time. It is NOT
+ * modelling "an account with two wallets" — no such state exists server-side, so
+ * there is nothing to model. It never returns both and never links them, exactly
+ * as the real endpoints cannot. Which identity a login lands on is `picks()`, an
+ * input it is told, because that decision is made on the device.
+ *
+ * Everything after login resolves the wallet from the session JWT, which is what
+ * the backend does — `getUserWallet` and `getAuthenticators` both note the user is
+ * resolved from the stamped credential plus the session token, with **no sub-org
+ * sent in the request**. Note the direction: the sub-org is not sent, but it *is*
+ * returned, as the `organization_id` claim inside the session token — which is how
+ * Core learns which wallet it landed on. What never comes back is the credential
+ * id, so Core knows which wallet but never which passkey produced it.
+ */
+function stubKms() {
+  const requests: { path: string; body: unknown; subOrg: string | null }[] = []
+  let picked: (typeof WALLETS)[number] = WALLETS[0]
+  let lastSessionKey = ''
+
+  const subOrgFromToken = (headers: HeadersInit | undefined) => {
+    const auth = new Headers(headers).get('Authorization')
+    if (!auth) return null
+    const payload = auth.replace('Bearer ', '').split('.')[1]
+    if (!payload) return null
+    const claims = JSON.parse(atob(payload)) as { organization_id?: string }
+    return claims.organization_id ?? null
+  }
+
+  const walletFor = (subOrg: string | null) =>
+    WALLETS.find((w) => w.subOrgId === subOrg)
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const target = String(url)
+      const body = init?.body ? JSON.parse(String(init.body)) : {}
+      const subOrg = subOrgFromToken(init?.headers)
+      const json = (payload: unknown, status = 200) =>
+        new Response(JSON.stringify(payload), {
+          status,
+          headers: { 'content-type': 'application/json' },
+        })
+
+      if (target.includes('server-info/parent-org-id')) {
+        return json({ parentOrgId: 'parent-org' })
+      }
+
+      if (target.includes('/auth/login/stamp')) {
+        requests.push({ path: 'login', body, subOrg })
+        // The key the backend now holds for this session, which logout has to
+        // find in the authenticator list before it will erase anything locally.
+        lastSessionKey = body.targetPublicKey
+        return json({ session: sessionToken(body.targetPublicKey, picked) })
+      }
+
+      if (target.includes('/authenticators')) {
+        requests.push({ path: 'authenticators', body, subOrg })
+        const wallet = walletFor(subOrg)
+        if (!wallet) return json({ error: 'unauthenticated' }, 401)
+        // Scoped to the authenticated sub-org, as the endpoint is: this lists
+        // the credentials of the wallet the login landed on and cannot mention
+        // the other one.
+        return json({
+          oauths: null,
+          passkeys: [{ rpId: 'localhost', credentialId: `cred-${subOrg}` }],
+          emailContacts: null,
+          apiKeys: null,
+          sessionKeys: [
+            { ApiKey: lastSessionKey, TurnkeyId: `apikey-${subOrg}` },
+          ],
+        })
+      }
+
+      if (target.includes('/auth/logout')) {
+        requests.push({ path: 'logout', body, subOrg })
+        return json({})
+      }
+
+      if (target.includes('/user-wallet')) {
+        requests.push({ path: 'user-wallet', body, subOrg })
+        const wallet = walletFor(subOrg)
+        if (!wallet) return json({ error: 'unauthenticated' }, 401)
+        return json({
+          walletAddresses: [wallet.signer.address],
+          userId: wallet.userId,
+        })
+      }
+
+      if (target.includes('/sign/message')) {
+        requests.push({ path: 'sign/message', body, subOrg })
+        // Signs with the wallet the SESSION belongs to, ignoring the `signWith`
+        // address in the payload. That is the worst plausible KMS answer — a real
+        // backend would more likely 403 a cross-sub-org `signWith` — and it is
+        // the one Core has to be correct for, because it is the answer that
+        // produces a valid signature from the wrong wallet.
+        const wallet = walletFor(subOrg)
+        if (!wallet) return json({ error: 'unauthenticated' }, 401)
+        const signature = await wallet.signer.sign({
+          hash: `0x${body.turnkeyPayload.parameters.payload}` as Hex,
+        })
+        return json({ signature })
+      }
+
+      requests.push({ path: `unstubbed:${target}`, body, subOrg })
+      return json({}, 404)
+    }),
+  )
+
+  return {
+    requests,
+    /** Which identity the authenticator offers up next — a device-side decision
+     *  standing in for the user tapping one passkey rather than the other.
+     *  Nothing Core sends today influences it; see the first test. */
+    picks: (index: 0 | 1) => {
+      picked = WALLETS[index]
+    },
+    lastOf: (path: string) => requests.filter((r) => r.path === path).at(-1),
+  }
+}
+
+async function buildCore() {
+  const store = new Map<string, string>()
+  const adapter: StorageAdapter = {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value)
+    },
+    removeItem: (key) => {
+      store.delete(key)
+    },
+  }
+  return createZeroDevWalletCore({
+    projectId: 'proj',
+    rpId: 'localhost',
+    sessionStorage: adapter,
+    apiKeyStamper: statefulStamper(),
+    passkeyStamper: passkeyStamper(),
+    proxyBaseUrl: 'https://kms.test.invalid/api/v1',
+  })
+}
+
+const loginWithPasskey = { type: 'passkey', mode: 'login' } as const
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('what a login is able to ask for', () => {
+  it('sends only targetPublicKey, timestamp and stamp', async () => {
+    // The REQUEST only. The response does carry the sub-org, as the session
+    // token's `organization_id` claim.
+    const kms = stubKms()
+    const core = await buildCore()
+
+    await core.auth(loginWithPasskey)
+
+    const login = kms.lastOf('login')
+    expect(Object.keys(login?.body as object).sort()).toEqual([
+      'stamp',
+      'targetPublicKey',
+      'timestamp',
+    ])
+  })
+})
+
+describe('the wallet a login lands on', () => {
+  it('resolves the address of the wallet whose credential was used', async () => {
+    const kms = stubKms()
+    kms.picks(0)
+    const core = await buildCore()
+
+    await core.auth(loginWithPasskey)
+    const account = await core.toAccount()
+
+    expect(account.address).toBe(WALLETS[0].signer.address)
+    await expect(account.signMessage({ message: 'hello' })).resolves.toMatch(
+      /^0x[0-9a-f]+$/i,
+    )
+  })
+
+  it('signs under the sub-organization of the session, not the parent org it authenticated against', async () => {
+    const kms = stubKms()
+    kms.picks(1)
+    const core = await buildCore()
+
+    await core.auth(loginWithPasskey)
+    const account = await core.toAccount()
+    await account.signMessage({ message: 'hello' })
+
+    const sign = kms.lastOf('sign/message') as {
+      body: { turnkeyPayload: { organizationId: string } }
+    }
+    expect(sign.body.turnkeyPayload.organizationId).toBe(WALLETS[1].subOrgId)
+    expect(sign.body.turnkeyPayload.organizationId).not.toBe('parent-org')
+  })
+
+  it('lands on a different wallet across a logout and a fresh login, with no error either time', async () => {
+    // `picks()` tells the double which credential the authenticator offers, so
+    // the two logins land on different wallets with nothing else changed.
+    const kms = stubKms()
+    const core = await buildCore()
+
+    kms.picks(0)
+    await core.auth(loginWithPasskey)
+    const first = await core.toAccount()
+    const firstSession = await core.getSession()
+
+    // Asserted because `logout()` returns false WITHOUT clearing when it cannot
+    // confirm remote revocation — which would silently change the scenario.
+    await expect(core.logout()).resolves.toBe(true)
+
+    kms.picks(1)
+    await core.auth(loginWithPasskey)
+    const second = await core.toAccount()
+    const secondSession = await core.getSession()
+
+    expect(first.address).toBe(WALLETS[0].signer.address)
+    expect(second.address).toBe(WALLETS[1].signer.address)
+    expect(second.address).not.toBe(first.address)
+    expect(firstSession?.organizationId).toBe(WALLETS[0].subOrgId)
+    expect(secondSession?.organizationId).toBe(WALLETS[1].subOrgId)
+  })
+})
+
+describe('an account object that outlives the wallet it was built for', () => {
+  it('refuses to sign with an account built before the switch rather than signing as the wrong wallet', async () => {
+    // A `LocalAccount` captures its address and sub-org at build time but fetches
+    // the token fresh per signature, so this stale one presents wallet A's
+    // address with wallet B's session. The double then answers the worst
+    // plausible way: it SIGNS, using the session's wallet.
+    const kms = stubKms()
+    const core = await buildCore()
+
+    kms.picks(0)
+    await core.auth(loginWithPasskey)
+    const staleAccount = await core.toAccount()
+
+    await expect(core.logout()).resolves.toBe(true)
+    kms.picks(1)
+    await core.auth(loginWithPasskey)
+
+    // Two redundant guards can catch this, so the match is on the shared "did
+    // not recover" rather than either one's wording.
+    await expect(
+      staleAccount.signMessage({ message: 'hello' }),
+    ).rejects.toThrow(/did not recover/)
+  })
+
+  it('recovers the correct signer when the caller rebuilds the account after the switch', async () => {
+    const kms = stubKms()
+    const core = await buildCore()
+
+    kms.picks(0)
+    await core.auth(loginWithPasskey)
+    await core.toAccount()
+
+    await expect(core.logout()).resolves.toBe(true)
+    kms.picks(1)
+    await core.auth(loginWithPasskey)
+    const rebuilt = await core.toAccount()
+    const signature = await rebuilt.signMessage({ message: 'hello' })
+
+    expect(rebuilt.address).toBe(WALLETS[1].signer.address)
+    const sign = kms.lastOf('sign/message') as {
+      body: { turnkeyPayload: { parameters: { payload: string } } }
+    }
+    expect(`0x${sign.body.turnkeyPayload.parameters.payload}`).toBe(
+      hashMessage('hello'),
+    )
+    expect(signature).toMatch(/^0x[0-9a-f]+$/i)
+  })
+})

--- a/packages/core/src/core/loginWalletIdentity.integration.test.ts
+++ b/packages/core/src/core/loginWalletIdentity.integration.test.ts
@@ -178,8 +178,8 @@ function stubKms() {
         return json({})
       }
 
-      if (target.includes('/user-wallet')) {
-        requests.push({ path: 'user-wallet', body, subOrg })
+      if (target.includes('/wallets')) {
+        requests.push({ path: 'wallets', body, subOrg })
         const wallet = walletFor(subOrg)
         if (!wallet) return json({ error: 'unauthenticated' }, 401)
         return json({

--- a/packages/core/src/core/loginWalletIdentity.integration.test.ts
+++ b/packages/core/src/core/loginWalletIdentity.integration.test.ts
@@ -6,13 +6,6 @@
  * as designed. So this is not a duplication defect; the question is what follows
  * from it: when a login lands on one of them, does Core resolve, scope and sign
  * under exactly that one?
- *
- * Which one it lands on is not Core's choice today. No sub-org is sent (the endpoint
- * resolves the user from the stamped credential) and no credential selector is
- * passed, so the double models the landed wallet as an input it is TOLD (`picks()`).
- *
- * Each wallet in the double is backed by a real private key, so the SDK's two owner
- * checks run against real signatures rather than canned ones.
  */
 import { type Hex, hashMessage, recoverMessageAddress } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -256,8 +249,6 @@ afterEach(() => {
 
 describe('what a login is able to ask for', () => {
   it('sends only targetPublicKey, timestamp and stamp', async () => {
-    // The REQUEST only. The response does carry the sub-org, as the session
-    // token's `organization_id` claim.
     const kms = stubKms()
     const core = await buildCore()
 
@@ -309,8 +300,6 @@ describe('the wallet a login lands on', () => {
   })
 
   it('lands on a different wallet across a logout and a fresh login, with no error either time', async () => {
-    // `picks()` tells the double which credential the authenticator offers, so
-    // the two logins land on different wallets with nothing else changed.
     const kms = stubKms()
     const core = await buildCore()
 
@@ -338,10 +327,6 @@ describe('the wallet a login lands on', () => {
 
 describe('an account object that outlives the wallet it was built for', () => {
   it('refuses to sign with an account built before the switch rather than signing as the wrong wallet', async () => {
-    // A `LocalAccount` captures its address and sub-org at build time but fetches
-    // the token fresh per signature, so this stale one presents wallet A's
-    // address with wallet B's session. The double then answers the worst
-    // plausible way: it SIGNS, using the session's wallet.
     const kms = stubKms()
     const core = await buildCore()
 

--- a/packages/core/src/core/logoutRevocation.integration.test.ts
+++ b/packages/core/src/core/logoutRevocation.integration.test.ts
@@ -3,7 +3,6 @@
  *
  * Two remote steps run before anything local is erased: `getAuthenticators` to
  * find the Turnkey id of the key currently held, then `logout` to revoke it.
- *
  * The invariant every case points at: the local API key is the only thing that
  * can sign, so erasing it on an unconfirmed revocation strands the user in a
  * session that is still live remotely. Keep local state unless sure.

--- a/packages/core/src/core/logoutRevocation.integration.test.ts
+++ b/packages/core/src/core/logoutRevocation.integration.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Boundary: Wallet Core <-> KMS, at `logout()`.
+ *
+ * Two remote steps run before anything local is erased: `getAuthenticators` to
+ * find the Turnkey id of the key currently held, then `logout` to revoke it.
+ *
+ * The invariant every case points at: the local API key is the only thing that
+ * can sign, so erasing it on an unconfirmed revocation strands the user in a
+ * session that is still live remotely. Keep local state unless sure.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'
+import type { StorageAdapter } from '../storage/manager.js'
+import { SessionType } from '../types/session.js'
+import { createZeroDevWalletCore } from './createZeroDevWalletCore.js'
+
+/**
+ * The nth key the store mints. `02` + a padded counter is the shape the real
+ * `indexedDbStamper` emits (a compressed SEC1 P-256 key); the counter only keeps
+ * successive keys distinct so a rotation is observable. Passkey login rotates
+ * once, so the live key throughout this file is `sessionKey(1)`.
+ */
+const sessionKey = (nth: number) => `02${String(nth).padStart(64, '0')}`
+
+/** Well-formed, and deliberately not the key the store holds. */
+const NOT_THE_LIVE_KEY = `02${'a'.repeat(64)}`
+
+/** Exposes the active key so "was the only signing key erased?" is observable. */
+function statefulStamper(): ApiKeyStamper & { activeKey: () => string | null } {
+  let active: string | null = null
+  let pending: string | null = null
+  let n = 0
+  const stamp = async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  })
+  return {
+    stamp,
+    clear: async () => {
+      active = null
+      pending = null
+    },
+    getPublicKey: async () => active,
+    resetKeyPair: async () => {
+      active = sessionKey(++n)
+    },
+    prepareKeyRotation: async () => {
+      pending = sessionKey(++n)
+      return pending
+    },
+    stampPending: stamp,
+    signPending: async () => 'sig',
+    commitKeyRotation: async () => {
+      if (pending) active = pending
+      pending = null
+    },
+    discardKeyRotation: async () => {
+      pending = null
+    },
+    sign: async () => 'sig',
+    activeKey: () => active,
+  }
+}
+
+const passkeyStamper: PasskeyStamper = {
+  stamp: async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  }),
+  clear: async () => {},
+  register: async () => ({
+    attestation: {
+      attestationObject: 'ao',
+      clientDataJson: 'cdj',
+      credentialId: 'cred-1',
+    },
+    encodedChallenge: 'challenge',
+  }),
+}
+
+function token(publicKey: string) {
+  return `hdr.${btoa(
+    JSON.stringify({
+      exp: Date.now() + 3_600_000,
+      public_key: publicKey,
+      session_type: SessionType.READ_WRITE,
+      user_id: 'user-1',
+      organization_id: 'suborg-1',
+    }),
+  )}.sig`
+}
+
+type Plan = {
+  /** Body for `GET /authenticators`, built from the key the store now holds. */
+  authenticators: (activeKey: string) => unknown
+  authenticatorsStatus?: number
+  revocationStatus?: number
+}
+
+/**
+ * Logs in for real so the session and the key are the ones Core actually holds,
+ * then clears the request log so only the logout traffic is recorded. Answers a
+ * script and decides nothing.
+ */
+async function loggedIn(plan: Plan) {
+  const api = statefulStamper()
+  const requests: { path: string; body: any }[] = []
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const path = String(url)
+      const body = init?.body ? JSON.parse(String(init.body)) : {}
+      const json = (payload: unknown, status = 200) =>
+        new Response(JSON.stringify(payload), {
+          status,
+          headers: { 'content-type': 'application/json' },
+        })
+
+      if (path.includes('server-info/parent-org-id')) {
+        return json({ parentOrgId: 'parent-org' })
+      }
+      requests.push({ path, body })
+
+      if (path.includes('/auth/login/stamp')) {
+        return json({ session: token(body.targetPublicKey) })
+      }
+      if (path.includes('/authenticators')) {
+        return plan.authenticatorsStatus
+          ? json(
+              { message: 'authenticators failed' },
+              plan.authenticatorsStatus,
+            )
+          : json(plan.authenticators(api.activeKey() ?? ''))
+      }
+      if (path.includes('/auth/logout')) {
+        return plan.revocationStatus
+          ? json({ message: 'revocation failed' }, plan.revocationStatus)
+          : json({})
+      }
+      return json({}, 404)
+    }),
+  )
+
+  const store = new Map<string, string>()
+  const adapter: StorageAdapter = {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value)
+    },
+    removeItem: (key) => {
+      store.delete(key)
+    },
+  }
+  const core = await createZeroDevWalletCore({
+    projectId: 'proj',
+    rpId: 'localhost',
+    sessionStorage: adapter,
+    apiKeyStamper: api,
+    passkeyStamper,
+    proxyBaseUrl: 'https://kms.test.invalid/api/v1',
+  })
+  await core.auth({ type: 'passkey', mode: 'login' })
+  requests.length = 0
+
+  return {
+    core,
+    api,
+    revocations: () => requests.filter((r) => r.path.includes('/auth/logout')),
+  }
+}
+
+/** The key list the backend returns today, keyed on the live session key. */
+const MATCHING = (activeKey: string) => ({
+  sessionKeys: [{ ApiKey: activeKey, TurnkeyId: 'turnkey-1' }],
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('logout: revocation confirmed', () => {
+  it('revokes the key it actually holds, then erases local state', async () => {
+    const { core, api, revocations } = await loggedIn({
+      authenticators: MATCHING,
+    })
+
+    await expect(core.logout()).resolves.toBe(true)
+
+    const sent = revocations()[0]?.body
+    expect(sent?.parameters?.apiKeyIds).toEqual(['turnkey-1'])
+    expect(sent?.parameters?.userId).toBe('user-1')
+    expect(sent?.organizationId).toBe('suborg-1')
+    await expect(core.getSession()).resolves.toBeUndefined()
+    expect(api.activeKey()).toBeNull()
+  })
+
+  it('reads the forward-compatible key casing too', async () => {
+    // The backend's Go model has no JSON tags today, so the wire casing is
+    // `ApiKey`/`TurnkeyId`; the lower-cased pair is tolerated for when it gains
+    // them. Dropping either half silently stops logout finding the key, which
+    // lands in the refuse-to-erase branch below.
+    const { core, revocations } = await loggedIn({
+      authenticators: (activeKey) => ({
+        sessionKeys: [{ apiKey: activeKey, turnkeyId: 'turnkey-1' }],
+      }),
+    })
+
+    await expect(core.logout()).resolves.toBe(true)
+
+    expect(revocations()[0]?.body?.parameters?.apiKeyIds).toEqual(['turnkey-1'])
+  })
+})
+
+describe('logout: the remote key cannot be identified', () => {
+  // Core has no id to revoke, so it must not touch the only key that can sign.
+  const cases: [string, (activeKey: string) => unknown][] = [
+    [
+      'the key list does not mention it',
+      () => ({
+        sessionKeys: [{ ApiKey: NOT_THE_LIVE_KEY, TurnkeyId: 'x' }],
+      }),
+    ],
+    ['the key list is null', () => ({ sessionKeys: null })],
+    ['the key list is absent', () => ({})],
+    [
+      'the entry has no Turnkey id',
+      (activeKey) => ({ sessionKeys: [{ ApiKey: activeKey }] }),
+    ],
+  ]
+
+  for (const [label, authenticators] of cases) {
+    it(`refuses and keeps local credentials when ${label}`, async () => {
+      const { core, api, revocations } = await loggedIn({ authenticators })
+
+      await expect(core.logout()).resolves.toBe(false)
+
+      expect(revocations()).toHaveLength(0)
+      await expect(core.getSession()).resolves.toBeDefined()
+      expect(api.activeKey()).not.toBeNull()
+    })
+  }
+})
+
+describe('logout: the remote call fails inconclusively', () => {
+  const cases: [string, Plan][] = [
+    [
+      'the key list is forbidden',
+      { authenticators: MATCHING, authenticatorsStatus: 403 },
+    ],
+    [
+      'the key list errors',
+      { authenticators: MATCHING, authenticatorsStatus: 500 },
+    ],
+    ['revocation errors', { authenticators: MATCHING, revocationStatus: 500 }],
+  ]
+
+  for (const [label, plan] of cases) {
+    it(`refuses and keeps local credentials when ${label}`, async () => {
+      const { core, api } = await loggedIn(plan)
+
+      await expect(core.logout()).resolves.toBe(false)
+
+      await expect(core.getSession()).resolves.toBeDefined()
+      expect(api.activeKey()).not.toBeNull()
+    })
+  }
+})
+
+describe('logout: a 401 is conclusive', () => {
+  it('erases local state when the credential is already rejected', async () => {
+    // The inverse risk to the guard above, and the reason the guard cannot simply
+    // be "never erase on failure": a rejected credential can no longer sign
+    // anything, so keeping it would strand the user in a session they cannot end.
+    const { core, api } = await loggedIn({
+      authenticators: MATCHING,
+      authenticatorsStatus: 401,
+    })
+
+    await expect(core.logout()).resolves.toBe(true)
+
+    await expect(core.getSession()).resolves.toBeUndefined()
+    expect(api.activeKey()).toBeNull()
+  })
+})
+
+describe('logout: force', () => {
+  it('erases local state even though the key could not be identified', async () => {
+    // Documented behaviour, not a defect: the API docstring says to use `force`
+    // "only when accepting that the remote key may remain until expiry".
+    const { core, api, revocations } = await loggedIn({
+      authenticators: () => ({ sessionKeys: null }),
+    })
+
+    await expect(core.logout({ force: true })).resolves.toBe(true)
+
+    expect(revocations()).toHaveLength(0)
+    await expect(core.getSession()).resolves.toBeUndefined()
+    expect(api.activeKey()).toBeNull()
+  })
+
+  it('still attempts revocation first when the key IS identifiable', async () => {
+    // The docstring promises `force` "still tries remote revocation first". A
+    // force that skipped straight to local erasure would orphan a key that could
+    // have been revoked cleanly.
+    const { core, revocations } = await loggedIn({ authenticators: MATCHING })
+
+    await expect(core.logout({ force: true })).resolves.toBe(true)
+
+    expect(revocations()).toHaveLength(1)
+  })
+})
+
+describe('logout: local cleanup', () => {
+  it('clears the session even when the key store fails to clear', async () => {
+    // Both cleanups are attempted and the first error is rethrown afterwards. If
+    // a throwing key store short-circuited the session erasure, logout would
+    // leave a usable session token behind while reporting failure.
+    const { core, api } = await loggedIn({ authenticators: MATCHING })
+    api.clear = async () => {
+      throw new Error('key store unavailable')
+    }
+
+    await expect(core.logout()).rejects.toThrow(/key store unavailable/)
+
+    await expect(core.getSession()).resolves.toBeUndefined()
+  })
+})

--- a/packages/core/src/core/oauthSessionAbsent.integration.test.ts
+++ b/packages/core/src/core/oauthSessionAbsent.integration.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Boundary: Wallet Core <-> KMS, at the `oauth` branch's sessionless success.
+ *
+ * A 200 with no `session` is guarded rather than deref'd: the rotation is
+ * discarded and the payload is returned, so `auth()` **resolves and the user is
+ * not logged in**. Whether that should instead reject is an open product
+ * question, so nothing here asserts it either way — only what holds under both
+ * answers: no session is committed, the pending key does not survive, and the
+ * returned payload is intact, since it is the caller's only signal.
+ *
+ * `otp` verify has the same guard but cannot be driven in-process —
+ * `encryptOtpAttempt` pins the HPKE envelope against a production key — so it is
+ * covered by reading, not from here.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'
+import type { StorageAdapter } from '../storage/manager.js'
+import { SessionType } from '../types/session.js'
+import { createZeroDevWalletCore } from './createZeroDevWalletCore.js'
+
+const sessionKey = (nth: number) => `02${String(nth).padStart(64, '0')}`
+
+/** Exposes pending vs active so a discarded rotation is observable. */
+function keyStore(): ApiKeyStamper & {
+  activeKey: () => string | null
+  pendingKey: () => string | null
+} {
+  let active: string | null = null
+  let pending: string | null = null
+  let minted = 0
+  const stamp = async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  })
+  return {
+    stamp,
+    clear: async () => {
+      active = null
+      pending = null
+    },
+    getPublicKey: async () => active,
+    resetKeyPair: async () => {
+      active = sessionKey(++minted)
+    },
+    prepareKeyRotation: async () => {
+      pending = sessionKey(++minted)
+      return pending
+    },
+    stampPending: stamp,
+    signPending: async () => 'sig',
+    commitKeyRotation: async () => {
+      if (pending) active = pending
+      pending = null
+    },
+    discardKeyRotation: async () => {
+      pending = null
+    },
+    sign: async () => 'sig',
+    activeKey: () => active,
+    pendingKey: () => pending,
+  }
+}
+
+const passkeyStamper: PasskeyStamper = {
+  stamp: async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  }),
+  clear: async () => {},
+  register: async () => ({
+    attestation: {
+      attestationObject: 'ao',
+      clientDataJson: 'cdj',
+      credentialId: 'cred-1',
+    },
+    encodedChallenge: 'challenge',
+  }),
+}
+
+function token(publicKey: string) {
+  return `hdr.${btoa(
+    JSON.stringify({
+      exp: Date.now() + 3_600_000,
+      public_key: publicKey,
+      session_type: SessionType.READ_WRITE,
+      user_id: 'user-1',
+      organization_id: 'suborg-1',
+    }),
+  )}.sig`
+}
+
+/** Return this from `respond` to answer with a raw, non-JSON body. */
+const rawBody = (body: string, contentType: string) => ({
+  __raw: body,
+  __contentType: contentType,
+})
+
+/**
+ * `respond` is called per `/auth/oauth` request with the key the store currently
+ * has pending — the oauth request body carries no public key, because the backend
+ * holds the one registered against the server-side session.
+ */
+async function harness(respond: (pendingKey: string) => unknown) {
+  const api = keyStore()
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL | Request) => {
+      const path = String(url)
+      const json = (payload: unknown) =>
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      if (path.includes('server-info/parent-org-id')) {
+        return json({ parentOrgId: 'parent-org' })
+      }
+      if (path.includes('/auth/oauth')) {
+        const answer = respond(api.pendingKey() ?? '') as Record<string, string>
+        if (answer?.__raw !== undefined) {
+          return new Response(answer.__raw, {
+            status: 200,
+            headers: { 'content-type': answer.__contentType },
+          })
+        }
+        return json(answer)
+      }
+      return new Response('{}', { status: 404 })
+    }),
+  )
+
+  const store = new Map<string, string>()
+  const adapter: StorageAdapter = {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value)
+    },
+    removeItem: (key) => {
+      store.delete(key)
+    },
+  }
+  const core = await createZeroDevWalletCore({
+    projectId: 'proj',
+    rpId: 'localhost',
+    sessionStorage: adapter,
+    apiKeyStamper: api,
+    passkeyStamper,
+    proxyBaseUrl: 'https://kms.test.invalid/api/v1',
+  })
+  return { core, api }
+}
+
+const oauth = {
+  type: 'oauth',
+  provider: 'google',
+  sessionId: 'oauth-session-1',
+} as const
+
+/**
+ * Attributable = a caller can tell the response was at fault. A raw `TypeError`
+ * reads like any other null deref, and a bare `Error('failed')` names nothing.
+ */
+function isAttributable(error: unknown) {
+  return (
+    error instanceof Error &&
+    !(error instanceof TypeError) &&
+    /session|response|oauth/i.test(error.message)
+  )
+}
+
+/** Either remedy passes: resolve without a session, or reject attributably. */
+async function endsWithoutMisleading(run: () => Promise<unknown>) {
+  const outcome = await run().then(
+    () => 'resolved' as const,
+    (error: unknown) => error,
+  )
+  return outcome === 'resolved' || isAttributable(outcome)
+}
+
+/** How a caller keying on `session` would classify the outcome. */
+async function classify(respond: (pendingKey: string) => unknown) {
+  const { core } = await harness(respond)
+  return core.auth(oauth).then(
+    (result) =>
+      (result as { session?: unknown })?.session ? 'logged-in' : 'sessionless',
+    () => 'rejected',
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('oauth: the control', () => {
+  it('commits the session when the response carries one', async () => {
+    const { core, api } = await harness((pending) => ({
+      session: token(pending),
+    }))
+
+    await core.auth(oauth)
+
+    await expect(core.getSession()).resolves.toBeDefined()
+    expect(api.activeKey()).toBe(sessionKey(1))
+  })
+})
+
+describe('oauth: a 200 with no session', () => {
+  const shapes: [string, () => unknown][] = [
+    ['the field is absent', () => ({ userId: 'u', subOrganizationId: 'o' })],
+    ['the field is null', () => ({ session: null })],
+  ]
+
+  for (const [label, respond] of shapes) {
+    it(`resolves without a session and drops the rotation when ${label}`, async () => {
+      const { core, api } = await harness(respond)
+
+      await expect(core.auth(oauth)).resolves.toBeDefined()
+
+      await expect(core.getSession()).resolves.toBeUndefined()
+      expect(api.activeKey()).toBeNull()
+      expect(api.pendingKey()).toBeNull()
+    })
+  }
+
+  it('returns the payload unchanged, since it is the only signal', async () => {
+    // Nothing else tells the caller they are not logged in: no throw, no
+    // in-band flag. If the payload were swallowed there would be no way to know.
+    const payload = { userId: 'user-1', subOrganizationId: 'suborg-1' }
+    const { core } = await harness(() => payload)
+
+    await expect(core.auth(oauth)).resolves.toEqual(payload)
+  })
+
+  it('does not hand out the discarded key on the next request for one', async () => {
+    // `getPublicKey()` caches a prepared key for the oauth flow to consume. The
+    // sessionless branch discards it, so serving the same value again would bind
+    // a later session to a key the store no longer holds.
+    const { core } = await harness(() => ({ session: null }))
+    const before = await core.getPublicKey()
+
+    await core.auth(oauth)
+
+    expect(await core.getPublicKey()).not.toBe(before)
+  })
+
+  it('leaves a later oauth able to succeed', async () => {
+    let sessionless = true
+    const { core, api } = await harness((pending) =>
+      sessionless ? { session: null } : { session: token(pending) },
+    )
+    await core.auth(oauth)
+    await expect(core.getSession()).resolves.toBeUndefined()
+
+    sessionless = false
+    await core.auth(oauth)
+
+    await expect(core.getSession()).resolves.toBeDefined()
+    expect(api.activeKey()).toBe(sessionKey(2))
+  })
+})
+
+describe('oauth: the response is not a response', () => {
+  it.fails('stays attributable when the body is literally null', async () => {
+    // `sessionResponseShape` covers `data.session` being absent on this branch —
+    // this is `data` ITSELF being null, so the guard is what derefs. Today:
+    // `TypeError: Cannot read properties of null (reading 'session')`.
+    const { core } = await harness(() => null)
+
+    expect(await endsWithoutMisleading(() => core.auth(oauth))).toBe(true)
+    await expect(core.getSession()).resolves.toBeUndefined()
+  })
+
+  it.fails(
+    'does not report a gateway interstitial as a sessionless login',
+    async () => {
+      // The transport's text fallback hands the HTML back as `data`, so
+      // `!data.session` is trivially true and a proxy failure becomes
+      // indistinguishable from "this user genuinely has no session" — which is a
+      // legitimate outcome. Compared rather than asserted directly, so any remedy
+      // that separates the two passes.
+      const genuine = await classify(() => ({ userId: 'u' }))
+      const gateway = await classify(() =>
+        rawBody('<html>gateway timeout</html>', 'text/html'),
+      )
+
+      expect(gateway).not.toBe(genuine)
+    },
+  )
+})
+
+describe('oauth: the cached prepared key', () => {
+  it('refuses a session bound to a different key than the cached one', async () => {
+    // Only oauth consumes a key cached by `getPublicKey()`, so this path exists
+    // nowhere else: if the backend answers for a different key, committing would
+    // store a session the wallet cannot sign for.
+    const { core, api } = await harness(() => ({
+      session: token(sessionKey(99)),
+    }))
+    await core.getPublicKey()
+
+    const caught = await core.auth(oauth).then(
+      () => 'RESOLVED' as const,
+      (error: unknown) => error,
+    )
+
+    expect(isAttributable(caught)).toBe(true)
+    await expect(core.getSession()).resolves.toBeUndefined()
+    expect(api.activeKey()).toBeNull()
+  })
+})

--- a/packages/core/src/core/oauthSessionAbsent.integration.test.ts
+++ b/packages/core/src/core/oauthSessionAbsent.integration.test.ts
@@ -1,16 +1,12 @@
 /**
- * Boundary: Wallet Core <-> KMS, at the `oauth` branch's sessionless success.
+ * Boundary between Wallet Core and KMS at the `oauth` branch's sessionless
+ * success.
  *
- * A 200 with no `session` is guarded rather than deref'd: the rotation is
- * discarded and the payload is returned, so `auth()` **resolves and the user is
- * not logged in**. Whether that should instead reject is an open product
- * question, so nothing here asserts it either way — only what holds under both
- * answers: no session is committed, the pending key does not survive, and the
- * returned payload is intact, since it is the caller's only signal.
- *
- * `otp` verify has the same guard but cannot be driven in-process —
- * `encryptOtpAttempt` pins the HPKE envelope against a production key — so it is
- * covered by reading, not from here.
+ * A 200 with no `session` is guarded rather than dereferenced: the rotation is
+ * discarded and the payload returned, so `auth()` resolves and the user is not
+ * logged in. Whether it should reject instead is an open product question, so
+ * nothing here asserts either answer. `otp` verify shares the guard but cannot
+ * be driven in this layer, since `encryptOtpAttempt` pins the HPKE envelope.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'

--- a/packages/core/src/core/otpSendResponse.integration.test.ts
+++ b/packages/core/src/core/otpSendResponse.integration.test.ts
@@ -1,14 +1,13 @@
 /**
- * Boundary: Wallet Core <-> KMS at `auth/init/otp` — the `sendOtp` branch of
- * `auth()`, and the only auth branch with no `withKeyTransition`, no try/catch
- * and no key rotation. That absence is CORRECT (verify prepares its own key, so
- * there is nothing to roll back) and is asserted rather than assumed.
+ * Boundary between Wallet Core and KMS at `auth/init/otp`, the `sendOtp` branch
+ * of `auth()`, and the only auth branch with no `withKeyTransition`, no
+ * try/catch and no key rotation. That absence is correct, since verify prepares
+ * its own key, so it is asserted rather than assumed.
  *
- * The branch is a bare pass-through returning `data`, while its declared return
- * type promises `{otpId, otpEncryptionTargetBundle}` — both of which the CALLER
- * must carry to verify. `rest.ts` returns `data as any`, so neither is checked.
- *
- * ONE defect, in the `it.fails` block.
+ * The branch simply returns `data`, while its declared return type promises
+ * `{otpId, otpEncryptionTargetBundle}`, both of which the caller must carry to
+ * verify, and `rest.ts` returns `data as any` so neither is checked. One defect,
+ * in the `it.fails` block.
  */
 import type { Hex } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'

--- a/packages/core/src/core/otpSendResponse.integration.test.ts
+++ b/packages/core/src/core/otpSendResponse.integration.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Boundary: Wallet Core <-> KMS at `auth/init/otp` — the `sendOtp` branch of
+ * `auth()`, and the only auth branch with no `withKeyTransition`, no try/catch
+ * and no key rotation. That absence is CORRECT (verify prepares its own key, so
+ * there is nothing to roll back) and is asserted rather than assumed.
+ *
+ * The branch is a bare pass-through returning `data`, while its declared return
+ * type promises `{otpId, otpEncryptionTargetBundle}` — both of which the CALLER
+ * must carry to verify. `rest.ts` returns `data as any`, so neither is checked.
+ *
+ * ONE defect, in the `it.fails` block.
+ */
+import type { Hex } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'
+import type { StorageAdapter } from '../storage/manager.js'
+import { SessionType } from '../types/session.js'
+import { createZeroDevWalletCore } from './createZeroDevWalletCore.js'
+
+const OWNER = privateKeyToAccount(`0x${'11'.repeat(32)}` as Hex)
+const sessionKey = (nth: number) => `02${String(nth).padStart(64, '0')}`
+
+/** Exposes pending vs active so "no rotation was left behind" is observable. */
+function keyStore(): ApiKeyStamper & {
+  state: () => { active: string | null; pending: string | null }
+} {
+  let active: string | null = null
+  let pending: string | null = null
+  let minted = 0
+  const stamp = async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  })
+  return {
+    stamp,
+    clear: async () => {
+      active = null
+      pending = null
+    },
+    getPublicKey: async () => active,
+    resetKeyPair: async () => {
+      active = sessionKey(++minted)
+    },
+    prepareKeyRotation: async () => {
+      pending = sessionKey(++minted)
+      return pending
+    },
+    stampPending: stamp,
+    signPending: async () => 'sig',
+    commitKeyRotation: async () => {
+      if (pending) active = pending
+      pending = null
+    },
+    discardKeyRotation: async () => {
+      pending = null
+    },
+    sign: async () => 'sig',
+    state: () => ({ active, pending }),
+  }
+}
+
+const passkeyStamper: PasskeyStamper = {
+  stamp: async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  }),
+  clear: async () => {},
+  register: async () => ({
+    attestation: {
+      attestationObject: 'ao',
+      clientDataJson: 'cdj',
+      credentialId: 'cred-1',
+    },
+    encodedChallenge: 'challenge',
+  }),
+}
+
+function token(publicKey: string) {
+  return `hdr.${btoa(
+    JSON.stringify({
+      exp: Date.now() + 3_600_000,
+      public_key: publicKey,
+      session_type: SessionType.READ_WRITE,
+      user_id: 'user-1',
+      organization_id: 'suborg-1',
+    }),
+  )}.sig`
+}
+
+/** How `auth/init/otp` answers. */
+type Reply = { body: unknown; status?: number } | { raw: string }
+
+const USABLE = { otpId: 'otp-1', otpEncryptionTargetBundle: 'bundle' }
+
+/**
+ * The double answers a script and records paths; it branches on nothing. `sent`
+ * is the `init/otp` bodies, `paths` every request, so "the auth proxy was never
+ * reached" is assertable.
+ */
+async function build(initOtp: Reply) {
+  const api = keyStore()
+  const sent: unknown[] = []
+  const paths: string[] = []
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const path = String(url)
+      const body = init?.body ? JSON.parse(String(init.body)) : {}
+      paths.push(path)
+      const json = (payload: unknown, status = 200) =>
+        new Response(JSON.stringify(payload), {
+          status,
+          headers: { 'content-type': 'application/json' },
+        })
+
+      if (path.includes('parent-org-id')) {
+        return json({ parentOrgId: 'parent-org' })
+      }
+      if (path.includes('/auth/login/stamp')) {
+        return json({ session: token(body.targetPublicKey) })
+      }
+      if (path.includes('/user-wallet')) {
+        return json({ walletAddresses: [OWNER.address] })
+      }
+      if (path.includes('/auth/init/otp')) {
+        sent.push(body)
+        if ('raw' in initOtp) {
+          return new Response(initOtp.raw, {
+            status: 200,
+            headers: { 'content-type': 'text/html' },
+          })
+        }
+        return json(initOtp.body, initOtp.status ?? 200)
+      }
+      return json({}, 404)
+    }),
+  )
+
+  const store = new Map<string, string>()
+  const adapter: StorageAdapter = {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value)
+    },
+    removeItem: (key) => {
+      store.delete(key)
+    },
+  }
+  const sdk = await createZeroDevWalletCore({
+    projectId: 'proj',
+    rpId: 'localhost',
+    sessionStorage: adapter,
+    apiKeyStamper: api,
+    passkeyStamper,
+    proxyBaseUrl: 'https://kms.test.invalid/api/v1',
+  })
+  return { sdk, api, sent, paths }
+}
+
+const SEND = {
+  type: 'otp',
+  mode: 'sendOtp',
+  email: 'user@example.com',
+  contact: { type: 'email', contact: 'user@example.com' },
+} as const
+
+const outcomeOf = (p: Promise<unknown>) =>
+  p.then(
+    (value) => ({ ok: true, value }) as const,
+    (error: unknown) => ({ ok: false, error }) as const,
+  )
+
+/** Rejects `''` so a `?? ''` "fix" cannot pass for a repair. */
+const usable = (v: unknown) => typeof v === 'string' && v.length > 0
+
+/** Both fields are required to reach verify at all. */
+function carriesAUsableHandle(value: unknown) {
+  if (!value || typeof value !== 'object') return false
+  const handle = value as Record<string, unknown>
+  return usable(handle.otpId) && usable(handle.otpEncryptionTargetBundle)
+}
+
+/** Attributable = an Error, not a raw deref, that names the OTP flow. */
+const blamesTheSend = (error: unknown) =>
+  error instanceof Error &&
+  !(error instanceof TypeError) &&
+  /otp|code|bundle/i.test(error.message)
+
+/** Refuse attributably, or hand back a usable handle. Neither is the defect. */
+const endsUsably = (outcome: Awaited<ReturnType<typeof outcomeOf>>) =>
+  outcome.ok
+    ? carriesAUsableHandle(outcome.value)
+    : blamesTheSend(outcome.error)
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('otp send: a healthy send', () => {
+  it('returns a handle the verify step can use', async () => {
+    const { sdk } = await build({ body: USABLE })
+
+    const outcome = await outcomeOf(sdk.auth(SEND))
+
+    expect(endsUsably(outcome)).toBe(true)
+  })
+
+  it('asks for the code with only the contact details', async () => {
+    const { sdk, sent } = await build({ body: USABLE })
+
+    await sdk.auth(SEND)
+
+    // Sending a code is pre-authentication, so a key committed here would be
+    // one nobody can ever use.
+    expect(sent).toEqual([
+      {
+        email: 'user@example.com',
+        contact: { type: 'email', contact: 'user@example.com' },
+      },
+    ])
+  })
+
+  it('sends the same request for a magic link', async () => {
+    // A distinct branch normalizing into the same request builder, so it is
+    // covered on its own.
+    const { sdk, sent } = await build({ body: USABLE })
+
+    await sdk.auth({
+      type: 'magicLink',
+      mode: 'send',
+      email: 'user@example.com',
+    })
+
+    expect(sent).toEqual([
+      {
+        email: 'user@example.com',
+        contact: { type: 'email', contact: 'user@example.com' },
+      },
+    ])
+  })
+})
+
+describe('otp send: a 200 that carries no usable handle', () => {
+  // DEFECT. Every shape below is reported as "the code was sent", so the user is
+  // told to check their inbox and the failure surfaces at verify instead.
+  // Predicate accepts either remedy and rejects `''`, so a `?? ''` stays
+  // expected-fail while a real fix goes red — both proven. Observed failure with
+  // `it()`: `expected false to be true`.
+  const hollow: [string, Reply][] = [
+    ['the body is empty', { body: {} }],
+    ['there is no bundle', { body: { otpId: 'otp-1' } }],
+    ['there is no otpId', { body: { otpEncryptionTargetBundle: 'bundle' } }],
+    [
+      'both fields are null',
+      { body: { otpId: null, otpEncryptionTargetBundle: null } },
+    ],
+    [
+      'the fields are not strings',
+      { body: { otpId: 42, otpEncryptionTargetBundle: 7 } },
+    ],
+    ['the body is null', { body: null }],
+    // Third instance of the `rest.ts` non-JSON-200 gap, after
+    // `kmsFailureFidelity` and `oauthSessionAbsent`.
+    ['the body is a gateway interstitial', { raw: '<html>timeout</html>' }],
+  ]
+
+  for (const [label, reply] of hollow) {
+    it.fails(`reports a send it cannot support when ${label}`, async () => {
+      const { sdk } = await build(reply)
+
+      const outcome = await outcomeOf(sdk.auth(SEND))
+
+      expect(endsUsably(outcome)).toBe(true)
+    })
+  }
+})
+
+describe('otp send: failures that are reported properly', () => {
+  // Rate limiting is the expected failure here, so losing the status leaves a
+  // caller unable to tell "slow down" from "broken".
+  const failures: [string, number][] = [
+    ['throttled', 429],
+    ['server error', 500],
+  ]
+
+  for (const [label, status] of failures) {
+    it(`propagates a ${label} response with its status intact`, async () => {
+      const { sdk } = await build({
+        body: { error: 'nope', message: 'try later' },
+        status,
+      })
+
+      const outcome = await outcomeOf(sdk.auth(SEND))
+
+      expect(outcome.ok).toBe(false)
+      expect((outcome as { error: Error }).error).toBeInstanceOf(Error)
+      expect((outcome as { error: Error }).error.message).toContain(
+        String(status),
+      )
+    })
+  }
+})
+
+describe('otp send: must not disturb what is already there', () => {
+  it('prepares no key rotation, so a failed send leaves nothing behind', async () => {
+    // Why `sendOtp` needs no `withKeyTransition` — and this catches anyone
+    // adding a rotation here without a rollback.
+    const { sdk, api } = await build({ body: { error: 'x' }, status: 500 })
+
+    await outcomeOf(sdk.auth(SEND))
+
+    expect(api.state()).toEqual({ active: null, pending: null })
+    await expect(sdk.getAllSessions()).resolves.toEqual({})
+  })
+
+  it('leaves an established session and its key untouched', async () => {
+    // A signed-in user adding a login method must not be logged out by it.
+    const { sdk, api } = await build({ body: USABLE })
+    await sdk.auth({ type: 'passkey', mode: 'login' })
+    const before = await sdk.getAllSessions()
+    const keyBefore = api.state()
+
+    await sdk.auth(SEND)
+
+    await expect(sdk.getAllSessions()).resolves.toEqual(before)
+    expect(api.state()).toEqual(keyBefore)
+  })
+
+  it('leaves an established session untouched when the send fails', async () => {
+    const { sdk, api } = await build({ body: { error: 'x' }, status: 429 })
+    await sdk.auth({ type: 'passkey', mode: 'login' })
+    const before = await sdk.getAllSessions()
+    const keyBefore = api.state()
+
+    await outcomeOf(sdk.auth(SEND))
+
+    await expect(sdk.getAllSessions()).resolves.toEqual(before)
+    expect(api.state()).toEqual(keyBefore)
+  })
+})
+
+describe('otp verify: an unusable bundle fails closed', () => {
+  // Driven directly, not through a hollow send, so these stay true once the send
+  // is fixed. `encryptOtpAttempt` pins the enclave envelope, hence no wire call.
+  const unusableBundles: [string, string | undefined][] = [
+    ['it is missing entirely', undefined],
+    ['it is empty', ''],
+    ['it is not JSON', '<html>timeout</html>'],
+    ['it is JSON but not a bundle', '{}'],
+  ]
+
+  for (const [label, bundle] of unusableBundles) {
+    it(`refuses before any network call when ${label}`, async () => {
+      const { sdk, api, paths } = await build({ body: USABLE })
+
+      const outcome = await outcomeOf(
+        sdk.auth({
+          type: 'otp',
+          mode: 'verifyOtp',
+          otpId: 'otp-1',
+          otpCode: '123456',
+          otpEncryptionTargetBundle: bundle as string,
+        }),
+      )
+
+      expect(outcome.ok).toBe(false)
+      expect(paths.some((path) => path.includes('authproxy'))).toBe(false)
+      expect(api.state().pending).toBeNull()
+      await expect(sdk.getAllSessions()).resolves.toEqual({})
+    })
+  }
+})

--- a/packages/core/src/core/otpSendResponse.integration.test.ts
+++ b/packages/core/src/core/otpSendResponse.integration.test.ts
@@ -119,7 +119,7 @@ async function build(initOtp: Reply) {
       if (path.includes('/auth/login/stamp')) {
         return json({ session: token(body.targetPublicKey) })
       }
-      if (path.includes('/user-wallet')) {
+      if (path.includes('/wallets')) {
         return json({ walletAddresses: [OWNER.address] })
       }
       if (path.includes('/auth/init/otp')) {

--- a/packages/core/src/core/passkeyCeremony.integration.test.ts
+++ b/packages/core/src/core/passkeyCeremony.integration.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Boundary: Wallet Core <-> the platform authenticator, reached through the
+ * injected `passkeyStamper` — `register()` on the register branch of `auth()`,
+ * and `stamp()` on the login branch via `loginWithStamp`.
+ *
+ * A cancelled ceremony must reach the caller still recognisable as one:
+ * `@zerodev/wallet-react-ui`'s `isCancellationError` keys on `err.name` being
+ * `AbortError` or `NotAllowedError`, so rewrapping either turns "I changed my
+ * mind" into a full-screen error takeover. The inverse costs as much — a real
+ * authenticator failure relabelled as a cancellation gets filtered out, leaving
+ * the user with no wallet and no error at all.
+ *
+ * Whether Core should translate a cancellation into something friendlier is a
+ * product call and is deliberately not asserted. Only pass-through is.
+ *
+ * This seam is HEALTHY as probed — no defect, so no `it.fails` here. The tests
+ * exist because the pass-through is one `throw error` that a later refactor can
+ * quietly wrap.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ApiKeyStamper, PasskeyStamper, Stamp } from '../stampers/types.js'
+import type { StorageAdapter } from '../storage/manager.js'
+import { SessionType } from '../types/session.js'
+import { createZeroDevWalletCore } from './createZeroDevWalletCore.js'
+
+/**
+ * Tracks pending vs active the way a real key store does, and exposes both so
+ * the rollback can be asserted as key-store state rather than as a call count.
+ */
+function statefulStamper(): ApiKeyStamper & {
+  activeKey: () => string | null
+  pendingKey: () => string | null
+} {
+  let active: string | null = null
+  let pending: string | null = null
+  let n = 0
+  const stamp = async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  })
+  return {
+    stamp,
+    clear: async () => {},
+    getPublicKey: async () => active,
+    resetKeyPair: async () => {
+      active = `02${String(++n).padStart(64, '0')}`
+    },
+    prepareKeyRotation: async () => {
+      pending = `02${String(++n).padStart(64, '0')}`
+      return pending
+    },
+    stampPending: stamp,
+    signPending: async () => 'sig',
+    commitKeyRotation: async () => {
+      if (pending) active = pending
+      pending = null
+    },
+    discardKeyRotation: async () => {
+      pending = null
+    },
+    sign: async () => 'sig',
+    activeKey: () => active,
+    pendingKey: () => pending,
+  }
+}
+
+/**
+ * Stands in for the OS ceremony. `failures` is consumed one entry per call, so
+ * a `[cancel]` script fails the first attempt and lets the retry through — the
+ * shape of "the user cancelled, then tried again".
+ */
+function ceremonyStamper(opts: {
+  registerFailures?: unknown[]
+  stampFailures?: unknown[]
+}) {
+  const registerFailures = [...(opts.registerFailures ?? [])]
+  const stampFailures = [...(opts.stampFailures ?? [])]
+  let registers = 0
+  let stamps = 0
+  const stamper: PasskeyStamper = {
+    stamp: async (): Promise<Stamp> => {
+      stamps += 1
+      if (stampFailures.length) throw stampFailures.shift()
+      return { stampHeaderName: 'X-Stamp', stampHeaderValue: 'stamp' }
+    },
+    clear: async () => {},
+    register: async () => {
+      registers += 1
+      if (registerFailures.length) throw registerFailures.shift()
+      return {
+        attestation: {
+          attestationObject: 'ao',
+          clientDataJson: 'cdj',
+          credentialId: `cred-${registers}`,
+        },
+        encodedChallenge: 'challenge',
+      }
+    },
+  }
+  return {
+    ...stamper,
+    registers: () => registers,
+    stamps: () => stamps,
+  }
+}
+
+function sessionToken(publicKey: string, organizationId: string) {
+  return `hdr.${btoa(
+    JSON.stringify({
+      exp: Date.now() + 3_600_000,
+      public_key: publicKey,
+      session_type: SessionType.READ_WRITE,
+      user_id: 'user-1',
+      organization_id: organizationId,
+    }),
+  )}.sig`
+}
+
+/**
+ * Records requests and answers a script. It decides nothing: no branching on
+ * request content, and no assertion reads the response fixtures.
+ */
+function recordingKms() {
+  const requests: string[] = []
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const path = String(url)
+      const body = init?.body ? JSON.parse(String(init.body)) : {}
+      const json = (payload: unknown, status = 200) =>
+        new Response(JSON.stringify(payload), {
+          status,
+          headers: { 'content-type': 'application/json' },
+        })
+
+      // Resolved on construction, before any ceremony — not part of the flow
+      // under test, so it is answered without being recorded.
+      if (path.includes('server-info/parent-org-id')) {
+        return json({ parentOrgId: 'parent-org' })
+      }
+
+      requests.push(path)
+
+      if (path.includes('/auth/register/passkey')) {
+        return json({
+          userId: 'user-1',
+          walletAddress: `0x${'1'.repeat(40)}`,
+          subOrganizationId: 'suborg-1',
+        })
+      }
+      if (path.includes('/auth/login/stamp')) {
+        return json({ session: sessionToken(body.targetPublicKey, 'suborg-1') })
+      }
+      return json({}, 404)
+    }),
+  )
+
+  const to = (suffix: string) => requests.filter((p) => p.includes(suffix))
+
+  return {
+    creates: () => to('/auth/register/passkey'),
+    logins: () => to('/auth/login/stamp'),
+  }
+}
+
+async function buildCore(passkeyStamper: PasskeyStamper, api: ApiKeyStamper) {
+  const store = new Map<string, string>()
+  const adapter: StorageAdapter = {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value)
+    },
+    removeItem: (key) => {
+      store.delete(key)
+    },
+  }
+  return createZeroDevWalletCore({
+    projectId: 'proj',
+    rpId: 'localhost',
+    sessionStorage: adapter,
+    apiKeyStamper: api,
+    passkeyStamper,
+    proxyBaseUrl: 'https://kms.test.invalid/api/v1',
+  })
+}
+
+const register = { type: 'passkey', mode: 'register' } as const
+const login = { type: 'passkey', mode: 'login' } as const
+
+/** The real ceremonies reject with a `DOMException`, so the double does too. */
+const cancellation = (name: 'NotAllowedError' | 'AbortError') =>
+  new DOMException(
+    name === 'AbortError' ? 'ceremony timed out' : 'user cancelled',
+    name,
+  )
+
+const caughtFrom = (p: Promise<unknown>) =>
+  p.then(
+    () => 'RESOLVED' as const,
+    (e: unknown) => e,
+  )
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('passkey ceremony: the ceremony is on the path at all', () => {
+  it('runs the ceremony and completes the registration', async () => {
+    const kms = recordingKms()
+    const stamper = ceremonyStamper({})
+
+    await (await buildCore(stamper, statefulStamper())).auth(register)
+
+    expect(stamper.registers()).toBe(1)
+    expect(kms.creates()).toHaveLength(1)
+  })
+
+  it('runs the ceremony and completes the login', async () => {
+    const kms = recordingKms()
+    const stamper = ceremonyStamper({})
+    const core = await buildCore(stamper, statefulStamper())
+
+    await core.auth(login)
+
+    expect(stamper.stamps()).toBe(1)
+    expect(kms.logins()).toHaveLength(1)
+    await expect(core.getSession()).resolves.toBeDefined()
+  })
+})
+
+describe('passkey ceremony: a cancellation stays a cancellation', () => {
+  // `name` only. Wrapping while preserving the name would still satisfy
+  // `isCancellationError`, so asserting error identity would fail a legitimate
+  // change.
+  const names = ['NotAllowedError', 'AbortError'] as const
+
+  for (const name of names) {
+    it(`surfaces a ${name} from the registration ceremony under its own name`, async () => {
+      recordingKms()
+      const core = await buildCore(
+        ceremonyStamper({ registerFailures: [cancellation(name)] }),
+        statefulStamper(),
+      )
+
+      const caught = await caughtFrom(core.auth(register))
+
+      expect(caught).toBeInstanceOf(Error)
+      expect((caught as Error).name).toBe(name)
+    })
+
+    it(`surfaces a ${name} from the login ceremony under its own name`, async () => {
+      recordingKms()
+      const core = await buildCore(
+        ceremonyStamper({ stampFailures: [cancellation(name)] }),
+        statefulStamper(),
+      )
+
+      const caught = await caughtFrom(core.auth(login))
+
+      expect(caught).toBeInstanceOf(Error)
+      expect((caught as Error).name).toBe(name)
+    })
+  }
+})
+
+describe('passkey ceremony: a real failure must not pass for a cancellation', () => {
+  // The inverse of the tests above, and the more expensive direction to get
+  // wrong: a failure wearing a cancellation's name is filtered out by
+  // `isCancellationError`, so the user is shown nothing and gets no wallet.
+  const cancellationNames = ['NotAllowedError', 'AbortError']
+
+  it('keeps a broken registration ceremony distinguishable', async () => {
+    recordingKms()
+    const core = await buildCore(
+      ceremonyStamper({
+        registerFailures: [new Error('authenticator unavailable')],
+      }),
+      statefulStamper(),
+    )
+
+    const caught = await caughtFrom(core.auth(register))
+
+    expect(caught).toBeInstanceOf(Error)
+    expect(cancellationNames).not.toContain((caught as Error).name)
+  })
+
+  it('keeps a broken login ceremony distinguishable', async () => {
+    recordingKms()
+    const core = await buildCore(
+      ceremonyStamper({
+        stampFailures: [new Error('authenticator unavailable')],
+      }),
+      statefulStamper(),
+    )
+
+    const caught = await caughtFrom(core.auth(login))
+
+    expect(caught).toBeInstanceOf(Error)
+    expect(cancellationNames).not.toContain((caught as Error).name)
+  })
+})
+
+describe('passkey ceremony: cancelling costs nothing', () => {
+  it('reaches KMS not at all when the registration ceremony is cancelled', async () => {
+    const kms = recordingKms()
+    const api = statefulStamper()
+    const core = await buildCore(
+      ceremonyStamper({ registerFailures: [cancellation('NotAllowedError')] }),
+      api,
+    )
+
+    await caughtFrom(core.auth(register))
+
+    // Nothing was created remotely, so unlike a failure BETWEEN the two
+    // registration calls there is nothing to reconcile afterwards.
+    expect(kms.creates()).toHaveLength(0)
+    expect(kms.logins()).toHaveLength(0)
+    await expect(core.getSession()).resolves.toBeUndefined()
+    expect(api.activeKey()).toBeNull()
+    expect(api.pendingKey()).toBeNull()
+  })
+
+  it('reaches KMS not at all when the login ceremony is cancelled', async () => {
+    const kms = recordingKms()
+    const api = statefulStamper()
+    const core = await buildCore(
+      ceremonyStamper({ stampFailures: [cancellation('NotAllowedError')] }),
+      api,
+    )
+
+    await caughtFrom(core.auth(login))
+
+    expect(kms.logins()).toHaveLength(0)
+    await expect(core.getSession()).resolves.toBeUndefined()
+    expect(api.pendingKey()).toBeNull()
+  })
+})
+
+describe('passkey ceremony: the user can simply try again', () => {
+  // CANARIES, not guards: no mutation to the failure path kills these, because a
+  // cancelled attempt leaves nothing behind for a retry to trip over. They go red
+  // only if a later change makes an attempt refuse while a cancelled one is
+  // outstanding.
+  it('registers on the attempt after a cancelled one', async () => {
+    const kms = recordingKms()
+    const core = await buildCore(
+      ceremonyStamper({ registerFailures: [cancellation('NotAllowedError')] }),
+      statefulStamper(),
+    )
+    await caughtFrom(core.auth(register))
+
+    await core.auth(register)
+
+    expect(kms.creates()).toHaveLength(1)
+    await expect(core.getSession()).resolves.toBeDefined()
+  })
+
+  it('logs in on the attempt after a cancelled one', async () => {
+    const kms = recordingKms()
+    const core = await buildCore(
+      ceremonyStamper({ stampFailures: [cancellation('AbortError')] }),
+      statefulStamper(),
+    )
+    await caughtFrom(core.auth(login))
+
+    await core.auth(login)
+
+    expect(kms.logins()).toHaveLength(1)
+    await expect(core.getSession()).resolves.toBeDefined()
+  })
+})

--- a/packages/core/src/core/passkeyCeremony.integration.test.ts
+++ b/packages/core/src/core/passkeyCeremony.integration.test.ts
@@ -1,21 +1,18 @@
 /**
- * Boundary: Wallet Core <-> the platform authenticator, reached through the
- * injected `passkeyStamper` — `register()` on the register branch of `auth()`,
+ * Boundary between Wallet Core and the platform authenticator, reached through
+ * the injected `passkeyStamper`: `register()` on the register branch of `auth()`,
  * and `stamp()` on the login branch via `loginWithStamp`.
  *
- * A cancelled ceremony must reach the caller still recognisable as one:
+ * A cancelled ceremony must reach the caller still recognisable as one, because
  * `@zerodev/wallet-react-ui`'s `isCancellationError` keys on `err.name` being
- * `AbortError` or `NotAllowedError`, so rewrapping either turns "I changed my
- * mind" into a full-screen error takeover. The inverse costs as much — a real
- * authenticator failure relabelled as a cancellation gets filtered out, leaving
- * the user with no wallet and no error at all.
+ * `AbortError` or `NotAllowedError`. Rewrapping either turns "I changed my mind"
+ * into an error takeover, and the inverse costs as much: a real authenticator
+ * failure relabelled as a cancellation is filtered out, leaving the user with no
+ * wallet and no error. Whether Core should translate a cancellation into
+ * something friendlier is a product call and is not asserted.
  *
- * Whether Core should translate a cancellation into something friendlier is a
- * product call and is deliberately not asserted. Only pass-through is.
- *
- * This seam is HEALTHY as probed — no defect, so no `it.fails` here. The tests
- * exist because the pass-through is one `throw error` that a later refactor can
- * quietly wrap.
+ * No defect found; no `it.fails` here. The tests exist because the propagation is
+ * one `throw error` that a later refactor can quietly wrap.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ApiKeyStamper, PasskeyStamper, Stamp } from '../stampers/types.js'

--- a/packages/core/src/core/registerMidFlowFailure.integration.test.ts
+++ b/packages/core/src/core/registerMidFlowFailure.integration.test.ts
@@ -1,19 +1,18 @@
 /**
- * Boundary: Wallet Core <-> KMS, across the TWO calls passkey registration makes
- * (the `passkey`/`register` branch of `auth()` in `createZeroDevWalletCore`).
+ * Boundary between Wallet Core and KMS across the two calls passkey registration
+ * makes, in the `passkey`/`register` branch of `auth()`.
  *
  * `client.registerWithPasskey` creates the account and its wallet remotely, then
- * `client.loginWithStamp` obtains a session, with a key rotation between them —
- * and the REST transport has no retry, so a 503/429/stall on the second call
- * throws straight out with the account already created.
+ * `client.loginWithStamp` obtains a session, with a key rotation between them. The
+ * REST transport has no retry, so a 503/429/stall on the second call throws
+ * straight out with the account already created.
  *
- * The `catch` calls `discardKeyRotation()` and rethrows, which is narrower than
- * it looks: `commitKeyRotation()` has already run one line after the create
- * succeeded, so the key store keeps an active API key from the abandoned attempt.
- * Session storage is genuinely empty.
- *
- * Registering again creates a second wallet as intended. Not tested here: the
- * cost of that path, which is an ambiguous login picker rather than a lost wallet.
+ * The `catch` calls `discardKeyRotation()` and rethrows, which is narrower than it
+ * looks: `commitKeyRotation()` has already run one line after the create
+ * succeeded, so the key store keeps an active API key from the abandoned attempt
+ * while session storage is genuinely empty. Registering again creates a second
+ * wallet as intended, and the cost of that path is an ambiguous login picker
+ * rather than a lost wallet, which is not tested here.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'

--- a/packages/core/src/core/registerMidFlowFailure.integration.test.ts
+++ b/packages/core/src/core/registerMidFlowFailure.integration.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Boundary: Wallet Core <-> KMS, across the TWO calls passkey registration makes
+ * (the `passkey`/`register` branch of `auth()` in `createZeroDevWalletCore`).
+ *
+ * `client.registerWithPasskey` creates the account and its wallet remotely, then
+ * `client.loginWithStamp` obtains a session, with a key rotation between them —
+ * and the REST transport has no retry, so a 503/429/stall on the second call
+ * throws straight out with the account already created.
+ *
+ * The `catch` calls `discardKeyRotation()` and rethrows, which is narrower than
+ * it looks: `commitKeyRotation()` has already run one line after the create
+ * succeeded, so the key store keeps an active API key from the abandoned attempt.
+ * Session storage is genuinely empty.
+ *
+ * Registering again creates a second wallet as intended. Not tested here: the
+ * cost of that path, which is an ambiguous login picker rather than a lost wallet.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'
+import type { StorageAdapter } from '../storage/manager.js'
+import { SessionType } from '../types/session.js'
+import { createZeroDevWalletCore } from './createZeroDevWalletCore.js'
+
+/**
+ * Tracks pending vs active the way a real key store does, so the rotation
+ * sequencing in the flow under test is exercised rather than stubbed away.
+ */
+function statefulStamper(): ApiKeyStamper {
+  let activeKey: string | null = null
+  let pending: string | null = null
+  let n = 0
+  const stamp = async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  })
+  return {
+    stamp,
+    clear: async () => {},
+    getPublicKey: async () => activeKey,
+    resetKeyPair: async () => {
+      activeKey = `02${String(++n).padStart(64, '0')}`
+    },
+    prepareKeyRotation: async () => {
+      pending = `02${String(++n).padStart(64, '0')}`
+      return pending
+    },
+    stampPending: stamp,
+    signPending: async () => 'sig',
+    commitKeyRotation: async () => {
+      if (pending) activeKey = pending
+      pending = null
+    },
+    discardKeyRotation: async () => {
+      pending = null
+    },
+    sign: async () => 'sig',
+  }
+}
+
+/**
+ * Mints a fresh credential per call, as both real stampers do, and survives a
+ * failed registration the way a device-resident passkey does. On Core's side of
+ * the boundary — it stands in for the SDK's own stampers, not for KMS.
+ */
+function freshPasskeyStamper(): PasskeyStamper {
+  let n = 0
+  return {
+    stamp: async () => ({
+      stampHeaderName: 'X-Stamp',
+      stampHeaderValue: 'stamp',
+    }),
+    clear: async () => {},
+    register: async () => ({
+      attestation: {
+        attestationObject: 'ao',
+        clientDataJson: 'cdj',
+        credentialId: `credential-${++n}`,
+      },
+      encodedChallenge: 'challenge',
+    }),
+  }
+}
+
+function sessionToken(publicKey: string, organizationId: string) {
+  return `hdr.${btoa(
+    JSON.stringify({
+      exp: Date.now() + 3_600_000,
+      public_key: publicKey,
+      session_type: SessionType.READ_WRITE,
+      user_id: 'user-1',
+      organization_id: organizationId,
+    }),
+  )}.sig`
+}
+
+type RecordedRequest = { path: string; body: Record<string, unknown> }
+
+/**
+ * A recording transport. It answers what it is told to answer and decides
+ * nothing: no account model, no dedupe rule, no branching on what a request
+ * contains. The response values are arbitrary fixtures in the real response
+ * shapes and no assertion reads them — the tests assert what Core sent and what
+ * Core holds locally, so nothing here can turn a fact about a double into a
+ * finding about Core.
+ */
+function recordingKms() {
+  const requests: RecordedRequest[] = []
+  const state = { failLogin: false }
+  let accounts = 0
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const path = String(url)
+      const body = init?.body ? JSON.parse(String(init.body)) : {}
+      const json = (payload: unknown, status = 200) =>
+        new Response(JSON.stringify(payload), {
+          status,
+          headers: { 'content-type': 'application/json' },
+        })
+
+      if (path.includes('server-info/parent-org-id')) {
+        return json({ parentOrgId: 'parent-org' })
+      }
+
+      requests.push({ path, body })
+
+      if (path.includes('/auth/register/passkey')) {
+        accounts += 1
+        return json({
+          userId: 'user-1',
+          walletAddress: `0x${String(accounts).repeat(40).slice(0, 40)}`,
+          subOrganizationId: `suborg-${accounts}`,
+        })
+      }
+
+      if (path.includes('/auth/login/stamp')) {
+        if (state.failLogin) {
+          return json({ error: 'unavailable', message: 'KMS down' }, 503)
+        }
+        return json({
+          session: sessionToken(body.targetPublicKey, `suborg-${accounts}`),
+        })
+      }
+
+      return json({}, 404)
+    }),
+  )
+
+  const to = (suffix: string) => requests.filter((r) => r.path.includes(suffix))
+
+  return {
+    requests,
+    creates: () => to('/auth/register/passkey'),
+    logins: () => to('/auth/login/stamp'),
+    failLoginWith503: (on: boolean) => {
+      state.failLogin = on
+    },
+  }
+}
+
+async function buildCore() {
+  const store = new Map<string, string>()
+  const adapter: StorageAdapter = {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value)
+    },
+    removeItem: (key) => {
+      store.delete(key)
+    },
+  }
+  return createZeroDevWalletCore({
+    projectId: 'proj',
+    rpId: 'localhost',
+    sessionStorage: adapter,
+    apiKeyStamper: statefulStamper(),
+    passkeyStamper: freshPasskeyStamper(),
+    proxyBaseUrl: 'https://kms.test.invalid/api/v1',
+  })
+}
+
+const register = { type: 'passkey', mode: 'register' } as const
+const login = { type: 'passkey', mode: 'login' } as const
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('passkey registration: the happy path', () => {
+  it('creates the account once and ends with a session', async () => {
+    const kms = recordingKms()
+    const core = await buildCore()
+
+    await core.auth(register)
+
+    expect(kms.creates()).toHaveLength(1)
+    expect(kms.logins()).toHaveLength(1)
+    await expect(core.getSession()).resolves.toBeDefined()
+  })
+})
+
+describe('passkey registration: KMS fails between the two calls', () => {
+  it('surfaces the failure and leaves no session, having already created the account', async () => {
+    const kms = recordingKms()
+    kms.failLoginWith503(true)
+    const core = await buildCore()
+
+    await expect(core.auth(register)).rejects.toThrow(/503/)
+
+    expect(kms.creates()).toHaveLength(1)
+    await expect(core.getSession()).resolves.toBeUndefined()
+  })
+
+  it('leaves the user able to log in with the passkey they already hold', async () => {
+    // A CANARY, not a guard: three mutations to the failure path all survived,
+    // because login rebuilds its own key rotation and nothing can un-create a
+    // device-resident credential. It goes red only if a future change makes login
+    // refuse while an interrupted registration is outstanding.
+    const kms = recordingKms()
+    kms.failLoginWith503(true)
+    const core = await buildCore()
+    await expect(core.auth(register)).rejects.toThrow(/503/)
+
+    kms.failLoginWith503(false)
+    await core.auth(login)
+
+    const session = await core.getSession()
+    expect(session).toBeDefined()
+    expect(session?.sessionType).toBe(SessionType.READ_WRITE)
+    expect(kms.creates()).toHaveLength(1)
+  })
+})

--- a/packages/core/src/core/sessionCommitRecovery.integration.test.ts
+++ b/packages/core/src/core/sessionCommitRecovery.integration.test.ts
@@ -1,13 +1,13 @@
 /**
- * Boundary: Wallet Core <-> the key store and session storage, inside
- * `commitReplacementSession` — the two-phase commit all five authenticated flows
+ * Boundary between Wallet Core and the key store plus session storage, inside
+ * `commitReplacementSession`, the two-phase commit all five authenticated flows
  * share.
  *
- * Order is: stage a journal entry, promote the pending key, commit the journal.
+ * The order is: stage a journal entry, promote the pending key, commit the journal.
  * Both later steps recover through `recoverSessionTransition`, which honours a
- * journal only if its `publicKey` is the key now active — that comparison is how
- * "the rotation happened, the error was cosmetic" is told from "it did not". The
- * same journal is crash recovery, completed on the next construction.
+ * journal only if its `publicKey` is the key now active. That comparison is how
+ * "the rotation happened, the error was cosmetic" is told apart from "it did not".
+ * The same journal is crash recovery, completed on the next construction.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'

--- a/packages/core/src/core/sessionCommitRecovery.integration.test.ts
+++ b/packages/core/src/core/sessionCommitRecovery.integration.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Boundary: Wallet Core <-> the key store and session storage, inside
+ * `commitReplacementSession` — the two-phase commit all five authenticated flows
+ * share.
+ *
+ * Order is: stage a journal entry, promote the pending key, commit the journal.
+ * Both later steps recover through `recoverSessionTransition`, which honours a
+ * journal only if its `publicKey` is the key now active — that comparison is how
+ * "the rotation happened, the error was cosmetic" is told from "it did not". The
+ * same journal is crash recovery, completed on the next construction.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'
+import type { StorageAdapter } from '../storage/manager.js'
+import { SessionType } from '../types/session.js'
+import { createZeroDevWalletCore } from './createZeroDevWalletCore.js'
+
+/** The storage key the journal lives under, needed to break it on purpose. */
+const JOURNAL = '@zerodev/session_transition'
+
+const sessionKey = (nth: number) => `02${String(nth).padStart(64, '0')}`
+
+type KeyStoreScript = {
+  /** Fail every `commitKeyRotation` without promoting the pending key. */
+  commitFails?: boolean
+  /** Fail only the first `commitKeyRotation` — a transient outage. */
+  commitFailsOnce?: boolean
+  /** Promote the key and THEN fail: the write landed, the acknowledgement did not. */
+  commitPromotesThenFails?: boolean
+  /** Fail the rollback that runs inside the commit-failure handler. */
+  discardFails?: boolean
+  /** Fail the key read that the commit-failure handler makes. */
+  readFailsAfterCommitFailure?: boolean
+  /**
+   * Start out holding the nth key. Needed to reach the key-ownership branch: a
+   * store holding NO key is rejected before the comparison runs.
+   */
+  holdingKey?: number
+}
+
+const COMMIT_FAILURE = 'key store commit failed'
+const DISCARD_FAILURE = 'key store cannot discard'
+const READ_FAILURE = 'key store unreadable'
+
+function keyStore(script: KeyStoreScript = {}): ApiKeyStamper & {
+  activeKey: () => string | null
+} {
+  let minted = script.holdingKey ?? 0
+  let active: string | null = script.holdingKey ? sessionKey(minted) : null
+  let pending: string | null = null
+  let commits = 0
+  let commitHasFailed = false
+  const stamp = async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  })
+  const promote = () => {
+    if (pending) active = pending
+    pending = null
+  }
+  return {
+    stamp,
+    clear: async () => {
+      active = null
+      pending = null
+    },
+    getPublicKey: async () => {
+      if (script.readFailsAfterCommitFailure && commitHasFailed) {
+        throw new Error(READ_FAILURE)
+      }
+      return active
+    },
+    resetKeyPair: async () => {
+      active = sessionKey(++minted)
+    },
+    prepareKeyRotation: async () => {
+      pending = sessionKey(++minted)
+      return pending
+    },
+    stampPending: stamp,
+    signPending: async () => 'sig',
+    commitKeyRotation: async () => {
+      const attempt = commits++
+      if (script.commitPromotesThenFails) {
+        promote()
+        commitHasFailed = true
+        throw new Error(COMMIT_FAILURE)
+      }
+      if (script.commitFails || (script.commitFailsOnce && attempt === 0)) {
+        commitHasFailed = true
+        throw new Error(COMMIT_FAILURE)
+      }
+      promote()
+    },
+    discardKeyRotation: async () => {
+      if (script.discardFails) throw new Error(DISCARD_FAILURE)
+      pending = null
+    },
+    sign: async () => 'sig',
+    activeKey: () => active,
+  }
+}
+
+const passkeyStamper: PasskeyStamper = {
+  stamp: async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  }),
+  clear: async () => {},
+  register: async () => ({
+    attestation: {
+      attestationObject: 'ao',
+      clientDataJson: 'cdj',
+      credentialId: 'cred-1',
+    },
+    encodedChallenge: 'challenge',
+  }),
+}
+
+function token(publicKey: string) {
+  return `hdr.${btoa(
+    JSON.stringify({
+      exp: Date.now() + 3_600_000,
+      public_key: publicKey,
+      session_type: SessionType.READ_WRITE,
+      user_id: 'user-1',
+      organization_id: 'suborg-1',
+    }),
+  )}.sig`
+}
+
+type StorageScript = {
+  /** Fail the journal write, so nothing is ever staged. */
+  stageFails?: boolean
+  /** Fail journal reads once it has been staged. */
+  journalReadFails?: boolean
+  /** Drop the journal the instant it is written. */
+  journalVanishes?: boolean
+}
+
+/** Backed by a plain Map so the store can be re-read by a second instance. */
+function storage(
+  script: StorageScript = {},
+  store = new Map<string, string>(),
+) {
+  let staged = false
+  const adapter: StorageAdapter = {
+    getItem: (key) => {
+      if (script.journalReadFails && key === JOURNAL && staged) {
+        throw new Error('storage read failed')
+      }
+      return store.get(key) ?? null
+    },
+    setItem: (key, value) => {
+      if (script.stageFails && key === JOURNAL) {
+        throw new Error('storage write failed')
+      }
+      store.set(key, value)
+      if (key === JOURNAL) {
+        staged = true
+        if (script.journalVanishes) store.delete(key)
+      }
+    },
+    removeItem: (key) => {
+      store.delete(key)
+    },
+  }
+  return { adapter, store }
+}
+
+function stubKms() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const path = String(url)
+      const body = init?.body ? JSON.parse(String(init.body)) : {}
+      const json = (payload: unknown, status = 200) =>
+        new Response(JSON.stringify(payload), {
+          status,
+          headers: { 'content-type': 'application/json' },
+        })
+      if (path.includes('server-info/parent-org-id')) {
+        return json({ parentOrgId: 'parent-org' })
+      }
+      if (path.includes('/auth/login/stamp')) {
+        return json({ session: token(body.targetPublicKey) })
+      }
+      return json({}, 404)
+    }),
+  )
+}
+
+async function build(opts: { api: ApiKeyStamper; adapter: StorageAdapter }) {
+  return createZeroDevWalletCore({
+    projectId: 'proj',
+    rpId: 'localhost',
+    sessionStorage: opts.adapter,
+    apiKeyStamper: opts.api,
+    passkeyStamper,
+    proxyBaseUrl: 'https://kms.test.invalid/api/v1',
+  })
+}
+
+const login = { type: 'passkey', mode: 'login' } as const
+
+const caught = (p: Promise<unknown>) =>
+  p.then(
+    () => 'RESOLVED' as const,
+    (e: unknown) => e,
+  )
+
+/**
+ * Walks the `cause` chain, so rethrowing the original, wrapping it, or
+ * aggregating all pass — a generic `Error('key store failure')` does not.
+ */
+function blames(error: unknown, text: string): boolean {
+  let current: unknown = error
+  for (let depth = 0; current instanceof Error && depth < 5; depth += 1) {
+    if (current.message.includes(text)) return true
+    current = (current as { cause?: unknown }).cause
+  }
+  return false
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('session commit: the control', () => {
+  it('promotes the key, stores the session and consumes the journal', async () => {
+    stubKms()
+    const api = keyStore()
+    const { adapter, store } = storage()
+
+    await (await build({ api, adapter })).auth(login)
+
+    expect(api.activeKey()).toBe(sessionKey(1))
+    expect(store.has(JOURNAL)).toBe(false)
+  })
+})
+
+describe('session commit: the key rotation fails outright', () => {
+  it('reports the key store and leaves nothing half-committed', async () => {
+    stubKms()
+    const api = keyStore({ commitFails: true })
+    const { adapter, store } = storage()
+    const core = await build({ api, adapter })
+
+    const error = await caught(core.auth(login))
+
+    expect(blames(error, COMMIT_FAILURE)).toBe(true)
+    await expect(core.getSession()).resolves.toBeUndefined()
+    // No key was promoted, so the journal can never match a live key: dropped,
+    // not left to be recovered against the wrong session.
+    expect(api.activeKey()).toBeNull()
+    expect(store.has(JOURNAL)).toBe(false)
+  })
+
+  it('lets the next attempt through when the failure was transient', async () => {
+    stubKms()
+    const api = keyStore({ commitFailsOnce: true })
+    const { adapter } = storage()
+    const core = await build({ api, adapter })
+    await caught(core.auth(login))
+
+    await core.auth(login)
+
+    await expect(core.getSession()).resolves.toBeDefined()
+  })
+})
+
+describe('session commit: the rotation happened but was not acknowledged', () => {
+  it('completes the login instead of failing it', async () => {
+    // Failing here would leave the caller believing it is logged out while
+    // holding a key the backend has already accepted.
+    stubKms()
+    const api = keyStore({ commitPromotesThenFails: true })
+    const { adapter, store } = storage()
+    const core = await build({ api, adapter })
+
+    await expect(core.auth(login)).resolves.toBeDefined()
+
+    await expect(core.getSession()).resolves.toBeDefined()
+    expect(api.activeKey()).toBe(sessionKey(1))
+    expect(store.has(JOURNAL)).toBe(false)
+  })
+})
+
+describe('session commit: a second key-store call fails inside the handler', () => {
+  // Both handlers `await` further key-store calls before rethrowing, unguarded.
+  // When one fails its error REPLACES the original, so the caller is told the
+  // rollback failed rather than the commit.
+  it.fails('still blames the commit when the rollback also fails', async () => {
+    stubKms()
+    const api = keyStore({ commitFails: true, discardFails: true })
+    const { adapter } = storage()
+    const core = await build({ api, adapter })
+
+    const error = await caught(core.auth(login))
+
+    expect(error).not.toBe('RESOLVED')
+    expect(blames(error, COMMIT_FAILURE)).toBe(true)
+  })
+
+  it.fails('still blames the commit when the key read also fails', async () => {
+    stubKms()
+    const api = keyStore({
+      commitFails: true,
+      readFailsAfterCommitFailure: true,
+    })
+    const { adapter } = storage()
+    const core = await build({ api, adapter })
+
+    const error = await caught(core.auth(login))
+
+    expect(error).not.toBe('RESOLVED')
+    expect(blames(error, COMMIT_FAILURE)).toBe(true)
+  })
+
+  it('surfaces the substituted failure attributably at least', async () => {
+    // Weaker than the invariant above, and true today: whichever error wins names
+    // the key store, and no session is committed on the way out.
+    stubKms()
+    const api = keyStore({ commitFails: true, discardFails: true })
+    const { adapter } = storage()
+    const core = await build({ api, adapter })
+
+    const error = await caught(core.auth(login))
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error).not.toBeInstanceOf(TypeError)
+    expect(
+      blames(error, DISCARD_FAILURE) || blames(error, COMMIT_FAILURE),
+    ).toBe(true)
+    await expect(core.getSession()).resolves.toBeUndefined()
+  })
+})
+
+describe('session commit: storage fails around the journal', () => {
+  it('fails before promoting the key when the journal cannot be staged', async () => {
+    stubKms()
+    const api = keyStore()
+    const { adapter } = storage({ stageFails: true })
+    const core = await build({ api, adapter })
+
+    await expect(core.auth(login)).rejects.toThrow(/storage write failed/)
+
+    // Staging runs first on purpose: an unwritable journal must stop the
+    // rotation, not follow it.
+    expect(api.activeKey()).toBeNull()
+    await expect(core.getSession()).resolves.toBeUndefined()
+  })
+
+  it('names the journal when it disappears between staging and commit', async () => {
+    stubKms()
+    const api = keyStore()
+    const { adapter } = storage({ journalVanishes: true })
+    const core = await build({ api, adapter })
+
+    const error = await caught(core.auth(login))
+
+    expect(blames(error, 'journal')).toBe(true)
+    await expect(core.getSession()).resolves.toBeUndefined()
+  })
+
+  it('reports a failing journal read rather than a silent half-login', async () => {
+    stubKms()
+    const api = keyStore()
+    const { adapter } = storage({ journalReadFails: true })
+    const core = await build({ api, adapter })
+
+    const error = await caught(core.auth(login))
+
+    expect(error).toBeInstanceOf(Error)
+    await expect(core.getSession()).resolves.toBeUndefined()
+  })
+
+  it('prepares the fallback: the key IS promoted, so the journal stays recoverable', async () => {
+    // Precondition for the crash-recovery test below: the rotation completed, so
+    // the journal still matches the live key and must NOT be discarded.
+    stubKms()
+    const api = keyStore()
+    const { adapter, store } = storage({ journalReadFails: true })
+    const core = await build({ api, adapter })
+    await caught(core.auth(login))
+
+    expect(api.activeKey()).toBe(sessionKey(1))
+    expect(store.has(JOURNAL)).toBe(true)
+  })
+})
+
+describe('session commit: crash recovery on the next construction', () => {
+  it('finishes an interrupted transition once storage works again', async () => {
+    stubKms()
+    const api = keyStore()
+    const broken = storage({ journalReadFails: true })
+    await caught((await build({ api, adapter: broken.adapter })).auth(login))
+    expect(broken.store.has(JOURNAL)).toBe(true)
+
+    const healed = storage({}, broken.store)
+    const rebuilt = await build({ api, adapter: healed.adapter })
+
+    await expect(rebuilt.getSession()).resolves.toBeDefined()
+    expect(healed.store.has(JOURNAL)).toBe(false)
+  })
+
+  it('discards the journal when no key is held at all', async () => {
+    stubKms()
+    const api = keyStore()
+    const broken = storage({ journalReadFails: true })
+    await caught((await build({ api, adapter: broken.adapter })).auth(login))
+
+    const healed = storage({}, broken.store)
+    const rebuilt = await build({ api: keyStore(), adapter: healed.adapter })
+
+    await expect(rebuilt.getSession()).resolves.toBeUndefined()
+    expect(healed.store.has(JOURNAL)).toBe(false)
+  })
+
+  it('discards the journal when a DIFFERENT key is held', async () => {
+    // Not a duplicate of the one above: that case short-circuits on the absent key
+    // before any comparison runs. Two checks enforce this one, so deleting either
+    // alone leaves it green — do not "fix" the surviving mutation.
+    stubKms()
+    const api = keyStore()
+    const broken = storage({ journalReadFails: true })
+    await caught((await build({ api, adapter: broken.adapter })).auth(login))
+
+    const healed = storage({}, broken.store)
+    const rebuilt = await build({
+      api: keyStore({ holdingKey: 9 }),
+      adapter: healed.adapter,
+    })
+
+    await expect(rebuilt.getSession()).resolves.toBeUndefined()
+    expect(healed.store.has(JOURNAL)).toBe(false)
+  })
+})

--- a/packages/core/src/core/sessionReconciliation.integration.test.ts
+++ b/packages/core/src/core/sessionReconciliation.integration.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Boundary: Wallet Core <-> the two local stateful stores it must keep in
+ * agreement — the key store (B5, `ApiKeyStamper`) and session storage (B6,
+ * `StorageAdapter`).
+ *
+ * `createZeroDevWalletCore` reconciles them on EVERY construction, before the SDK
+ * object is returned: it replays any staged transition, then compares the restored
+ * session's bound public key against the live signing key and clears sessions if
+ * they disagree. The two stores fail independently — eviction, a partial device
+ * restore, a half-done rotation — so this decides whether a returning user keeps
+ * their login or is silently signed out.
+ *
+ * Construction makes no network call; the org-id lookup is lazy.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ApiKeyStamper } from '../stampers/types.js'
+import type { StorageAdapter } from '../storage/manager.js'
+import { SessionType, type ZeroDevWalletSession } from '../types/session.js'
+import { createZeroDevWalletCore } from './createZeroDevWalletCore.js'
+
+const ACTIVE_SESSION_KEY = '@zerodev/active_session'
+const ALL_SESSIONS_KEY = '@zerodev/sessions'
+const SESSION_TRANSITION_KEY = '@zerodev/session_transition'
+
+const KEY_LIVE =
+  '02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const KEY_OTHER =
+  '02bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
+function sessionToken(publicKey: string): string {
+  return `hdr.${btoa(
+    JSON.stringify({
+      exp: Date.now() + 3_600_000,
+      public_key: publicKey,
+      session_type: SessionType.READ_WRITE,
+      user_id: 'user-1',
+      organization_id: 'org-1',
+    }),
+  )}.sig`
+}
+
+function session(id: string, publicKey: string): ZeroDevWalletSession {
+  return {
+    id,
+    userId: 'user-1',
+    organizationId: 'org-1',
+    stamperType: 'apiKey',
+    sessionType: SessionType.READ_WRITE,
+    token: sessionToken(publicKey),
+    publicKey,
+    expiry: Date.now() + 3_600_000,
+    createdAt: Date.now(),
+  }
+}
+
+/** Storage pre-seeded as if a previous run had stored `s` and made it active. */
+function seededStore(s?: ZeroDevWalletSession): Map<string, string> {
+  const store = new Map<string, string>()
+  if (s) {
+    store.set(s.id, JSON.stringify(s))
+    store.set(ALL_SESSIONS_KEY, JSON.stringify([s.id]))
+    store.set(ACTIVE_SESSION_KEY, s.id)
+  }
+  return store
+}
+
+function adapterOver(store: Map<string, string>): StorageAdapter {
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value)
+    },
+    removeItem: (key) => {
+      store.delete(key)
+    },
+  }
+}
+
+/** Minimal ApiKeyStamper whose active key is fixed; no crypto, no network. */
+function fakeStamper(activeKey: string | null): ApiKeyStamper {
+  return {
+    stamp: vi.fn(async () => ({
+      stampHeaderName: 'X-Stamp',
+      stampHeaderValue: 'stamp',
+    })),
+    clear: vi.fn(async () => {}),
+    getPublicKey: vi.fn(async () => activeKey),
+    resetKeyPair: vi.fn(async () => {}),
+    prepareKeyRotation: vi.fn(async () => KEY_OTHER),
+    stampPending: vi.fn(async () => ({
+      stampHeaderName: 'X-Stamp',
+      stampHeaderValue: 'stamp',
+    })),
+    signPending: vi.fn(async () => 'sig'),
+    commitKeyRotation: vi.fn(async () => {}),
+    discardKeyRotation: vi.fn(async () => {}),
+    sign: vi.fn(async () => 'sig'),
+  }
+}
+
+async function buildCore(store: Map<string, string>, activeKey: string | null) {
+  return createZeroDevWalletCore({
+    projectId: 'project-1',
+    rpId: 'localhost',
+    sessionStorage: adapterOver(store),
+    apiKeyStamper: fakeStamper(activeKey),
+    // A dead address on purpose: a construction-time request would fail loudly
+    // here rather than silently reach real KMS.
+    proxyBaseUrl: 'http://127.0.0.1:1/api/v1',
+  })
+}
+
+describe('core reconciliation on construction: keys agree', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  // Load-bearing: without it the spy outlives this describe and wraps `fetch`
+  // for every later test in the file.
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('keeps the stored session when its bound key matches the live signing key', async () => {
+    const stored = session('session_live', KEY_LIVE)
+    const store = seededStore(stored)
+
+    const core = await buildCore(store, KEY_LIVE)
+
+    await expect(core.getSession()).resolves.toMatchObject({
+      id: 'session_live',
+    })
+    expect(store.get(ACTIVE_SESSION_KEY)).toBe('session_live')
+    expect(JSON.parse(store.get(ALL_SESSIONS_KEY) as string)).toEqual([
+      'session_live',
+    ])
+  })
+
+  it('performs no network request while reconciling', async () => {
+    const store = seededStore(session('session_live', KEY_LIVE))
+
+    await buildCore(store, KEY_LIVE)
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('tolerates a case- and 0x-prefix difference between the two stores', async () => {
+    // Same key, handed to the stamper 0x-prefixed and upper-cased — as a
+    // different component writing the other store may well produce.
+    const stored = session('session_live', KEY_LIVE)
+    const store = seededStore(stored)
+
+    const core = await buildCore(store, `0x${KEY_LIVE.toUpperCase()}`)
+
+    await expect(core.getSession()).resolves.toMatchObject({
+      id: 'session_live',
+    })
+  })
+})
+
+describe('core reconciliation on construction: stores disagree', () => {
+  it('clears sessions when the stored session is bound to a different key', async () => {
+    const store = seededStore(session('session_stale', KEY_OTHER))
+
+    const core = await buildCore(store, KEY_LIVE)
+
+    await expect(core.getSession()).resolves.toBeUndefined()
+    expect(store.get(ACTIVE_SESSION_KEY)).toBeUndefined()
+  })
+
+  it('clears sessions when the stored token cannot be parsed', async () => {
+    const stored = session('session_corrupt', KEY_LIVE)
+    const store = seededStore({ ...stored, token: 'not-a-jwt' })
+
+    const core = await buildCore(store, KEY_LIVE)
+
+    await expect(core.getSession()).resolves.toBeUndefined()
+  })
+
+  it('does not throw when there is no live key and no session', async () => {
+    const store = new Map<string, string>()
+
+    const core = await buildCore(store, null)
+
+    await expect(core.getSession()).resolves.toBeUndefined()
+  })
+})
+
+describe('core reconciliation on construction: crashed transition', () => {
+  it('replays a staged transition whose key matches the live key', async () => {
+    // A journal staged and then abandoned mid-commit, with the key rotation
+    // itself having landed — so the staged session matches the live key.
+    const store = new Map<string, string>()
+    store.set(
+      SESSION_TRANSITION_KEY,
+      JSON.stringify({
+        sessionData: session('session_staged', KEY_LIVE),
+        publicKey: KEY_LIVE,
+      }),
+    )
+
+    const core = await buildCore(store, KEY_LIVE)
+
+    await expect(core.getSession()).resolves.toMatchObject({
+      id: 'session_staged',
+    })
+    expect(store.get(SESSION_TRANSITION_KEY)).toBeUndefined()
+  })
+
+  it('discards a staged transition for a key that never became live, keeping the old session', async () => {
+    // A journal naming a key the device never ended up holding, on top of a
+    // still-valid session.
+    const store = seededStore(session('session_live', KEY_LIVE))
+    store.set(
+      SESSION_TRANSITION_KEY,
+      JSON.stringify({
+        sessionData: session('session_staged', KEY_OTHER),
+        publicKey: KEY_OTHER,
+      }),
+    )
+
+    const core = await buildCore(store, KEY_LIVE)
+
+    await expect(core.getSession()).resolves.toMatchObject({
+      id: 'session_live',
+    })
+    expect(store.get(SESSION_TRANSITION_KEY)).toBeUndefined()
+  })
+})

--- a/packages/core/src/core/sessionReconciliation.integration.test.ts
+++ b/packages/core/src/core/sessionReconciliation.integration.test.ts
@@ -1,16 +1,15 @@
 /**
- * Boundary: Wallet Core <-> the two local stateful stores it must keep in
- * agreement — the key store (B5, `ApiKeyStamper`) and session storage (B6,
- * `StorageAdapter`).
+ * Boundary between Wallet Core and the two local stateful stores it must keep in
+ * agreement: the key store (`ApiKeyStamper`) and session storage
+ * (`StorageAdapter`).
  *
  * `createZeroDevWalletCore` reconciles them on EVERY construction, before the SDK
  * object is returned: it replays any staged transition, then compares the restored
  * session's bound public key against the live signing key and clears sessions if
- * they disagree. The two stores fail independently — eviction, a partial device
- * restore, a half-done rotation — so this decides whether a returning user keeps
- * their login or is silently signed out.
- *
- * Construction makes no network call; the org-id lookup is lazy.
+ * they disagree. The two stores fail independently, through eviction, a partial
+ * device restore or a rotation left half finished, so this decides whether a
+ * returning user keeps their login or is silently signed out. Construction makes
+ * no network call; the org id lookup is lazy.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ApiKeyStamper } from '../stampers/types.js'

--- a/packages/core/src/core/sessionResponseShape.integration.test.ts
+++ b/packages/core/src/core/sessionResponseShape.integration.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Boundary: Wallet Core <-> KMS, at the one field every authenticated flow
+ * depends on — `data.session` in a 200 response.
+ *
+ * Five flows commit a session through the same two-phase path
+ * (`createReplacementSession` then `commitReplacementSession`), and they do NOT
+ * agree on whether the field is checked first. `oauth` and `otp` verify guard it
+ * (`if (!data.session)` → discard the rotation and return); passkey **register**,
+ * passkey **login** and **refreshSession** pass it straight in. That asymmetry
+ * inside one file is the argument that the guard is expected rather than a
+ * design choice — three paths deref an absent session into a raw `TypeError`.
+ *
+ * The assertion holds under either remedy: rejecting attributably, and resolving
+ * without committing a session the way `oauth` already does, both pass. Only an
+ * unattributable throw fails — so a fix in either direction turns these green
+ * rather than red.
+ *
+ * `otp`/`magicLink` verify is the fifth path and is NOT covered here: it cannot
+ * be driven in-process. `encryptOtpAttempt` pins the HPKE envelope against
+ * `TURNKEY_TLS_FETCHER_SIGN_PUBLIC_KEY` and Core passes no override, so the flow
+ * fails closed before any request. It is guarded like `oauth` by reading.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'
+import type { StorageAdapter } from '../storage/manager.js'
+import { SessionType } from '../types/session.js'
+import { createZeroDevWalletCore } from './createZeroDevWalletCore.js'
+
+function statefulStamper(): ApiKeyStamper & {
+  pendingKey: () => string | null
+} {
+  let active: string | null = null
+  let pending: string | null = null
+  let n = 0
+  const stamp = async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  })
+  return {
+    stamp,
+    clear: async () => {},
+    getPublicKey: async () => active,
+    resetKeyPair: async () => {
+      active = `02${String(++n).padStart(64, '0')}`
+    },
+    prepareKeyRotation: async () => {
+      pending = `02${String(++n).padStart(64, '0')}`
+      return pending
+    },
+    stampPending: stamp,
+    signPending: async () => 'sig',
+    commitKeyRotation: async () => {
+      if (pending) active = pending
+      pending = null
+    },
+    discardKeyRotation: async () => {
+      pending = null
+    },
+    sign: async () => 'sig',
+    pendingKey: () => pending,
+  }
+}
+
+const passkeyStamper: PasskeyStamper = {
+  stamp: async () => ({
+    stampHeaderName: 'X-Stamp',
+    stampHeaderValue: 'stamp',
+  }),
+  clear: async () => {},
+  register: async () => ({
+    attestation: {
+      attestationObject: 'ao',
+      clientDataJson: 'cdj',
+      credentialId: 'cred-1',
+    },
+    encodedChallenge: 'challenge',
+  }),
+}
+
+/** A session token whose claims are valid unless `over` breaks one on purpose. */
+function token(publicKey: string, over: Record<string, unknown> = {}) {
+  return `hdr.${btoa(
+    JSON.stringify({
+      exp: Date.now() + 3_600_000,
+      public_key: publicKey,
+      session_type: SessionType.READ_WRITE,
+      user_id: 'user-1',
+      organization_id: 'suborg-1',
+      ...over,
+    }),
+  )}.sig`
+}
+
+/**
+ * Answers a script and decides nothing. `sessionResponse` is what every
+ * session-bearing endpoint returns, so one fixture drives all four paths.
+ */
+function kms(sessionResponse: (targetPublicKey: string) => unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const path = String(url)
+      const body = init?.body ? JSON.parse(String(init.body)) : {}
+      const json = (payload: unknown, status = 200) =>
+        new Response(JSON.stringify(payload), {
+          status,
+          headers: { 'content-type': 'application/json' },
+        })
+
+      if (path.includes('server-info/parent-org-id')) {
+        return json({ parentOrgId: 'parent-org' })
+      }
+      if (path.includes('/auth/register/passkey')) {
+        return json({
+          userId: 'user-1',
+          walletAddress: `0x${'1'.repeat(40)}`,
+          subOrganizationId: 'suborg-1',
+        })
+      }
+      if (path.includes('/auth/login/stamp')) {
+        return json(sessionResponse(body.targetPublicKey))
+      }
+      if (path.includes('/auth/oauth')) {
+        // The oauth request body carries no public key — the backend already
+        // holds the key registered against the server-side session, and
+        // `popSignature` is what proves possession. So the token has to be bound
+        // to the key the store just prepared, which `harness` supplies.
+        return json(sessionResponse(''))
+      }
+      return json({}, 404)
+    }),
+  )
+}
+
+/**
+ * One fixture for all four paths. `sessionResponse` receives the target public
+ * key the flow is committing to, taken from the request where the request
+ * carries it and from the key store otherwise.
+ */
+async function harness(sessionResponse: (targetPublicKey: string) => unknown) {
+  const api = statefulStamper()
+  kms((fromRequest) => sessionResponse(fromRequest || (api.pendingKey() ?? '')))
+
+  const store = new Map<string, string>()
+  const adapter: StorageAdapter = {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value)
+    },
+    removeItem: (key) => {
+      store.delete(key)
+    },
+  }
+  const core = await createZeroDevWalletCore({
+    projectId: 'proj',
+    rpId: 'localhost',
+    sessionStorage: adapter,
+    apiKeyStamper: api,
+    passkeyStamper,
+    proxyBaseUrl: 'https://kms.test.invalid/api/v1',
+  })
+  return { core, api }
+}
+
+const register = { type: 'passkey', mode: 'register' } as const
+const login = { type: 'passkey', mode: 'login' } as const
+const oauth = {
+  type: 'oauth',
+  provider: 'google',
+  sessionId: 'oauth-session-1',
+} as const
+
+/**
+ * Attributable = the caller can tell the session response was at fault. A raw
+ * `TypeError` reads the same as a null deref anywhere else in the flow, and a
+ * bare `Error('failed')` names nothing — both are rejected here on purpose, so
+ * that neither a rethrown `TypeError` nor a message-less throw can pass for a
+ * fix.
+ */
+function isAttributable(e: unknown) {
+  return (
+    e instanceof Error &&
+    !(e instanceof TypeError) &&
+    /session|jwt/i.test(e.message)
+  )
+}
+
+/**
+ * Both remedies pass: reject attributably, or resolve without a session the way
+ * the `oauth` branch does. Whether Core should reject or resolve is the open
+ * "sessionless OAuth" question and is deliberately not pinned.
+ */
+async function endsAttributably(run: () => Promise<unknown>) {
+  const outcome = await run().then(
+    () => 'resolved' as const,
+    (e: unknown) => e,
+  )
+  return outcome === 'resolved' || isAttributable(outcome)
+}
+
+const ABSENT = { session: undefined }
+const NULLED = { session: null }
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('session response: a 200 that carries a session', () => {
+  // The control. Without it, a guard that rejected every response would pass
+  // every test below.
+  it('commits the session on passkey login', async () => {
+    const { core } = await harness((pk) => ({ session: token(pk) }))
+
+    await core.auth(login)
+
+    await expect(core.getSession()).resolves.toBeDefined()
+  })
+
+  it('commits the session on oauth', async () => {
+    const { core } = await harness((pk) => ({ session: token(pk) }))
+
+    await core.auth(oauth)
+
+    await expect(core.getSession()).resolves.toBeDefined()
+  })
+})
+
+describe('session response: the session field is missing from a 200', () => {
+  // Each of these asserts the outcome AND that nothing was stored. Attributability
+  // alone would be satisfied by resolving with a fabricated session, which is a
+  // worse outcome than the `TypeError` — the pair is what makes these detect only
+  // a real fix.
+  it.fails('stays attributable on passkey register', async () => {
+    // Today: `TypeError: Cannot read properties of undefined (reading
+    // 'publicKey')`, thrown from `createReplacementSession`.
+    const { core } = await harness(() => ABSENT)
+
+    expect(await endsAttributably(() => core.auth(register))).toBe(true)
+    await expect(core.getSession()).resolves.toBeUndefined()
+  })
+
+  it.fails('stays attributable on passkey login', async () => {
+    const { core } = await harness(() => ABSENT)
+
+    expect(await endsAttributably(() => core.auth(login))).toBe(true)
+    await expect(core.getSession()).resolves.toBeUndefined()
+  })
+
+  it.fails('stays attributable when the session field is null', async () => {
+    // The same deref, one message apart ("...of null"), so a fix that only
+    // guards `undefined` still leaves this one red.
+    const { core } = await harness(() => NULLED)
+
+    expect(await endsAttributably(() => core.auth(login))).toBe(true)
+    await expect(core.getSession()).resolves.toBeUndefined()
+  })
+
+  it('stays attributable on oauth, which already guards the field', async () => {
+    const { core } = await harness(() => ABSENT)
+
+    expect(await endsAttributably(() => core.auth(oauth))).toBe(true)
+    await expect(core.getSession()).resolves.toBeUndefined()
+  })
+
+  it('commits no session on any path', async () => {
+    const { core } = await harness(() => ABSENT)
+
+    await core.auth(login).catch(() => {})
+    await expect(core.getSession()).resolves.toBeUndefined()
+
+    await core.auth(register).catch(() => {})
+    await expect(core.getSession()).resolves.toBeUndefined()
+  })
+})
+
+describe('session response: refreshSession is the third unguarded path', () => {
+  /** Logs in for real, then makes the NEXT session response degenerate. */
+  async function loggedInThenDegenerate(degenerate: unknown) {
+    let live = false
+    const { core } = await harness((pk) =>
+      live ? degenerate : { session: token(pk) },
+    )
+    await core.auth(login)
+    const before = await core.getSession()
+    live = true
+    return { core, before }
+  }
+
+  it.fails(
+    'stays attributable when the refreshed session is missing',
+    async () => {
+      // Paired with the session already held: a fix must be attributable AND
+      // leave the live session alone, so neither a bare throw nor a fix that
+      // logs the user out can satisfy this.
+      const { core, before } = await loggedInThenDegenerate(ABSENT)
+
+      expect(await endsAttributably(() => core.refreshSession())).toBe(true)
+      expect((await core.getSession())?.token).toBe(before?.token)
+    },
+  )
+
+  it('leaves the existing session usable when the refresh fails', async () => {
+    // The healthy half, and worth locking in: a failed refresh must not drop the
+    // user to unauthenticated. The rotation is discarded, so the active key still
+    // matches the session already stored and it keeps working until it expires.
+    const { core, before } = await loggedInThenDegenerate(ABSENT)
+
+    await core.refreshSession().catch(() => {})
+
+    const after = await core.getSession()
+    expect(after?.token).toBe(before?.token)
+  })
+})
+
+describe('session response: the token is present but its claims are not usable', () => {
+  // Regression cover for the guards between a hollow session and a wallet that
+  // cannot sign. Not one guard: mutating `parseSession`'s field check reddens only
+  // two of these, and a missing `user_id` is caught only accidentally, by the
+  // storage journal.
+  const cases: [string, (pk: string) => unknown][] = [
+    [
+      'a required claim is missing',
+      (pk) => ({ session: token(pk, { user_id: undefined }) }),
+    ],
+    [
+      'a required claim is empty',
+      (pk) => ({ session: token(pk, { organization_id: '' }) }),
+    ],
+    [
+      'the public key is empty',
+      (pk) => ({ session: token(pk, { public_key: '' }) }),
+    ],
+    ['the expiry is zero', (pk) => ({ session: token(pk, { exp: 0 }) })],
+    [
+      'the session is already expired',
+      (pk) => ({ session: token(pk, { exp: Date.now() - 1_000 }) }),
+    ],
+    [
+      'the session type is unknown',
+      (pk) => ({ session: token(pk, { session_type: 'WAT' }) }),
+    ],
+    ['the token is not a JWT', () => ({ session: 'not-a-jwt' })],
+    [
+      'the public key is another key',
+      () => ({ session: token(`02${'f'.repeat(64)}`) }),
+    ],
+  ]
+
+  for (const [label, response] of cases) {
+    it(`rejects attributably and stores nothing when ${label}`, async () => {
+      const { core } = await harness(response)
+
+      const caught = await core.auth(login).then(
+        () => 'RESOLVED' as const,
+        (e: unknown) => e,
+      )
+
+      expect(isAttributable(caught)).toBe(true)
+      await expect(core.getSession()).resolves.toBeUndefined()
+    })
+  }
+})

--- a/packages/core/src/core/sessionResponseShape.integration.test.ts
+++ b/packages/core/src/core/sessionResponseShape.integration.test.ts
@@ -1,24 +1,22 @@
 /**
- * Boundary: Wallet Core <-> KMS, at the one field every authenticated flow
- * depends on — `data.session` in a 200 response.
+ * Boundary between Wallet Core and KMS at the one field every authenticated flow
+ * depends on: `data.session` in a 200 response.
  *
  * Five flows commit a session through the same two-phase path
  * (`createReplacementSession` then `commitReplacementSession`), and they do NOT
- * agree on whether the field is checked first. `oauth` and `otp` verify guard it
- * (`if (!data.session)` → discard the rotation and return); passkey **register**,
- * passkey **login** and **refreshSession** pass it straight in. That asymmetry
- * inside one file is the argument that the guard is expected rather than a
- * design choice — three paths deref an absent session into a raw `TypeError`.
+ * agree on whether the field is checked first. `oauth` and `otp` verify guard it,
+ * discarding the rotation and returning; passkey register, passkey login and
+ * `refreshSession` pass it straight in, dereferencing an absent session into a raw
+ * `TypeError`. That asymmetry inside one file is the argument that the guard is
+ * expected rather than a design choice.
  *
- * The assertion holds under either remedy: rejecting attributably, and resolving
+ * The assertions hold under either remedy: rejecting attributably, and resolving
  * without committing a session the way `oauth` already does, both pass. Only an
- * unattributable throw fails — so a fix in either direction turns these green
- * rather than red.
+ * unattributable throw fails.
  *
- * `otp`/`magicLink` verify is the fifth path and is NOT covered here: it cannot
- * be driven in-process. `encryptOtpAttempt` pins the HPKE envelope against
- * `TURNKEY_TLS_FETCHER_SIGN_PUBLIC_KEY` and Core passes no override, so the flow
- * fails closed before any request. It is guarded like `oauth` by reading.
+ * `otp`/`magicLink` verify is the fifth path and is NOT covered here, since
+ * `encryptOtpAttempt` pins the HPKE envelope and Core passes no override, so the
+ * flow fails closed before any request.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ApiKeyStamper, PasskeyStamper } from '../stampers/types.js'

--- a/packages/core/src/storage/sessionTransition.integration.test.ts
+++ b/packages/core/src/storage/sessionTransition.integration.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Boundary: Wallet Core <-> session storage (B6).
+ *
+ * The storage adapter is injected and external — IndexedDB on web,
+ * expo-secure-store / AsyncStorage on native — so it can fail mid-write, be
+ * evicted, or come back from a device restore holding stale data.
+ *
+ * The contract: a staged transition is applied ONLY when the live signing key
+ * matches the key it was staged for. Every other case discards the journal and
+ * leaves existing state alone.
+ *
+ * `mem.store` is read directly in places — that is the record of what the manager
+ * wrote, not a fact about the double, which is a bare `Map`.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SessionType, type ZeroDevWalletSession } from '../types/session.js'
+import { createStorageManager, type StorageAdapter } from './manager.js'
+
+const ACTIVE_SESSION_KEY = '@zerodev/active_session'
+const ALL_SESSIONS_KEY = '@zerodev/sessions'
+const SESSION_TRANSITION_KEY = '@zerodev/session_transition'
+
+const KEY_A =
+  '02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const KEY_B =
+  '02bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
+/** A token `parseSession` accepts: 3 parts, future `exp`, all required claims. */
+function sessionToken(publicKey: string, userId = 'user-1'): string {
+  const payload = {
+    exp: Date.now() + 3_600_000,
+    public_key: publicKey,
+    session_type: SessionType.READ_WRITE,
+    user_id: userId,
+    organization_id: 'org-1',
+  }
+  return `hdr.${btoa(JSON.stringify(payload))}.sig`
+}
+
+function session(
+  id: string,
+  publicKey: string,
+  userId = 'user-1',
+): ZeroDevWalletSession {
+  return {
+    id,
+    userId,
+    organizationId: 'org-1',
+    stamperType: 'apiKey',
+    sessionType: SessionType.READ_WRITE,
+    token: sessionToken(publicKey, userId),
+    publicKey,
+    expiry: Date.now() + 3_600_000,
+    createdAt: Date.now(),
+  }
+}
+
+/** In-memory adapter with a seam for making one specific write fail. */
+function memoryAdapter(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial))
+  let failWrite: ((key: string) => boolean) | undefined
+  const adapter: StorageAdapter = {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      if (failWrite?.(key)) throw new Error(`storage write failed: ${key}`)
+      store.set(key, value)
+    },
+    removeItem: (key) => {
+      store.delete(key)
+    },
+  }
+  return {
+    adapter,
+    store,
+    failWritesTo(predicate: (key: string) => boolean) {
+      failWrite = predicate
+    },
+    stopFailing() {
+      failWrite = undefined
+    },
+  }
+}
+
+describe('session storage boundary: transition journal', () => {
+  let mem: ReturnType<typeof memoryAdapter>
+  let manager: ReturnType<typeof createStorageManager>
+
+  beforeEach(() => {
+    mem = memoryAdapter()
+    manager = createStorageManager(mem.adapter)
+  })
+
+  it('applies a staged transition when the live key matches the staged key', async () => {
+    const next = session('session_new', KEY_A)
+    await manager.stageSessionTransition(next, KEY_A)
+
+    const recovered = await manager.recoverSessionTransition(KEY_A)
+
+    expect(recovered?.id).toBe('session_new')
+    await expect(manager.getActiveSession()).resolves.toMatchObject({
+      id: 'session_new',
+    })
+    expect(await manager.getActiveSessionKey()).toBe('session_new')
+    expect(mem.store.has(SESSION_TRANSITION_KEY)).toBe(false)
+  })
+
+  it('discards the journal and preserves the existing session when the live key does not match', async () => {
+    const existing = session('session_existing', KEY_A)
+    await manager.storeSession(existing, existing.id)
+    const staged = session('session_staged', KEY_B)
+    await manager.stageSessionTransition(staged, KEY_B)
+
+    // Recover with live key A against a transition staged for B — a rotation
+    // that never completed.
+    const recovered = await manager.recoverSessionTransition(KEY_A)
+
+    expect(recovered).toBeUndefined()
+    expect(mem.store.has(SESSION_TRANSITION_KEY)).toBe(false)
+    await expect(manager.getActiveSession()).resolves.toMatchObject({
+      id: 'session_existing',
+    })
+  })
+
+  it('discards the journal when there is no live key at all', async () => {
+    const staged = session('session_staged', KEY_B)
+    await manager.stageSessionTransition(staged, KEY_B)
+
+    const recovered = await manager.recoverSessionTransition(null)
+
+    expect(recovered).toBeUndefined()
+    expect(mem.store.has(SESSION_TRANSITION_KEY)).toBe(false)
+    await expect(manager.getActiveSession()).resolves.toBeUndefined()
+  })
+
+  it('is a no-op when there is no journal, and leaves the active session intact', async () => {
+    const existing = session('session_existing', KEY_A)
+    await manager.storeSession(existing, existing.id)
+
+    await expect(
+      manager.recoverSessionTransition(KEY_A),
+    ).resolves.toBeUndefined()
+
+    await expect(manager.getActiveSession()).resolves.toMatchObject({
+      id: 'session_existing',
+    })
+  })
+
+  it('treats a corrupt journal as absent rather than throwing', async () => {
+    // Garbage written straight into the store, as a truncated write or a
+    // half-synced backup would leave it.
+    const existing = session('session_existing', KEY_A)
+    await manager.storeSession(existing, existing.id)
+    mem.store.set(SESSION_TRANSITION_KEY, '{not json')
+
+    await expect(
+      manager.recoverSessionTransition(KEY_A),
+    ).resolves.toBeUndefined()
+
+    expect(mem.store.has(SESSION_TRANSITION_KEY)).toBe(false)
+    await expect(manager.getActiveSession()).resolves.toMatchObject({
+      id: 'session_existing',
+    })
+  })
+
+  it('does not activate a staged session whose stored shape is invalid', async () => {
+    const existing = session('session_existing', KEY_A)
+    await manager.storeSession(existing, existing.id)
+    mem.store.set(
+      SESSION_TRANSITION_KEY,
+      JSON.stringify({
+        sessionData: { id: 'bogus', userId: 'user-1' },
+        publicKey: KEY_A,
+      }),
+    )
+
+    await expect(
+      manager.recoverSessionTransition(KEY_A),
+    ).resolves.toBeUndefined()
+
+    await expect(manager.getActiveSession()).resolves.toMatchObject({
+      id: 'session_existing',
+    })
+  })
+
+  it('commitSessionTransition replaces every prior session, not just the pointer', async () => {
+    const old = session('session_old', KEY_A)
+    await manager.storeSession(old, old.id)
+    const next = session('session_new', KEY_B)
+    await manager.stageSessionTransition(next, KEY_B)
+
+    await manager.commitSessionTransition()
+
+    const keys = await manager.listSessionKeys()
+    expect(keys).toEqual(['session_new'])
+    await expect(manager.getSession('session_old')).resolves.toBeUndefined()
+  })
+})
+
+describe('session storage boundary: partial write failure', () => {
+  it('rolls the session index back when the active-pointer write fails', async () => {
+    // Forces the LAST of the three writes (record, index, active pointer) to
+    // throw, so the first two have already landed when it fails.
+    const mem = memoryAdapter()
+    const manager = createStorageManager(mem.adapter)
+    const existing = session('session_existing', KEY_A)
+    await manager.storeSession(existing, existing.id)
+
+    const before = new Map(mem.store)
+    const next = session('session_new', KEY_B)
+    mem.failWritesTo((key) => key === ACTIVE_SESSION_KEY)
+
+    await expect(manager.storeSession(next, next.id)).rejects.toThrow(
+      /storage write failed/,
+    )
+    mem.stopFailing()
+
+    expect(mem.store.get(ALL_SESSIONS_KEY)).toBe(before.get(ALL_SESSIONS_KEY))
+    expect(mem.store.get(ACTIVE_SESSION_KEY)).toBe(
+      before.get(ACTIVE_SESSION_KEY),
+    )
+    await expect(manager.getActiveSession()).resolves.toMatchObject({
+      id: 'session_existing',
+    })
+  })
+
+  it('does not report a usable session when the storage read fails', async () => {
+    // Every read throws. Loose on purpose: "propagate" vs "resolve to no
+    // session" is an unanswered product question, so do NOT tighten this to
+    // `.rejects` — that would pin current behaviour as the contract.
+    const mem = memoryAdapter()
+    const failing: StorageAdapter = {
+      ...mem.adapter,
+      getItem: vi.fn(() => {
+        throw new Error('IndexedDB unavailable')
+      }),
+    }
+    const manager = createStorageManager(failing)
+
+    const outcome = await manager
+      .getActiveSession()
+      .then((session) => ({ ok: true as const, session }))
+      .catch((error: unknown) => ({ ok: false as const, error }))
+
+    if (outcome.ok) {
+      expect(outcome.session).toBeUndefined()
+    } else {
+      expect(outcome.error).toBeInstanceOf(Error)
+    }
+  })
+})

--- a/packages/core/src/storage/sessionTransition.integration.test.ts
+++ b/packages/core/src/storage/sessionTransition.integration.test.ts
@@ -1,15 +1,15 @@
 /**
- * Boundary: Wallet Core <-> session storage (B6).
+ * Boundary between Wallet Core and session storage.
  *
- * The storage adapter is injected and external — IndexedDB on web,
- * expo-secure-store / AsyncStorage on native — so it can fail mid-write, be
+ * The storage adapter is injected and external, IndexedDB on web or
+ * expo-secure-store and AsyncStorage on native, so it can fail while writing, be
  * evicted, or come back from a device restore holding stale data.
  *
  * The contract: a staged transition is applied ONLY when the live signing key
  * matches the key it was staged for. Every other case discards the journal and
  * leaves existing state alone.
  *
- * `mem.store` is read directly in places — that is the record of what the manager
+ * `mem.store` is read directly in places. That is the record of what the manager
  * wrote, not a fact about the double, which is a bare `Map`.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'

--- a/packages/core/src/utils/walletExport.integration.test.ts
+++ b/packages/core/src/utils/walletExport.integration.test.ts
@@ -315,13 +315,24 @@ describe('wallet export: what a caller can tell about a failure', () => {
   )
 
   it.fails('does not wait forever on an unanswered export', async () => {
-    // A fetch that never settles, with fake timers so the clock is advanced
-    // rather than waited on. Neither export helper passes an abort signal, where
-    // `rest.ts` aborts a KMS call after 10 s.
+    // A fetch that never settles on its own; it rejects only once the caller's
+    // own abort signal fires, so a timeout is the only thing that can end it.
+    // A stub ignoring the signal would stay pending under an AbortController
+    // remedy too, leaving this expected-fail forever. Neither export helper
+    // passes a signal today, where `rest.ts` aborts a KMS call after 10 s.
     vi.useFakeTimers()
     vi.stubGlobal(
       'fetch',
-      vi.fn(() => new Promise<Response>(() => {})),
+      vi.fn(
+        (_url: string | URL | Request, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => {
+              const error = new Error('The operation was aborted')
+              error.name = 'AbortError'
+              reject(error)
+            })
+          }),
+      ),
     )
 
     let settled = false
@@ -339,7 +350,7 @@ describe('wallet export: what a caller can tell about a failure', () => {
       },
     )
 
-    await vi.advanceTimersByTimeAsync(60_000)
+    await vi.advanceTimersByTimeAsync(600_000)
 
     expect(pending).toBeInstanceOf(Promise)
     expect(settled).toBe(true)

--- a/packages/core/src/utils/walletExport.integration.test.ts
+++ b/packages/core/src/utils/walletExport.integration.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Boundary: Wallet Core <-> the Turnkey DIRECT API (B2).
+ *
+ * `exportWallet` and `exportPrivateKey` bypass `client/transports/rest.ts`
+ * entirely and call `https://api.turnkey.com/public/v1/…` with raw `fetch` — so
+ * none of the transport's behaviour applies: no timeout, no typed error, no
+ * status preserved. What crosses this seam is key material, so a wrong answer
+ * here is worse than a wrong address.
+ *
+ * The two siblings disagree with each other, and that is the argument running
+ * through this file: `exportPrivateKey` reports `<status> <body>` and dumps the
+ * response when a bundle is missing, while `exportWallet` throws bare strings and
+ * silently takes `wallets[0]`.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ZeroDevWalletSDK } from '../core/createZeroDevWalletCore.js'
+import { exportPrivateKey } from './exportPrivateKey.js'
+import { exportWallet } from './exportWallet.js'
+
+const ADDRESS = `0x${'11'.repeat(20)}`
+const TARGET_PUBLIC_KEY = 'target-public-key'
+
+const WALLET_BUNDLE = {
+  activity: { result: { exportWalletResult: { exportBundle: 'bundle-1' } } },
+}
+const ACCOUNT_BUNDLE = {
+  activity: {
+    result: { exportWalletAccountResult: { exportBundle: 'bundle-1' } },
+  },
+}
+
+function walletDouble(): ZeroDevWalletSDK {
+  return {
+    getSession: async () => ({
+      organizationId: 'suborg-1',
+      stamperType: 'apiKey',
+    }),
+    toAccount: async () => ({ address: ADDRESS }),
+    client: {
+      apiKeyStamper: {
+        stamp: async () => ({
+          stampHeaderName: 'X-Stamp',
+          stampHeaderValue: 'stamp',
+        }),
+      },
+    },
+  } as unknown as ZeroDevWalletSDK
+}
+
+const json = (payload: unknown, status = 200) =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+
+/** Routes by endpoint: `list_wallets` first, then the export submission. */
+function respond(list: () => Response, submit: () => Response) {
+  const fetchMock = vi.fn(async (url: string | URL | Request) =>
+    String(url).includes('list_wallets') ? list() : submit(),
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+/** A fix may surface the status in the message or on the error; either counts. */
+const reportsStatus = (error: unknown, status: number) =>
+  error instanceof Error &&
+  (error.message.includes(String(status)) ||
+    (error as { status?: number }).status === status)
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('wallet export: the contract that must keep holding', () => {
+  it('returns the export bundle for the wallet it listed', async () => {
+    respond(
+      () => json({ wallets: [{ walletId: 'wallet-A' }] }),
+      () => json(WALLET_BUNDLE),
+    )
+
+    const result = await exportWallet({
+      wallet: walletDouble(),
+      targetPublicKey: TARGET_PUBLIC_KEY,
+    })
+
+    expect(result).toMatchObject({
+      exportBundle: 'bundle-1',
+      walletId: 'wallet-A',
+      organizationId: 'suborg-1',
+    })
+  })
+
+  it('returns the export bundle for a private key without listing wallets', async () => {
+    const fetchMock = respond(
+      () => json({}),
+      () => json(ACCOUNT_BUNDLE),
+    )
+
+    const result = await exportPrivateKey({
+      wallet: walletDouble(),
+      targetPublicKey: TARGET_PUBLIC_KEY,
+    })
+
+    expect(result).toMatchObject({
+      exportBundle: 'bundle-1',
+      address: ADDRESS,
+      organizationId: 'suborg-1',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports the status and body when a private-key export is refused', async () => {
+    respond(
+      () => json({}),
+      () => new Response('rate limited', { status: 429 }),
+    )
+
+    await expect(
+      exportPrivateKey({
+        wallet: walletDouble(),
+        targetPublicKey: TARGET_PUBLIC_KEY,
+      }),
+    ).rejects.toThrow(/429.*rate limited/)
+  })
+
+  it('reports a missing wallet export bundle attributably', async () => {
+    respond(
+      () => json({ wallets: [{ walletId: 'wallet-A' }] }),
+      () => json({ activity: { result: {} } }),
+    )
+
+    await expect(
+      exportWallet({
+        wallet: walletDouble(),
+        targetPublicKey: TARGET_PUBLIC_KEY,
+      }),
+    ).rejects.toThrow(/Export bundle not found/)
+  })
+
+  it('names the response when a private-key export bundle is missing', async () => {
+    respond(
+      () => json({}),
+      () => json({ activity: { result: {} } }),
+    )
+
+    await expect(
+      exportPrivateKey({
+        wallet: walletDouble(),
+        targetPublicKey: TARGET_PUBLIC_KEY,
+      }),
+    ).rejects.toThrow(/Export bundle not found in response: \{/)
+  })
+})
+
+describe('wallet export: choosing which wallet to hand over', () => {
+  it.fails(
+    'does not export a wallet of its own choosing when Turnkey lists several',
+    async () => {
+      // Two wallets in the authenticated sub-org.
+      //
+      // Today: resolves, having exported `wallet-A` — the caller is handed key
+      // material for a wallet they never named. Same shape as
+      // `walletAddresses[0]` in the viem adapter, one severity up.
+      const fetchMock = respond(
+        () =>
+          json({
+            wallets: [{ walletId: 'wallet-A' }, { walletId: 'wallet-B' }],
+          }),
+        () => json(WALLET_BUNDLE),
+      )
+
+      await expect(
+        exportWallet({
+          wallet: walletDouble(),
+          targetPublicKey: TARGET_PUBLIC_KEY,
+        }),
+      ).rejects.toThrow()
+
+      // Nothing was exported: refusing must happen before the submission.
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    },
+  )
+
+  it.fails(
+    'attributes an empty wallet list to the response rather than dereferencing it',
+    async () => {
+      // Today: `TypeError: Cannot read properties of undefined (reading
+      // 'walletId')`.
+      respond(
+        () => json({ wallets: [] }),
+        () => json(WALLET_BUNDLE),
+      )
+
+      const error = await exportWallet({
+        wallet: walletDouble(),
+        targetPublicKey: TARGET_PUBLIC_KEY,
+      }).catch((e: unknown) => e)
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error).not.toBeInstanceOf(TypeError)
+      expect((error as Error).message).toMatch(/wallet/i)
+    },
+  )
+
+  it.fails(
+    'attributes a missing wallet list to the response rather than dereferencing it',
+    async () => {
+      // Today: `TypeError: Cannot read properties of undefined (reading '0')`.
+      // Separate from the empty-array case because a fix for one can miss it.
+      respond(
+        () => json({}),
+        () => json(WALLET_BUNDLE),
+      )
+
+      const error = await exportWallet({
+        wallet: walletDouble(),
+        targetPublicKey: TARGET_PUBLIC_KEY,
+      }).catch((e: unknown) => e)
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error).not.toBeInstanceOf(TypeError)
+      expect((error as Error).message).toMatch(/wallet/i)
+    },
+  )
+})
+
+describe('wallet export: what a caller can tell about a failure', () => {
+  it.fails('reports the status when listing wallets is throttled', async () => {
+    // Today: bare `Error: Failed to list wallets` — the 429 is gone, so a caller
+    // cannot tell a throttle from a rejection. `exportPrivateKey` gets this
+    // right on the same kind of failure.
+    respond(
+      () => new Response('rate limited', { status: 429 }),
+      () => json(WALLET_BUNDLE),
+    )
+
+    const error = await exportWallet({
+      wallet: walletDouble(),
+      targetPublicKey: TARGET_PUBLIC_KEY,
+    }).catch((e: unknown) => e)
+
+    expect(reportsStatus(error, 429)).toBe(true)
+  })
+
+  it.fails(
+    'reports the status when the export submission is rejected',
+    async () => {
+      // Today: bare `Error: Failed to export wallet`.
+      respond(
+        () => json({ wallets: [{ walletId: 'wallet-A' }] }),
+        () => new Response('unauthorized', { status: 401 }),
+      )
+
+      const error = await exportWallet({
+        wallet: walletDouble(),
+        targetPublicKey: TARGET_PUBLIC_KEY,
+      }).catch((e: unknown) => e)
+
+      expect(reportsStatus(error, 401)).toBe(true)
+    },
+  )
+
+  it.fails(
+    'attributes a non-JSON export response to the wallet export',
+    async () => {
+      // A 200 carrying HTML, as a gateway interstitial would. Today
+      // `response.json()` throws `SyntaxError: Unexpected token '<'` — neither
+      // sibling checks content-type, where `rest.ts` checks and falls back to
+      // text.
+      respond(
+        () => json({ wallets: [{ walletId: 'wallet-A' }] }),
+        () =>
+          new Response('<html>gateway</html>', {
+            status: 200,
+            headers: { 'content-type': 'text/html' },
+          }),
+      )
+
+      const error = await exportWallet({
+        wallet: walletDouble(),
+        targetPublicKey: TARGET_PUBLIC_KEY,
+      }).catch((e: unknown) => e)
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error).not.toBeInstanceOf(SyntaxError)
+      expect((error as Error).message).toMatch(/export/i)
+    },
+  )
+
+  it.fails(
+    'attributes a non-JSON private-key export response to the export',
+    async () => {
+      // Its own case: the two siblings parse separate responses, so a fix to one
+      // can leave the other behind.
+      respond(
+        () => json({}),
+        () =>
+          new Response('<html>gateway</html>', {
+            status: 200,
+            headers: { 'content-type': 'text/html' },
+          }),
+      )
+
+      const error = await exportPrivateKey({
+        wallet: walletDouble(),
+        targetPublicKey: TARGET_PUBLIC_KEY,
+      }).catch((e: unknown) => e)
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error).not.toBeInstanceOf(SyntaxError)
+      expect((error as Error).message).toMatch(/export/i)
+    },
+  )
+
+  it.fails('does not wait forever on an unanswered export', async () => {
+    // A fetch that never settles, with fake timers so the clock is advanced
+    // rather than waited on. Neither export helper passes an abort signal, where
+    // `rest.ts` aborts a KMS call after 10 s.
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise<Response>(() => {})),
+    )
+
+    let settled = false
+    // Deliberately not awaited — awaiting a request with no timeout IS the hang
+    // under test.
+    const pending = exportWallet({
+      wallet: walletDouble(),
+      targetPublicKey: TARGET_PUBLIC_KEY,
+    }).then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      },
+    )
+
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    expect(pending).toBeInstanceOf(Promise)
+    expect(settled).toBe(true)
+  })
+})

--- a/packages/core/src/utils/walletExport.integration.test.ts
+++ b/packages/core/src/utils/walletExport.integration.test.ts
@@ -1,11 +1,11 @@
 /**
- * Boundary: Wallet Core <-> the Turnkey DIRECT API (B2).
+ * Boundary between Wallet Core and the Turnkey direct API.
  *
  * `exportWallet` and `exportPrivateKey` bypass `client/transports/rest.ts`
- * entirely and call `https://api.turnkey.com/public/v1/…` with raw `fetch` — so
- * none of the transport's behaviour applies: no timeout, no typed error, no
- * status preserved. What crosses this seam is key material, so a wrong answer
- * here is worse than a wrong address.
+ * entirely and call `https://api.turnkey.com/public/v1/…` with raw `fetch`, so
+ * none of the transport's behaviour applies: no timeout, no typed error, no status
+ * preserved. What crosses this boundary is key material, so a wrong answer here is
+ * worse than a wrong address.
  *
  * The two siblings disagree with each other, and that is the argument running
  * through this file: `exportPrivateKey` reports `<status> <body>` and dumps the

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,6 +1,14 @@
 import * as path from 'node:path'
 import { configDefaults, defineConfig } from 'vitest/config'
 
+// The integration layer: boundary and flow tests that span a seam but need NO
+// live service. Nothing here may read a secret or open a socket — the
+// live-dependency suites are `e2e/vitest.backend.config.ts` (real KMS/Turnkey)
+// and `e2e/playwright.config.ts` (browser).
+//
+// The alias block mirrors `vitest.config.ts` on purpose: cross-package boundary
+// tests import by package specifier. If a third config ever needs it, extract
+// it rather than adding a third copy.
 export default defineConfig({
   resolve: {
     alias: {
@@ -22,10 +30,12 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'happy-dom',
+    include: ['packages/*/src/**/*.integration.test.ts'],
+    exclude: configDefaults.exclude,
     coverage: {
       provider: 'v8',
-      // `lcov` (coverage/lcov.info) is what Codecov ingests in CI.
       reporter: ['text', 'html', 'lcov'],
+      reportsDirectory: 'coverage/integration',
       include: ['packages/*/src/**/*.ts', 'packages/*/src/**/*.tsx'],
       exclude: [
         'packages/*/src/**/*.test.ts',
@@ -40,17 +50,5 @@ export default defineConfig({
         'packages/*/src/**/*.d.ts',
       ],
     },
-    include: [
-      'packages/*/src/**/*.test.ts',
-      'packages/*/src/**/*.test.tsx',
-      'e2e/mocks/**/*.test.ts',
-    ],
-    // `*.integration.test.ts` matches the include glob above, so without this
-    // the unit suite silently swallows the whole integration layer. It has its
-    // own runner: `pnpm test:integration`.
-    exclude: [
-      ...configDefaults.exclude,
-      'packages/*/src/**/*.integration.test.ts',
-    ],
   },
 })


### PR DESCRIPTION
This PR adds the initial Core boundary tests.

## Core integration layer scope
Core's **outbound** dependencies only. Inbound callers (react, react-ui, the wagmi connector) are boundaries of *those* packages and belong in their own tests. Excluded: chain RPC / bundler / paymaster (transport is injected by the caller, never Core's), and the enclave HPKE envelope

## Integration layer bootstrap
- `vitest.integration.config.ts` — glob `packages/*/src/**/*.integration.test.ts`, happy-dom, no live dependencies
- `vitest.config.ts` — **excludes** the integration glob to avoid having everything running at the same time in the same layer
- `.github/workflows/ci.yml` — an `Integration Tests` job

### Boundaries  covered:
- KMS proxy via `rest.ts`
- Transports via `rest.ts`
- Non-HTTP dependencies
  - Session storage adapter
  - Key store
  - Passkey stamper

