### PR TITLE
test(qa-lab): run CI tests using package previews instead of symlinks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,12 +147,32 @@ jobs:
           ZD_PROJECT_ID: ${{ secrets.ZD_PROJECT_ID }}
           ZD_OTP_PROJECT_ID: ${{ secrets.ZD_OTP_PROJECT_ID }}
 
+  preview:
+    name: Publish preview packages
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/preview.yml
+
   e2e-test:
     name: Browser E2E Tests
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-    needs: [build]
+    needs: [build, preview]
+    # `always()` only because `preview` is skipped on a push, which would
+    # otherwise skip this job. The preview check sits in the first step instead: a
+    # guard here would report *skipped* on failure, which does not read as red.
+    if: >-
+      always()
+      && needs.build.result == 'success'
+      && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
     steps:
+      - name: Require published previews
+        if: github.event_name == 'pull_request' && needs.preview.result != 'success'
+        run: |
+          echo "Preview finished as '${{ needs.preview.result }}', so there are no published" >&2
+          echo "packages to install. Failing rather than silently testing workspace symlinks." >&2
+          exit 1
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
@@ -165,14 +185,19 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Point QA lab at preview packages
+        if: github.event_name == 'pull_request'
+        run: node scripts/use-preview-packages.mjs ${{ needs.preview.outputs.sha }}
 
-      - name: Build demo SDK dependencies
-        run: pnpm build:e2e
+      # --no-frozen-lockfile since the step above rewrites the lab's deps
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
 
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
+
+      - name: Build demo SDK dependencies
+        run: pnpm build:e2e
 
       - name: Build and start QA lab
         working-directory: apps/qa-lab-testing

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -60,9 +60,10 @@ jobs:
             exit 1
           fi
           echo "Publishing previews for:" $pkgs
-          pnpm dlx pkg-pr-new publish --pnpm $pkgs | tee "$RUNNER_TEMP/publish.log"
+          pnpm dlx pkg-pr-new publish --pnpm $pkgs 2>&1 | tee "$RUNNER_TEMP/publish.log"
 
-          urls=$(grep -oE 'https://pkg\.pr\.new/@[^ ]+' "$RUNNER_TEMP/publish.log" | sort -u)
+          urls=$(sed 's/\x1b\[[0-9;]*m//g' "$RUNNER_TEMP/publish.log" \
+            | grep -oE 'https://pkg\.pr\.new/@[^ ]+' | sort -u || true)
           if [ -z "$urls" ]; then
             echo "pkg-pr-new printed no install URLs — nothing to hand to the E2E job" >&2
             exit 1

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,20 +3,17 @@ name: Preview
 # Publishes throwaway preview packages for each PR via pkg.pr.new, installable
 # from its CDN (e.g. `npm i https://pkg.pr.new/@zerodev/wallet-react@<sha>`).
 #
-# SECURITY (public repo): the only caller triggers on `pull_request` — NOT
-# `pull_request_target` — and passes NO secrets. Fork PRs run with a read-only
-# token and cannot reach anything sensitive. pkg.pr.new publishes to its own CDN
-# (never npm) using the Actions OIDC identity; its GitHub App posts the PR
-# comment. No NPM_TOKEN is involved.
+# SECURITY (public repo): the only caller triggers on `pull_request`, not
+# `pull_request_target`, so fork PRs get a read-only token and no secrets.
+# pkg.pr.new publishes to its own CDN, never npm — no NPM_TOKEN involved.
 
 on:
   workflow_call:
     outputs:
       sha:
         description: >-
-          The commit the previews were published for. Callers must install by
-          this value rather than recomputing it, so the packages under test and
-          the packages that were published cannot drift apart.
+          The ref pkg.pr.new keyed its URLs on, parsed from its own output. Install
+          by this rather than formatting one from the commit sha.
         value: ${{ jobs.preview.outputs.sha }}
 
 permissions:
@@ -27,16 +24,12 @@ jobs:
     name: Publish preview packages
     runs-on: ubuntu-latest
     outputs:
