### PR TITLE
chore(changeset): wallet-react patch, not minor (kills wallet-react-ui 1.0.0 cascade)

### DIFF
--- a/.changeset/safe-react-state.md
+++ b/.changeset/safe-react-state.md
@@ -1,5 +1,5 @@
 ---
-'@zerodev/wallet-react': minor
+'@zerodev/wallet-react': patch
 ---
 
 Invalidate owner-sensitive account caches and recreate destroyed session


### PR DESCRIPTION
Follow-up to #427. The "Version Packages" PR (#398) was still bumping:
- `@zerodev/wallet-react` → **0.1.0** (minor)
- `@zerodev/wallet-react-ui` → **1.0.0** (MAJOR) ← nobody expects this

## Why wallet-react-ui hit 1.0.0
No changeset targets `wallet-react-ui`. It's a cascade: it depends on `wallet-react` via **`workspace:*`**, and changesets escalates a `workspace:*` dependent to **major** when the dependency takes a **minor** bump. (`smart-routing-address-react-ui` uses `workspace:*` too but only on `react-ui`, which is patch, so it stays patch — confirms the rule.)

## Fix
Downgrade `safe-react-state` (wallet-react) `minor → patch`. The reset-state change is behavioral (cache invalidation + provider recreation on disconnect/logout/chain-switch/re-login), not an API break — same reasoning as wallet-core in #427.

Verified with `changeset status` — everything now lands on 0.0.x:
| package | before | after |
|---|---|---|
| wallet-react | 0.1.0 | **0.0.6** |
| wallet-react-ui | 1.0.0 | **0.0.9** |
| wallet-core | 0.0.4 | 0.0.4 |
| react-ui | 0.0.6 | 0.0.6 |
| smart-routing-address-react-ui | 0.0.2 | 0.0.2 |

After merge, the changesets bot regenerates #398 with these versions.

## Durable follow-up (separate)
The root footgun is `workspace:*` on internal deps. Switching internal deps to `workspace:^` stops the major-escalation for good, regardless of dep bump level — worth doing repo-wide so this doesn't recur on the next minor.
