### PR TITLE
chore(changeset): wallet-core signer-hardening patch, not minor

### DIFF
--- a/.changeset/safe-signer-state.md
+++ b/.changeset/safe-signer-state.md
@@ -1,5 +1,5 @@
 ---
-'@zerodev/wallet-core': minor
+'@zerodev/wallet-core': patch
 ---
 
 Harden signer and session state transitions across authentication, refresh,


### PR DESCRIPTION
Downgrades the `@zerodev/wallet-core` signer/session-hardening changeset (`safe-signer-state.md`) from **`minor`** to **`patch`**, so the next release is `0.0.4` instead of `0.1.0`.

## Why it was `minor`
It adds required methods to the public `ApiKeyStamper` interface (`prepareKeyRotation`, `stampPending`, `signPending`, `commitKeyRotation`, `discardKeyRotation`) — breaking for anyone implementing a custom stamper.

## Why `patch` is safe
No custom stampers exist:
- The only implementers of the new methods are the built-in `createIndexedDbStamper` (web) and `createSecureStoreStamper` (RN), which ship with them.
- The only consumer passing `apiKeyStamper` (`apps/expo-example`) uses the built-in `createSecureStoreStamper()`.

So the interface change breaks nobody in practice. The rest of the changeset (yParity preservation, token purge, `logout({ force: true })`) is additive/behavioral, not breaking.

After this merges, the changesets bot regenerates the "Version Packages" PR (#398) with `wallet-core@0.0.4`.
