### PR TITLE
fix(wallet-react-ui): verify link race condition

### DIFF
--- a/.changeset/verify-otp-restore-race.md
+++ b/.changeset/verify-otp-restore-race.md
@@ -1,0 +1,19 @@
+---
+"@zerodev/wallet-react-ui": patch
+---
+
+fix: magic-link verification no longer dead-ends on `/verify?code=…`
+
+- The persisted OTP session is now restored before base connector setup.
+  Verification raced the restore: `auth.initialize()` (a synchronous
+  localStorage read) only ran after `await connector.setup?.()`, whose async
+  work (wallet creation, session validation) could be slow or fail.
+  `Verifying` reads the session once on mount, so landing on the magic link
+  before the restore finished stripped the code from the URL and silently
+  dropped the flow. The restore now runs first, synchronously inside wagmi's
+  `createConfig`, so the session is always in the store before any React
+  effect can observe it.
+- Opening a magic link with no pending OTP session (expired, already used,
+  or a browser that never started the email flow) now shows a "Link
+  Expired" error with a path back to sign-in, instead of stripping the code
+  and rendering nothing.

--- a/apps/qa-lab-testing/src/app/verify/page.tsx
+++ b/apps/qa-lab-testing/src/app/verify/page.tsx
@@ -27,7 +27,19 @@ export default function VerifyPage() {
 function VerifyPageInner() {
   const router = useRouter()
   const { isConnected } = useAccount()
-  const { otpId } = useAuth()
+  const { otpId, step, reset } = useAuth()
+
+  // "Choose another sign-in method" on the error screens moves the step to
+  // 'sign-up' — nothing else does on /verify (reconnect rethrows without
+  // touching the step). Hand the flow back to the home login screen instead
+  // of restarting sign-up inside /verify: reset first so LoginScreen's
+  // auto-connect reopens the widget through the normal connect path.
+  useEffect(() => {
+    if (step === 'sign-up') {
+      reset()
+      router.push('/')
+    }
+  }, [step, reset, router])
 
   /**
    * Don't mount `ConnectWallet` until the OTP session has been restored.

--- a/apps/zerodev-signer-demo/src/app/verify/page.tsx
+++ b/apps/zerodev-signer-demo/src/app/verify/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ConnectWallet } from '@zerodev/wallet-react-ui'
+import { ConnectWallet, useAuth } from '@zerodev/wallet-react-ui'
 import { useRouter } from 'next/navigation'
 import { Suspense, useEffect } from 'react'
 import { useAccount } from 'wagmi'
@@ -18,12 +18,25 @@ export default function VerifyPage() {
 function VerifyPageInner() {
   const router = useRouter()
   const { isConnected } = useAccount()
+  const { step, reset } = useAuth()
 
   useEffect(() => {
     if (isConnected) {
       router.push('/dashboard')
     }
   }, [isConnected, router])
+
+  // "Choose another sign-in method" on the verify error screens moves the
+  // step to 'sign-up' — nothing else does on /verify (reconnect rethrows
+  // without touching the step). Hand the flow back to the home login screen
+  // instead of restarting sign-up inside /verify: reset first so the home
+  // page's auto-connect reopens the widget through the normal connect path.
+  useEffect(() => {
+    if (step === 'sign-up') {
+      reset()
+      router.push('/')
+    }
+  }, [step, reset, router])
 
   return (
     <div className="mx-auto w-full max-w-[500px] min-h-screen flex flex-col sm:max-w-none sm:h-screen sm:min-h-0 sm:flex-row sm:items-center sm:justify-center">

--- a/packages/wallet-react-ui/src/auth/pages/Verifying.tsx
+++ b/packages/wallet-react-ui/src/auth/pages/Verifying.tsx
@@ -15,6 +15,7 @@ export function Verifying() {
     useAuth()
   const [code] = useState<string | null>(getCodeFromUrl)
   const [error, setError] = useState<Error | null>(null)
+  const [sessionMissing, setSessionMissing] = useState(false)
 
   // ref to prevent useEffect firing twice in dev's StrictMode
   const hasVerifiedRef = useRef(false)
@@ -35,14 +36,15 @@ export function Verifying() {
     if (hasVerifiedRef.current || !code) return
     hasVerifiedRef.current = true
 
-    // No active OTP session — most commonly the user tapped the same
-    // magic link again after a successful verify, which cleared the
-    // session. Skip the (doomed) mutation, clean the URL, and drop
-    // back to step=null so the host app's own routing handles the
-    // already-authenticated user without flashing an error.
+    // No active OTP session — the link was already used, expired, or opened
+    // in a browser that never started the email flow. Skip the (doomed)
+    // mutation and show the expired-link error below instead of silently
+    // dropping the step: a blank screen gives the user nothing to act on.
+    // The already-authenticated re-tap case is covered too — hosts route
+    // connected users away on their own (wagmi reconnect), so the error only
+    // stays up for users who genuinely can't be verified.
     if (!otpId || !otpEncryptionTargetBundle) {
-      stripMagicLinkCodeFromUrl()
-      goToStep(null)
+      setSessionMissing(true)
       return
     }
 
@@ -58,7 +60,25 @@ export function Verifying() {
           </StatusScreen>
         )}
 
-        {!error && !code && !isVerificationLoading && (
+        {!error && sessionMissing && (
+          <>
+            <StatusScreen imageName="error" title="Link Expired">
+              This verification link has expired or was already used.
+              <br />
+              Please sign in again to request a new one.
+            </StatusScreen>
+            <Button
+              action="primary"
+              onClick={() => {
+                stripMagicLinkCodeFromUrl()
+                goToStep('sign-up')
+              }}
+              text="Choose another sign-in method"
+            />
+          </>
+        )}
+
+        {!error && !sessionMissing && !code && !isVerificationLoading && (
           <>
             <StatusScreen imageName="error" title="Invalid Link">
               This verification link is invalid or incomplete.

--- a/packages/wallet-react-ui/src/connector.ts
+++ b/packages/wallet-react-ui/src/connector.ts
@@ -106,15 +106,24 @@ export function zeroDevWallet(
       },
 
       async setup() {
+        // Restore a persisted OTP session BEFORE base setup so an email flow
+        // survives a reload. The restore is a synchronous localStorage read;
+        // base setup does async work (wallet creation, session validation)
+        // that can be slow or fail. Magic-link verification races on this —
+        // `Verifying` reads the session once on mount, and gating the restore
+        // behind base setup made it see an empty session and strip the code
+        // from the URL. Restoring first runs synchronously inside wagmi's
+        // createConfig, before any React effect can observe the store.
+        if (typeof window !== 'undefined') {
+          store.getState().auth.initialize()
+        }
+
         await connector.setup?.()
 
         // Everything below is browser-only. Skip during SSR — getProvider()
         // touches `window` for EIP-6963 discovery and would crash on the
-        // server, and the session restore reads localStorage.
+        // server.
         if (typeof window === 'undefined') return
-
-        // Restore a persisted OTP session so an email flow survives a reload.
-        store.getState().auth.initialize()
 
         // Signing is pinned to background mode: the prompt-mode confirmation UI
         // is not part of this package's public surface, so requests always pass


### PR DESCRIPTION
Closes [FS-2593](https://linear.app/offchain-labs/issue/FS-2593/verify-link-race-condition)

 ### Summary

  Opening a magic link (`/verify?code=…`) stripped the code from the URL and left a blank screen, even with a valid pending sign-in.

  **Root cause:** `Verifying` checks the store for the OTP session once on mount, and strips the code if it's missing. But the session restore (`auth.initialize()`, a sync localStorage read) only ran after `await connector.setup?.()`, whose async work (wallet creation, network session validation) is slower than the first render, so valid links were treated as dead.

  ### Changes
  
  - **Connector**: restore the OTP session *before* base setup, it now runs synchronously inside wagmi's `createConfig`, before any React effect can observe the store.
  - **`Verifying`**: with genuinely no session (link reused/expired), show a "Link Expired" error screen instead of a blank screen.
  - **Demo apps**: "Choose another sign-in method" on `/verify` now resets auth and redirects to `/`, where the home login reopens the widget.





<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