-      sha: ${{ steps.resolve.outputs.sha }}
+      sha: ${{ steps.publish.outputs.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Resolve published commit
-        id: resolve
-        run: echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
@@ -53,10 +46,13 @@ jobs:
       - name: Build packages
         run: pnpm build
 
-      # Derived rather than hardcoded, because a spelled-out list drifts. Captured
-      # to a variable first so a script failure cannot become an empty argument
-      # list that publishes nothing and still exits 0.
+      # Package list derived rather than hardcoded, and captured first so a script
+      # failure cannot become an empty argument list that publishes nothing.
+      # `sha` is parsed out of pkg-pr-new's own URLs: the keys are short shas, and
+      # a full one gave ERR_PNPM_FETCH_404 in run 33178618160.
       - name: Publish previews
+        id: publish
+        shell: bash
         run: |
           pkgs=$(node scripts/check-publishable.mjs --list | sed 's|^|./|')
           if [ -z "$pkgs" ]; then
@@ -64,4 +60,35 @@ jobs:
             exit 1
           fi
           echo "Publishing previews for:" $pkgs
-          pnpm dlx pkg-pr-new publish --pnpm $pkgs
+          pnpm dlx pkg-pr-new publish --pnpm $pkgs | tee "$RUNNER_TEMP/publish.log"
+
+          urls=$(grep -oE 'https://pkg\.pr\.new/@[^ ]+' "$RUNNER_TEMP/publish.log" | sort -u)
+          if [ -z "$urls" ]; then
+            echo "pkg-pr-new printed no install URLs — nothing to hand to the E2E job" >&2
+            exit 1
+          fi
+          refs=$(printf '%s\n' "$urls" | sed 's/.*@//' | sort -u)
+          if [ "$(printf '%s\n' "$refs" | wc -l)" -ne 1 ]; then
+            echo "packages were published under more than one ref: $refs" >&2
+            exit 1
+          fi
+          echo "sha=$refs" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$urls" > "$RUNNER_TEMP/preview-urls.txt"
+
+      # "Published" and "installable" are not the same instant, and E2E's `needs:`
+      # trusts this job. Bounded, because the publish already succeeded.
+      - name: Verify previews are installable
+        shell: bash
+        run: |
+          while read -r url; do
+            for _ in $(seq 1 12); do
+              code=$(curl -sS -o /dev/null -w '%{http_code}' -L --max-time 20 "$url" || echo 000)
+              [ "$code" = 200 ] && break
+              sleep 5
+            done
+            if [ "$code" != 200 ]; then
+              echo "published but not installable after 60s: $url (HTTP $code)" >&2
+              exit 1
+            fi
+            echo "ok $url"
+          done < "$RUNNER_TEMP/preview-urls.txt"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,32 +3,40 @@ name: Preview
 # Publishes throwaway preview packages for each PR via pkg.pr.new, installable
 # from its CDN (e.g. `npm i https://pkg.pr.new/@zerodev/wallet-react@<sha>`).
 #
-# SECURITY (public repo): uses `pull_request` — NOT `pull_request_target` — and
-# NO secrets. Fork PRs run with a read-only token and cannot access anything
-# sensitive. pkg.pr.new publishes to its own CDN (never npm) using the Actions
-# OIDC identity; its GitHub App posts the PR comment. No NPM_TOKEN is involved.
+# SECURITY (public repo): the only caller triggers on `pull_request` — NOT
+# `pull_request_target` — and passes NO secrets. Fork PRs run with a read-only
+# token and cannot reach anything sensitive. pkg.pr.new publishes to its own CDN
+# (never npm) using the Actions OIDC identity; its GitHub App posts the PR
+# comment. No NPM_TOKEN is involved.
 
 on:
-  pull_request:
-    branches: [main]
+  workflow_call:
+    outputs:
+      sha:
+        description: >-
+          The commit the previews were published for. Callers must install by
+          this value rather than recomputing it, so the packages under test and
+          the packages that were published cannot drift apart.
+        value: ${{ jobs.preview.outputs.sha }}
 
 permissions:
   contents: read
-
-concurrency:
-  group: preview-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
 
 jobs:
   preview:
     name: Publish preview packages
     runs-on: ubuntu-latest
-    # Previews are advisory — a hiccup (or the pkg.pr.new app not yet installed)
-    # must never block a PR from merging.
-    continue-on-error: true
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Resolve published commit
+        id: resolve
+        run: echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
@@ -45,11 +53,15 @@ jobs:
       - name: Build packages
         run: pnpm build
 
-      # Only the four publishable packages (skips react-kit / native-kit / apps).
+      # Derived rather than hardcoded, because a spelled-out list drifts. Captured
+      # to a variable first so a script failure cannot become an empty argument
+      # list that publishes nothing and still exits 0.
       - name: Publish previews
-        run: >
-          pnpm dlx pkg-pr-new publish --pnpm
-          './packages/core'
-          './packages/react'
-          './packages/react-ui'
-          './packages/wallet-react-ui'
+        run: |
+          pkgs=$(node scripts/check-publishable.mjs --list | sed 's|^|./|')
+          if [ -z "$pkgs" ]; then
+            echo "check-publishable produced no packages — refusing to publish nothing" >&2
+            exit 1
+          fi
+          echo "Publishing previews for:" $pkgs
+          pnpm dlx pkg-pr-new publish --pnpm $pkgs

--- a/scripts/use-preview-packages.mjs
+++ b/scripts/use-preview-packages.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Repoints apps/qa-lab-testing at one commit's pkg.pr.new previews, so CI installs
+// the SDK from real tarballs and `files` and `exports` are actually enforced. A
+// `workspace:*` install symlinks the source tree and checks neither.
+//
+//   node scripts/use-preview-packages.mjs <head-sha>
+//
+// A sha, not a PR number: `@<pr>` is a moving tag, so CI could install one commit
+// while reporting on another. ci.yml passes the Preview workflow's own output and
+// depends on it, which is why nothing here checks that the URLs resolve.
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const manifestPath = join(root, 'apps/qa-lab-testing/package.json')
+
+const sha = process.argv[2]
+if (!/^[0-9a-f]{7,40}$/i.test(sha ?? '')) {
+  console.error('usage: node scripts/use-preview-packages.mjs <head-sha>')
+  process.exit(1)
+}
+
+const previewUrl = (name) => `https://pkg.pr.new/${name}@${sha}`
+
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+const deps = manifest.dependencies ?? {}
+// Only @zerodev deps are relevant to this script, so ignore the rest.
+const sdkDeps = Object.keys(deps).filter((name) => name.startsWith('@zerodev/'))
+
+if (!sdkDeps.length) {
+  console.error('use-preview-packages: the QA lab declares no @zerodev dependencies.')
+  console.error('Nothing would be installed from a preview, so this job would prove nothing.')
+  process.exit(1)
+}
+
+const toRewrite = sdkDeps.filter((name) => deps[name].startsWith('workspace:'))
+const alreadyPinned = sdkDeps.filter((name) => deps[name] === previewUrl(name))
+// `.npmrc` sets link-workspace-packages=deep, so a plain semver range silently
+// resolves back to the local package. Refuse rather than test a symlink.
+const unexpected = sdkDeps.filter(
+  (name) => !toRewrite.includes(name) && !alreadyPinned.includes(name),
+)
+
+if (unexpected.length) {
+  console.error(`use-preview-packages: unexpected @zerodev specifiers for ${sha}:\n`)
+  for (const name of unexpected) console.error(`  ✗ ${name}: ${deps[name]}`)
+  console.error('\nEach must be `workspace:*` (to rewrite) or the preview URL for this commit.')
+  if (unexpected.some((name) => !deps[name].startsWith('https://pkg.pr.new/'))) {
+    console.error('A plain version range resolves to the workspace package via')
+    console.error('`link-workspace-packages=deep`, which is the symlink this job exists to avoid.')
+  }
+  process.exit(1)
+}
+
+if (!toRewrite.length) {
+  console.log(`use-preview-packages: all ${sdkDeps.length} @zerodev deps already pinned to ${sha}`)
+  process.exit(0)
+}
+
+for (const name of toRewrite) deps[name] = previewUrl(name)
+writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+
+console.log(`use-preview-packages: QA lab now installs ${sha} previews`)
+for (const name of toRewrite) console.log(`  ✓ ${name} -> ${previewUrl(name)}`)


### PR DESCRIPTION
This PR makes the Browser E2E run against published sdk dependencies instead of using symlinks through `workspace:*`.
It also makes use of `check-publishable.mjs` to get the packages that need publishing instead of being hardcoded in the workflow.