### PR TITLE
fix(core): broken runtime, pin `json-canonicalize` to exactly 2.0.0

### DIFF
--- a/.changeset/pin-json-canonicalize.md
+++ b/.changeset/pin-json-canonicalize.md
@@ -1,0 +1,15 @@
+---
+'@zerodev/wallet-core': patch
+---
+
+fix: pin `json-canonicalize` to exactly 2.0.0
+
+`json-canonicalize@2.0.1` is a broken npm publish: its `main`/`module` point
+at `bundles/` and `esm5/` build output that is missing from the tarball (only
+`src/*.ts` ships). Our previous `^2.0.0` range resolved to 2.0.1 on every
+fresh install, so new consumers of `@zerodev/wallet-core` crashed at runtime
+with `Cannot find module 'json-canonicalize'`. The SDK repo's own lockfile
+held 2.0.0, which is why this never reproduced locally.
+
+Pinned to the exact known-good 2.0.0 until upstream ships a fixed release
+(3.0.0 requires separate validation before adopting).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -119,7 +119,7 @@
     "@turnkey/iframe-stamper": "^2.5.0",
     "@turnkey/indexed-db-stamper": "^1.1.1",
     "@turnkey/webauthn-stamper": "^0.6.0",
-    "json-canonicalize": "^2.0.0"
+    "json-canonicalize": "2.0.0"
   },
   "peerDependencies": {
     "viem": "^2.47.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,7 +397,7 @@ importers:
         specifier: ^0.6.0
         version: 0.6.0
       json-canonicalize:
-        specifier: ^2.0.0
+        specifier: 2.0.0
         version: 2.0.0
       react-native:
         specifier: '>=0.73.0'
@@ -4479,7 +4479,6 @@ packages:
   '@safe-global/safe-gateway-typescript-sdk@3.23.1':
     resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
     engines: {node: '>=16'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
@@ -25099,7 +25098,7 @@ snapshots:
       ox: 0.9.17(typescript@5.9.3)(zod@4.4.3)
       viem: 2.54.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 4.4.3
-      zustand: 5.0.14(@types/react@19.2.17)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+      zustand: 5.0.3(@types/react@19.2.17)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     optionalDependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.3)
       expo-web-browser: 56.0.5(expo@56.0.15)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
@@ -25122,7 +25121,7 @@ snapshots:
       ox: 0.9.17(typescript@5.9.3)(zod@4.4.3)
       viem: 2.54.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       zod: 4.4.3
-      zustand: 5.0.14(@types/react@19.2.17)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+      zustand: 5.0.3(@types/react@19.2.17)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     optionalDependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.3)
       expo-web-browser: 56.0.5(expo@56.0.15)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))


### PR DESCRIPTION
### Summary

`json-canonicalize@2.0.1` is a broken npm publish, its `main`/`module` point at `bundles/index.umd.js` / `esm5/index.js`, but the tarball only ships `src/*.ts` (verify: `curl -s $(npm view json-canonicalize@2.0.1 dist.tarball) | tar -tz`). Our `^2.0.0` range resolves to 2.0.1 on every fresh install, so new consumers of `@zerodev/wallet-core` crash at runtime with `Cannot find module 'json-canonicalize'`, three packages deep with no hint the SDK is involved. Our own lockfile holds 2.0.0, which is why it never reproduced when developing locally.

Repro:
```bash
npm i json-canonicalize@2.0.1 && node -e "require('json-canonicalize')"   # MODULE_NOT_FOUND
npm i json-canonicalize@2.0.0 && node -e "require('json-canonicalize')"   # ok
```

Pinned to exact 2.0.0. Upstream issue to be filed at snowyu/json-canonicalize.ts; 3.0.0 requires separate validation before adopting.